### PR TITLE
Changes for apns ws extension

### DIFF
--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/extension/WsExtensionValidation.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/extension/WsExtensionValidation.java
@@ -23,7 +23,7 @@ package org.kaazing.gateway.transport.ws.extension;
 
 public class WsExtensionValidation {
 
-    static enum Status {
+    public static enum Status {
         INVALID,
         VALID
     }

--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/extension/WsExtensionValidation.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/extension/WsExtensionValidation.java
@@ -23,7 +23,7 @@ package org.kaazing.gateway.transport.ws.extension;
 
 public class WsExtensionValidation {
 
-    public static enum Status {
+    public enum Status {
         INVALID,
         VALID
     }


### PR DESCRIPTION
Just a minor change to make WsExtensionValidation.STATUS public. This whole class will go away once we redo the WebSocket extension framework but for now it gets us out of trouble for the other work I am doing (jms service, which requires enabling the transport.ws.extension.apns extension in EE).