### PR TITLE
Eliminate ugly exceptions stacks in build output by removing calls to…

### DIFF
--- a/service/broadcast/src/test/java/org/kaazing/gateway/service/broadcast/BroadcastServiceTest.java
+++ b/service/broadcast/src/test/java/org/kaazing/gateway/service/broadcast/BroadcastServiceTest.java
@@ -34,7 +34,6 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.PropertyConfigurator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,8 +53,6 @@ public class BroadcastServiceTest {
 
     @Before
     public void setup() {
-        PropertyConfigurator.configure("src/test/resources/log4j-trace.properties");
-
         service = (BroadcastService)ServiceFactory.newServiceFactory().newService("broadcast");
         service.setSchedulerProvider(new SchedulerProvider());
     }
@@ -423,14 +420,11 @@ public class BroadcastServiceTest {
     private class SlowTestClient implements Runnable {
         private CountDownLatch latch = new CountDownLatch(1);
         private int clientNumber;
-        private boolean stopped = false;
-
         private SlowTestClient(int num) {
             clientNumber = num;
         }
 
         public void stop() {
-            stopped = true;
         }
 
         @Override

--- a/service/echo/src/test/java/org/kaazing/gateway/service/echo/EchoServiceTest.java
+++ b/service/echo/src/test/java/org/kaazing/gateway/service/echo/EchoServiceTest.java
@@ -21,9 +21,7 @@
 
 package org.kaazing.gateway.service.echo;
 
-import org.apache.log4j.PropertyConfigurator;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -33,11 +31,6 @@ import org.kaazing.test.util.MethodExecutionTrace;
 public class EchoServiceTest {
     @Rule
     public TestRule testExecutionTrace = new MethodExecutionTrace();
-
-    @Before
-    public void setup() {
-        PropertyConfigurator.configure("src/test/resources/log4j-trace.properties");
-    }
 
     @Test
     public void testCreateService() throws Exception {

--- a/service/proxy/pom.xml
+++ b/service/proxy/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>test.util</artifactId>
-            <version>[1.0.0.0,1.1.0.0)</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/service/proxy/src/test/java/org/kaazing/gateway/service/proxy/ProxyServiceTest.java
+++ b/service/proxy/src/test/java/org/kaazing/gateway/service/proxy/ProxyServiceTest.java
@@ -21,24 +21,17 @@
 
 package org.kaazing.gateway.service.proxy;
 
-import org.apache.log4j.PropertyConfigurator;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.MethodRule;
+import org.junit.rules.TestRule;
 import org.kaazing.gateway.service.ServiceFactory;
 import org.kaazing.test.util.MethodExecutionTrace;
 
 public class ProxyServiceTest {
     @Rule
-    public MethodRule testExecutionTrace = new MethodExecutionTrace();
-
-    @Before
-    public void setup() {
-        PropertyConfigurator.configure("src/test/resources/log4j-trace.properties");
-    }
-
+    public TestRule testExecutionTrace = new MethodExecutionTrace();
+    
     @Test
     public void testCreateService() throws Exception {
         ProxyService service = (ProxyService)ServiceFactory.newServiceFactory().newService("proxy");

--- a/service/spi/pom.xml
+++ b/service/spi/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>test.util</artifactId>
-       <version>${project.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/spi/src/test/java/org/kaazing/gateway/service/test/CreateServiceTest.java
+++ b/service/spi/src/test/java/org/kaazing/gateway/service/test/CreateServiceTest.java
@@ -21,7 +21,6 @@
 
 package org.kaazing.gateway.service.test;
 
-import org.apache.log4j.PropertyConfigurator;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,7 +36,6 @@ public class CreateServiceTest {
 
     @Test
     public void createTestService() {
-        PropertyConfigurator.configure("src/test/resources/log4j-trace.properties");
 
         ServiceFactory factory = ServiceFactory.newServiceFactory();
         Service testService = factory.newService("test");

--- a/transport/nio/src/test/java/org/kaazing/gateway/transport/nio/NioSocketAcceptorTest.java
+++ b/transport/nio/src/test/java/org/kaazing/gateway/transport/nio/NioSocketAcceptorTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.log4j.PropertyConfigurator;
 import org.apache.mina.core.filterchain.IoFilter;
 import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.future.IoFuture;
@@ -94,7 +93,6 @@ public class NioSocketAcceptorTest {
     private static final String TCP_MAXIMUM_OUTBOUND_RATE = "tcp.maximumOutboundRate";
     private static final String NEXT_PROTOCOL = "nextProtocol";
 
-
     @Rule
     public TestRule testExecutionTrace = new MethodExecutionTrace();
 
@@ -107,8 +105,6 @@ public class NioSocketAcceptorTest {
 
     @Before
     public void before() throws Exception {
-        // Avoid annoying console warnings like "No appenders could be found for logger (transport.tcp.accept)"
-        PropertyConfigurator.configure("src/test/resources/log4j-trace.properties");
         acceptor = new NioSocketAcceptor(new Properties());
         acceptor.setSchedulerProvider(schedulerProvider = new SchedulerProvider());
         acceptor.setResourceAddressFactory(newResourceAddressFactory());

--- a/transport/pipe/src/test/java/org/kaazing/gateway/transport/pipe/NamedPipeTransportTest.java
+++ b/transport/pipe/src/test/java/org/kaazing/gateway/transport/pipe/NamedPipeTransportTest.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.PropertyConfigurator;
 import org.apache.mina.core.future.CloseFuture;
 import org.apache.mina.core.future.ConnectFuture;
 import org.apache.mina.core.future.IoFutureListener;
@@ -46,7 +45,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.kaazing.gateway.resource.address.ResourceAddress;
 import org.kaazing.gateway.resource.address.ResourceAddressFactory;
 import org.kaazing.gateway.transport.BridgeServiceFactory;
@@ -54,18 +55,16 @@ import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.gateway.transport.TransportFactory;
 import org.kaazing.gateway.util.scheduler.SchedulerProvider;
 import org.kaazing.mina.core.future.UnbindFuture;
+import org.kaazing.test.util.MethodExecutionTrace;
 
 public class NamedPipeTransportTest {
 
-    private static final boolean DEBUG = true;
+    @Rule
+    public TestRule testExecutionTrace = new MethodExecutionTrace();
 
     @BeforeClass
     public static void init()
             throws Exception {
-
-        if (DEBUG) {
-            PropertyConfigurator.configure("src/test/resources/log4j-trace.properties");
-        }
     }
 
     ResourceAddressFactory resourceAddressFactory = newResourceAddressFactory();

--- a/transport/sse/src/test/java/org/kaazing/gateway/transport/sse/SseCrossOriginIT.java
+++ b/transport/sse/src/test/java/org/kaazing/gateway/transport/sse/SseCrossOriginIT.java
@@ -36,8 +36,10 @@ import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
 
 public class SseCrossOriginIT {
+    private TestRule trace = new MethodExecutionTrace();
     private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
 
@@ -61,7 +63,7 @@ public class SseCrossOriginIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(timeout).around(robot).around(gateway);
+    public TestRule chain = outerRule(trace).around(timeout).around(robot).around(gateway);
 
     @Specification("sse.connect.from.bridge.and.get.data")
     @Test


### PR DESCRIPTION
… PropertyConfigurator.configure("src/test/resources/log4j-trace.properties") in all tests since they fail with file not found and are no longer needed thanks to enhancements made in MethodExecutionTrace in the test.util module. Add MethodExecutionTrace to SseCrossOriginIT. Update test.util dependency in server/proxy to pull in the latest version.