### PR TITLE
#49: allow Gateway to start using Azul Zing JVM by not checking java poi...

### DIFF
--- a/server/src/main/java/org/kaazing/gateway/server/impl/GatewayImpl.java
+++ b/server/src/main/java/org/kaazing/gateway/server/impl/GatewayImpl.java
@@ -343,8 +343,13 @@ final class GatewayImpl implements Gateway {
         }
     }
 
-    private boolean supportedJavaVersion(int major, int minor, String point) {
-        String javaVersion = System.getProperty("java.version");
+    private static boolean supportedJavaVersion(int major, int minor, String point) {
+        return supportedJavaVersion(System.getProperty("java.version"), System.getProperty("java.vendor"), major,
+                minor, point);
+    }
+
+    // package access for unit test
+    static boolean supportedJavaVersion(String javaVersion, String javaVendor, int major, int minor, String point) {
         String[] versionParts = javaVersion.split("\\.");
         int currentMajor = Integer.parseInt(versionParts[0]);
         int currentMinor = Integer.parseInt(versionParts[1]);
@@ -356,7 +361,10 @@ final class GatewayImpl implements Gateway {
             if (currentMinor > minor) {
                 return true;
             } else if (currentMinor == minor) {
-                return currentPoint.compareTo(point) >= 0;
+                // java.version point version is not a version number and for Azul (zing) it does not follow the
+                // the number_number... format used by Oracle and Open JDK (e.g. 1.7.0-zing_5.10.1.0). So just
+                // allow any zing version that starts with major.minor.
+                return javaVendor.startsWith("Azul") || currentPoint.compareTo(point) >= 0;
             }
         }
 

--- a/server/src/test/java/org/kaazing/gateway/server/impl/GatewayImplTest.java
+++ b/server/src/test/java/org/kaazing/gateway/server/impl/GatewayImplTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.server.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class GatewayImplTest {
+
+    @Test
+    public void shouldAllowGreaterJavaMajorVersion() {
+        assertTrue(GatewayImpl.supportedJavaVersion("2.6.0_11", "vendor", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldAllowGreaterJavaMinorVersion() {
+        assertTrue(GatewayImpl.supportedJavaVersion("1.8.0_19", "vendor", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldAllowGreaterJavaPointVersion() {
+        assertTrue(GatewayImpl.supportedJavaVersion("1.7.1_20", "vendor", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldAllowGreaterJavaBuildVersion() {
+        assertTrue(GatewayImpl.supportedJavaVersion("1.7.1_22", "vendor", 1, 7, "1_21"));
+    }
+
+    @Test
+    public void shouldAllowEqualJavaVersion() {
+        assertTrue(GatewayImpl.supportedJavaVersion("1.7.0_21", "vendor", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldDisallowSmallerJavaMajorVersion() {
+        assertFalse(GatewayImpl.supportedJavaVersion("0.8.1_31", "vendor", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldDisallowSmallerJavaMinorVersion() {
+        assertFalse(GatewayImpl.supportedJavaVersion("1.7.1_21", "vendor", 1, 8, "0_21"));
+    }
+
+    @Test
+    public void shouldDisallowSmallerJavaPointVersion() {
+        assertFalse(GatewayImpl.supportedJavaVersion("1.7.0_21", "vendor", 1, 7, "1_21"));
+    }
+
+    @Test
+    public void shouldDisallowSmallerJavaBuildVersion() {
+        assertFalse(GatewayImpl.supportedJavaVersion("1.7.0_20", "vendor", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldAllowGreaterJavaAzulMajorVersion() {
+        assertTrue(GatewayImpl.supportedJavaVersion("2.7.0-zing_5.10.1.0", "Azul", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldAllowGreaterJavaAzulMinorVersion() {
+        assertTrue(GatewayImpl.supportedJavaVersion("1.8.0-zing_5.10.1.0", "Azul", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldAllowEqualJavaAzulMajorAndMinorVersion() {
+        assertTrue(GatewayImpl.supportedJavaVersion("1.7.0-zing_5.10.1.0", "Azul", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldDisallowSmallerJavaAzulMajorVersion() {
+        assertFalse(GatewayImpl.supportedJavaVersion("0.8.1-zing_14.9.1.0", "Azul", 1, 7, "0_21"));
+    }
+
+    @Test
+    public void shouldDisallowSmallerJavaAzulMinorVersion() {
+        assertFalse(GatewayImpl.supportedJavaVersion("1.7.1-zing_5.10.1.0", "Azul", 1, 8, "AAA"));
+    }
+
+}


### PR DESCRIPTION
...nt version for vendor Azul (for roadmap#127)