### PR TITLE
Add dependencies to the bom so it includes everything in assembly, remove duplicate version numbers

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -29,7 +29,27 @@
             </dependency>
             <dependency>
                 <groupId>org.kaazing</groupId>
+                <artifactId>gateway.service</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
                 <artifactId>gateway.service.amqp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>gateway.security</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>gateway.util</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>test.util</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -117,6 +137,16 @@
             </dependency>
 
             <!-- transport dependencies -->
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>mina.netty</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>gateway.transport</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.kaazing</groupId>
                 <artifactId>gateway.transport.ssl</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -77,23 +77,15 @@
                 <artifactId>gateway.management</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <!-- This imports dependencyManagement from gateway.management -->
             <dependency>
                 <groupId>org.kaazing</groupId>
-                <artifactId>snmp4j</artifactId>
-                <version>1.11.3</version>
+                <artifactId>gateway.management</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.kaazing</groupId>
-                <artifactId>snmp4j-agent</artifactId>
-                <version>1.4.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kaazing</groupId>
-                <artifactId>sigar.dist</artifactId>
-                <classifier>distribution</classifier>
-                <type>zip</type>
-                <version>[1.0.0.0,1.1.0.0)</version>
-            </dependency>
+
             <!-- service dependencies -->
             <dependency>
                 <groupId>org.kaazing</groupId>
@@ -290,7 +282,48 @@
                 <artifactId>gateway.resource.address.wse</artifactId>
                 <version>${project.version}</version>
             </dependency>
-        </dependencies>
 
+            <!-- external dependencies (as included in gateway assembly) -->
+        </dependencies>
     </dependencyManagement>
+
+    <!-- for testing purposes only -->
+    <dependencies>
+        <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>sigar.dist</artifactId>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>sigar.dist</artifactId>
+                <classifier>distribution</classifier>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.jdom</groupId>
+                <artifactId>jdom</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>snmp4j</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>gateway.management</artifactId>
+            </dependency>
+
+    </dependencies>
 </project>

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -20,6 +20,34 @@
         <url>git@github.com:kaazing/gateway.management.git</url>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>sigar.dist</artifactId>
+            <version>1.0.0.0</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>sigar.dist</artifactId>
+            <classifier>distribution</classifier>
+            <type>zip</type>
+            <version>[1.0.0.0,1.1.0.0)</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>snmp4j</artifactId>
+            <version>1.11.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>snmp4j-agent</artifactId>
+            <version>1.4.3</version>
+        </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Because we depend on gateway.server, a ton of other dependencies 
             come in transitively -->
@@ -66,7 +94,6 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20090211</version>
         </dependency>
         <dependency>
             <groupId>org.kaazing</groupId>
@@ -114,18 +141,15 @@
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>sigar.dist</artifactId>
-            <version>1.0.0.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>snmp4j</artifactId>
-            <version>1.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>snmp4j-agent</artifactId>
-            <version>1.4.3</version>
         </dependency>
         <dependency>
             <groupId>org.jmock</groupId>

--- a/mina.core/parent/pom.xml
+++ b/mina.core/parent/pom.xml
@@ -108,29 +108,7 @@
             </dependency>
 
             <!-- Logging -->
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.5.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>1.5.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.5.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.14</version>
-            </dependency>
+            <!-- logging dependencies are now picked up from gateway pom  -->
 
             <!-- Testing -->
             <dependency>

--- a/mina.netty/pom.xml
+++ b/mina.netty/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.5.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -134,10 +134,15 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
+                <artifactId>slf4j-parent</artifactId>
                 <version>${slf4j.log4j.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,10 @@
         <maven.compiler.testSource>1.7</maven.compiler.testSource>
         <maven.compiler.testTarget>1.7</maven.compiler.testTarget>
         <animal.sniffer.signature.artifactId>java17</animal.sniffer.signature.artifactId>
+        <hazelcast.version>1.9.4.8</hazelcast.version>
+        <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
+        <slf4j.log4j.version>1.7.5</slf4j.log4j.version>
         <enforcer.skip>true</enforcer.skip>
     </properties>
 
@@ -127,7 +130,14 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.5</version>
+                <version>${slf4j.log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.log4j.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -150,6 +160,36 @@
                 <version>1.2</version>
                 <type>jar</type>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlbeans</groupId>
+                <artifactId>xmlbeans</artifactId>
+                <version>2.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>${hazelcast.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast-client</artifactId>
+                <version>${hazelcast.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast-cloud</artifactId>
+                <version>${hazelcast.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jdom</groupId>
+                <artifactId>jdom</artifactId>
+                <version>${jdom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20090211</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>test.util</artifactId>
-            <version>[1.0.0.0,1.1.0.0)</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -177,27 +177,10 @@
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>${xmlbeans.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom</artifactId>
-            <version>${jdom.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-cloud</artifactId>
-            <version>${hazelcast.version}</version>
         </dependency>
 
         <dependency>
@@ -514,9 +497,6 @@
         <pipe.address.version>${project.version}</pipe.address.version>
         <proxy.address.version>${project.version}</proxy.address.version>
 
-        <hazelcast.version>1.9.4.8</hazelcast.version>
-        <jdom.version>1.1</jdom.version>
-        <xmlbeans.version>2.4.0</xmlbeans.version>
         <jna.version>3.3.0</jna.version>
         <!-- remove this after next core.common release -->
         <commons-cli.version>1.2</commons-cli.version>

--- a/service/amqp/pom.xml
+++ b/service/amqp/pom.xml
@@ -64,7 +64,6 @@
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>${xmlbeans.version}</version>
         </dependency>
 
         <dependency>
@@ -151,7 +150,4 @@
         </plugins>
     </reporting>
 
-    <properties>
-        <xmlbeans.version>2.4.0</xmlbeans.version>
-    </properties>
 </project>

--- a/service/spi/pom.xml
+++ b/service/spi/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>1.9.4.8</version>
         </dependency>
 
         <!-- test scope dependencies -->

--- a/service/update.check/pom.xml
+++ b/service/update.check/pom.xml
@@ -54,7 +54,6 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20090211</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Add some more dependencies to the bom so it includes transitive org.kaazing dependencies from distribution (mina.netty, etc).This is needed so I can progress with work on transport.apns and jms.server.
- Add more dependencies to the bom so it includes everything in the assembly (generic-bin.xml).
- Remove all duplication of version numbers across all poms (including slf4j and log4j).