### PR TITLE
Fix up the timing of when proxy service extensions are invoked (initAcceptSession)

### DIFF
--- a/service/proxy/pom.xml
+++ b/service/proxy/pom.xml
@@ -57,6 +57,12 @@
             <version>[1.0.0.0,1.1.0.0)</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/ProxyServiceHandler.java
+++ b/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/ProxyServiceHandler.java
@@ -66,12 +66,6 @@ public class ProxyServiceHandler extends AbstractProxyAcceptHandler {
             final Object serviceRegistration = acceptSession.getAttribute(HttpAcceptor.SERVICE_REGISTRATION_KEY);
             final String nextProtocol = BridgeSession.NEXT_PROTOCOL_KEY.get(acceptSession);
 
-            // hook in any ProxyServiceExtensions here and give them a chance
-            // to initialize the accept side of the proxy connection
-            for (ProxyServiceExtensionSpi extension : extensions) {
-                extension.initAcceptSession(acceptSession, getServiceContext().getProperties());
-            }
-
             // TODO: implement ServiceContext.connect(Collection<URI> connectURIs, connectHandler, sessionInitializer)
             // see commented ProxyConnectManager below for implementation hint.
             // Note: simpler to randomize order into a copy before initial connect, then consume until no connectURI
@@ -106,6 +100,12 @@ public class ProxyServiceHandler extends AbstractProxyAcceptHandler {
             }
 
             super.sessionOpened(acceptSession);
+
+            // hook in any ProxyServiceExtensions here and give them a chance
+            // to initialize the accept side of the proxy connection
+            for (ProxyServiceExtensionSpi extension : extensions) {
+                extension.initAcceptSession(acceptSession, getServiceContext().getProperties());
+            }
         }
     }
 

--- a/service/proxy/src/test/java/org/kaazing/gateway/service/proxy/ProxyServiceExtensionTest.java
+++ b/service/proxy/src/test/java/org/kaazing/gateway/service/proxy/ProxyServiceExtensionTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ * 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kaazing.gateway.service.proxy;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.mina.core.session.IoSession;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.service.ServiceProperties;
+import org.kaazing.mina.core.session.IoSessionEx;
+
+public class ProxyServiceExtensionTest {
+
+    private static CountDownLatch latch;
+
+    @Rule
+    public GatewayRule gateway = new GatewayRule() {
+        {
+            // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("tcp://localhost:8888"))
+                            .connect(URI.create("tcp://localhost:8051"))
+                            .type("proxy")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration);
+        }
+    };
+
+    @Before
+    public void init() {
+        latch = new CountDownLatch(3);
+    }
+
+    @Test
+    public void shouldInvokeExtension() throws Exception {
+        CountDownLatch backendReady = new CountDownLatch(1);
+
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    ServerSocket backendServer = new ServerSocket();
+                    backendServer.bind(new InetSocketAddress("localhost", 8051));
+                    backendReady.countDown();
+                    Socket s = backendServer.accept();
+                    s.close();
+                    backendServer.close();
+                } catch (Exception ex) {
+                    fail("Unexpected exception in backend server: " + ex);
+                }
+            }
+        }, "backendServer-thread");
+        t.start();
+
+        boolean backendBound = backendReady.await(1, TimeUnit.SECONDS);
+        assertTrue("Backend Server failed to bind, pre-conditions not established", backendBound);
+
+        // connect to the service to ensure the extension is executed
+        Socket clientSocket = new Socket("localhost", 8888);
+
+        boolean success = latch.await(5, TimeUnit.SECONDS);
+
+        clientSocket.close();
+
+        assertTrue("Failed to execute all phases of proxy service extension", success);
+    }
+
+    public static class TestExtension implements ProxyServiceExtensionSpi {
+        @Override
+        public void initAcceptSession(IoSession session, ServiceProperties properties) {
+            latch.countDown();
+        }
+        @Override
+        public void initConnectSession(IoSession session, ServiceProperties properties) {
+            latch.countDown();
+        }
+        @Override
+        public void proxiedConnectionEstablished(IoSessionEx acceptSession, IoSessionEx connectSession) {
+            latch.countDown();
+        }
+    }
+}

--- a/service/proxy/src/test/resources/META-INF/services/org.kaazing.gateway.service.proxy.ProxyServiceExtensionSpi
+++ b/service/proxy/src/test/resources/META-INF/services/org.kaazing.gateway.service.proxy.ProxyServiceExtensionSpi
@@ -1,0 +1,1 @@
+org.kaazing.gateway.service.proxy.ProxyServiceExtensionTest$TestExtension


### PR DESCRIPTION
Move the initAcceptSession call on any extensions until after the proxy service has done its own initialization in the sessionOpened() method.  This ensures the filter chain is set up as per the proxy service's needs before any extension adds to the filter chain (most importantly the codec will be in the right place so extensions see the correct decoded messages).