### PR TITLE
wse create binding doesn't include ;e or ;e/ct  etc.

### DIFF
--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpProtocolCompatibilityFilter.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpProtocolCompatibilityFilter.java
@@ -286,8 +286,7 @@ public class HttpProtocolCompatibilityFilter extends HttpFilterAdapter<IoSession
                         case 't':
                         case 'b':
                             // handle ;e balancer bindings by inspecting transport
-                            final String sessionPath = BridgeSession.LOCAL_ADDRESS.get(session).getResource().getPath();
-                            if (isBalancerPath(sessionPath)) {
+                            if (isBalancerPath(path)) {
                                 // balancer requests are terminal so have no next protocol
                                 httpRequest.removeHeader(HEADER_X_NEXT_PROTOCOL);
                             } else {

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpProtocolCompatibilityFilter.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpProtocolCompatibilityFilter.java
@@ -286,7 +286,8 @@ public class HttpProtocolCompatibilityFilter extends HttpFilterAdapter<IoSession
                         case 't':
                         case 'b':
                             // handle ;e balancer bindings by inspecting transport
-                            if (isBalancerPath(path)) {
+                            final String sessionPath = BridgeSession.LOCAL_ADDRESS.get(session).getResource().getPath();
+                            if (isBalancerPath(sessionPath)) {
                                 // balancer requests are terminal so have no next protocol
                                 httpRequest.removeHeader(HEADER_X_NEXT_PROTOCOL);
                             } else {

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebTransportIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebTransportIT.java
@@ -115,4 +115,10 @@ public class WsebTransportIT {
         robot.finish();
     }
 
+    @Test
+    @Specification("echo.text.and.binary")
+    public void echoTextAndBinary() throws Exception {
+        robot.finish();
+    }
+
 }

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/closeDownstreamShouldUnbindUpstream.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/closeDownstreamShouldUnbindUpstream.rpt
@@ -186,8 +186,13 @@ write notify UPSTREAM_CLOSE_SENT
 #TIME SEQ: 8 - upstream should be unbound
 read await UPSTREAM_CLOSE_SENT
 read "HTTP/1.1 404 Not Found\r\n"
-read "Content-Type: text/html\r\n"
 read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 404 Not Found\r\n"
+read "Content-Type: text/html\r\n"
 read "\r\n"
 read "<html><head></head><body><h1>404 Not Found</h1></body></html>"
 

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/echo.text.and.binary.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/echo.text.and.binary.rpt
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
+#
+
+# create request for text
+
+connect tcp://localhost:8000
+connected
+
+write "GET /echo/;e/ct HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "Connection: keep-alive\r\n"
+write "Host: localhost:8000\r\n"
+write "Referer: http://localhost:8000/?.kr=xs\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36\r\n"
+write "X-Origin: http://localhost:8000\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Content-Length: 196\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read "\r\n"
+read "http://localhost:8000/echo/;e/ut" /(?<upct>.*)/ "\n"
+read "http://localhost:8000/echo/;e/dt" /(?<downct>.*)/ "\n"
+
+close
+closed
+
+
+# create request for binary
+
+connect tcp://localhost:8000
+connected
+
+# Send create request
+
+write "POST /;post/echo/;e/cb HTTP/1.1\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Accept-Commands: ping\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8000\r\n"
+write "Content-Length: 3\r\n"
+write "Expect: 100-continue\r\n"
+write "Connection: Keep-Alive\r\n"
+write "\r\n"
+write ">|<"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Content-Length: 196\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+# read "Content-Length: 132\r\n"
+read "\r\n"
+# Example: http://localhost:8000/echo/;e/ub/fUOutUjjl9sgFumZWv1XySfdooieOf7e
+read "http://localhost:8000/echo/;e/ub" /(?<upcb>.*)/ "\n"
+read "http://localhost:8000/echo/;e/db" /(?<downcb>.*)/ "\n"
+
+close
+closed
+


### PR DESCRIPTION
wse create binding doesn't include ;e or ;e/ct (for e.g it binds to /echo)

* HTTP request path and headers are used to to determine next protocol
and that will help in finding the right binding.
* This will reduce the number of http bindings