### PR TITLE
kaazing/gateway#176  Update to latest community to get animal-sniffer…

### DIFF
--- a/mina.core/legal/pom.xml
+++ b/mina.core/legal/pom.xml
@@ -20,6 +20,7 @@
 
     <properties>
         <maven.test.skip>true</maven.test.skip>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -493,3 +493,4 @@
     </build>
 
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kaazing</groupId>
         <artifactId>community</artifactId>
-        <version>2.4</version>
+        <version>2.12</version>
     </parent>
 
     <artifactId>gateway</artifactId>
@@ -27,7 +27,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
-        <animal.sniffer.signature.artifactId>java18</animal.sniffer.signature.artifactId>
         <hazelcast.version>1.9.4.8</hazelcast.version>
         <k3po.version>2.0.0</k3po.version>
         <jdom.version>1.1</jdom.version>


### PR DESCRIPTION
… plugin fixes for Java 1.8.  Ignore animal sniffer in mina.core/legal since some of the resource files cause exceptions in the plugin.