### PR TITLE
Fix how ws.inactivity.timeout was applied though accept-options

### DIFF
--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultAcceptOptionsContext.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultAcceptOptionsContext.java
@@ -299,7 +299,7 @@ public class DefaultAcceptOptionsContext implements AcceptOptionsContext {
 
     private long getWsInactivityTimeout() {
         long wsInactivityTimeout = DEFAULT_WS_INACTIVITY_TIMEOUT_MILLIS;
-        String value = options.get("ws.inactivityTimeout");
+        String value = options.get("ws.inactivity.timeout");
         if (value != null) {
             long val = Utils.parseTimeInterval(value, TimeUnit.MILLISECONDS);
             if (val > 0) {

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebInactivityTimeoutIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebInactivityTimeoutIT.java
@@ -56,7 +56,7 @@ public class WsebInactivityTimeoutIT {
                         .service()
                             .accept(URI.create("wse://localhost:8123/echo"))
                             // NOTE: even though in the config file it's ws.inactivity.timeout!
-                            .acceptOption("ws.inactivityTimeout", "2sec")
+                            .acceptOption("ws.inactivity.timeout", "2sec")
                             .type("echo")
                         .done()
                     .done();

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/HttpBindingsIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/HttpBindingsIT.java
@@ -58,7 +58,7 @@ public class HttpBindingsIT {
                         .crossOrigin()
                             .allowOrigin("*")
                         .done()
-                        .acceptOption("ws.inactivityTimeout", "2sec")
+                        .acceptOption("ws.inactivity.timeout", "2sec")
                     .done()
                     .service()
                         .accept(URI.create("ws://localhost:80/echo80"))
@@ -66,7 +66,7 @@ public class HttpBindingsIT {
                         .crossOrigin()
                             .allowOrigin("*")
                         .done()
-                        .acceptOption("ws.inactivityTimeout", "2sec")
+                        .acceptOption("ws.inactivity.timeout", "2sec")
                         .acceptOption("tcp.bind", "8002")
                     .done()
                 .done();

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnInactivityTimeoutIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnInactivityTimeoutIT.java
@@ -58,7 +58,7 @@ public class WsnInactivityTimeoutIT {
                         .crossOrigin()
                             .allowOrigin("*")
                         .done()
-                        .acceptOption("ws.inactivityTimeout", "2sec")
+                        .acceptOption("ws.inactivity.timeout", "2sec")
                     .done()
                     .service()
                         .accept(URI.create("ws://localhost:80/echo80"))
@@ -66,7 +66,7 @@ public class WsnInactivityTimeoutIT {
                         .crossOrigin()
                             .allowOrigin("*")
                         .done()
-                        .acceptOption("ws.inactivityTimeout", "2sec")
+                        .acceptOption("ws.inactivity.timeout", "2sec")
                         .acceptOption("tcp.bind", "8080")
                     .done()
                 .done();

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/idletimeout/IdleTimeoutExtensionIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/idletimeout/IdleTimeoutExtensionIT.java
@@ -60,7 +60,7 @@ public class IdleTimeoutExtensionIT {
                         .crossOrigin()
                             .allowOrigin("*")
                         .done()
-                        .acceptOption("ws.inactivityTimeout", "123secs")
+                        .acceptOption("ws.inactivity.timeout", "123secs")
                     .done()
                     .service()
                         .accept(URI.create("wsn://localhost:8001/echoNoTimeout"))

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/idletimeout/IdleTimeoutExtensionPongsIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/idletimeout/IdleTimeoutExtensionPongsIT.java
@@ -63,7 +63,7 @@ public class IdleTimeoutExtensionPongsIT {
                         .crossOrigin()
                             .allowOrigin("*")
                         .done()
-                        .acceptOption("ws.inactivityTimeout", "2000milliseconds")
+                        .acceptOption("ws.inactivity.timeout", "2000milliseconds")
                     .done()
                 .done();
 


### PR DESCRIPTION
The configuration values are supposed to be in the dotted lowercase format.  Once applied as an optionsMap it should be turned into ws.inactivityTimeout.  However, pulled from the accept-options it should be ws.inactivity.timeout.  This is because the accept-options had the name in the XSD set to ws.inactivity.timeout, so this should always be the name in the accept-options.