### PR TITLE
Apply fix for http://jira.codehaus.org/browse/MASSEMBLY-728 

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -310,6 +310,7 @@
                                 <descriptor>src/main/assembly/unix-bin.xml</descriptor>
                                 <descriptor>src/main/assembly/windows-bin.xml</descriptor>
                             </descriptors>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
- assembly failing on tar file production on MacOSX
- closes #23 
