### PR TITLE
Updated name of bower-maven-plugin

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -248,8 +248,8 @@
 
             <plugin>
                 <groupId>org.kaazing</groupId>
-                <artifactId>bower-dependency-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <artifactId>unpack-bower-dependency-maven-plugin</artifactId>
+                <version>1.0.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Note: don't merge this until bower-maven-plugin has been released to Maven Central and is registered (should happen in next 4 hours)
