### PR TITLE
Integration tests failing in HTTP directory service

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 *.xml text
 
 # These files should always use lf (for test predictability)
-**/src/test/*/*.html text eol=lf
+**/src/test/**/*.html text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# These files are text and should be normalized (convert crlf to lf on commit)
+*.java text
+*.xml text
+
+# These files should always use lf (for test predictability)
+**/src/test/*/*.html text eol=lf


### PR DESCRIPTION
Purpose: resolve issue #47
The tests were failing because the index.html file(s) under src contained Windows style end of line markers (CRLF) when checked out on a Windows machine with git configuration core.autocrlf=true (which is the recommended setting). This causes the content length of any HTTP response serviing up the content of index.html to be 11 more than expected because each of the 11 lines of HTML content has with one extra CR character.

The fix is to add a .gitattributes file to tell Git not to modify the end of line characters for html files under any path under src/test. I also added entries to make sure EOL converting is done for .java and .xml files, so Windows users would always see expected behavior and will not accidentally check-in source files containing Windows style EOLs.