### PR TITLE
Allow a proxy.connector to be injected into the N…

### DIFF
--- a/transport/spi/src/main/java/org/kaazing/gateway/transport/AbstractBridgeConnector.java
+++ b/transport/spi/src/main/java/org/kaazing/gateway/transport/AbstractBridgeConnector.java
@@ -57,23 +57,23 @@ public abstract class AbstractBridgeConnector<S extends AbstractBridgeSession<?,
 
     @Override
     public final ConnectFuture connect(ResourceAddress address, IoHandler handler, IoSessionInitializer<? extends ConnectFuture> initializer) {
-        
+
         // connect only address with matching scheme
         URI location = address.getResource();
         String schemeName = location.getScheme();
         if (!canConnect(schemeName)) {
             throw new IllegalArgumentException(format("Unexpected scheme \"%s\" for URI: %s", schemeName, location));
         }
-        
+
         if (started.get() == false) {
-        	synchronized (started) {
+            synchronized (started) {
                 if (started.get() == false) {
-	                init();
-	            	started.set(true);
+                    init();
+                    started.set(true);
                 }
-        	}
+            }
         }
-    	
+
         return connectInternal(address, handler, initializer);
     }
 


### PR DESCRIPTION
…ioSocketConnector to handle cases were a proxy is configured in the JVM to handle certain connections.  See java.net.Proxy and java.net.ProxySelector.Also fix up some minor formatting.