### PR TITLE
Have the cobertura build happen during normal building rather than during after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: Java
 jdk:
   - oraclejdk8
-install: mvn -q clean -DskipTests -DskipITs install && mvn -q clean cobertura:cobertura-integration-test coveralls:report
+install: mvn -q clean -DskipTests -DskipITs install
 script: mvn -q clean verify && mvn -q clean cobertura:cobertura-integration-test coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: Java
 jdk:
   - oraclejdk8
-install: mvn -q clean -DskipTests -DskipITs install
-script: mvn -q clean verify
-after_success:
-  - mvn -q clean cobertura:cobertura-integration-test coveralls:report
+install: mvn -q clean -DskipTests -DskipITs install && mvn -q clean cobertura:cobertura-integration-test coveralls:report
+script: mvn -q clean verify && mvn -q clean cobertura:cobertura-integration-test coveralls:report


### PR DESCRIPTION
Must  be done due to lack of reporting of failures during after_success by travis