### PR TITLE
#203 Avoid syntax like read /:.*/ "\n" in transport/sse k3po test scr…

### DIFF
--- a/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/should.receive.location.and.message.event.rpt
+++ b/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/should.receive.location.and.message.event.rpt
@@ -39,7 +39,7 @@ read "X-Content-Type-Options: nosniff\r\n"
 read "\r\n"
 
 read "location:"
-read /.*/ "\n"
+read /.*\n/
 read "\n"
 
 read "data:Hello, world\n"

--- a/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.and.get.data.rpt
+++ b/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.and.get.data.rpt
@@ -47,13 +47,13 @@ read "HTTP/1.1 200 OK\r\n"
 read "Cache-Control: no-cache\r\n"
 read "Connection: close\r\n"
 read "Content-Type: text/event-stream\r\n"
-read /Date:.*/ "\r\n"
+read /Date:.*\r\n/
 read "Server: Kaazing Gateway\r\n"
 read "X-Content-Type-Options: nosniff\r\n"
 read "\r\n"
 
 # Stream opened
-read /location:.*/ "\n\n"
+read /location:.*\n\n/
 
 read notify CONNECTED_AND_CAN_SEND_DATA_FROM_BACKEND_TO_FRONT
 

--- a/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.and.get.data.via.ie8.httpxe.rpt
+++ b/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.and.get.data.via.ie8.httpxe.rpt
@@ -63,7 +63,7 @@ read "Access-Control-Allow-Origin: http://localhost:8005\r\n"
 read "Cache-Control: no-cache\r\n"
 read "Connection: close\r\n"
 read "Content-Type: text/plain\r\n"
-read /Date: .*/ "\r\n"
+read /Date: .*\r\n/
 read "Server: Kaazing Gateway\r\n"
 read "X-Content-Type-Options: nosniff\r\n"
 read "\r\n"
@@ -72,9 +72,9 @@ read "HTTP/1.1 200 OK\r\n"
 read "Content-Type: text/event-stream\r\n"
 read "\r\n"
 read notify CONNECTED_AND_CAN_SEND_DATA_FROM_BACKEND_TO_FRONT
-read /location:.*/ "\n"
+read /location:.*\n/
 read "\n"
-read /:.*/ "\n"
+read /:.*\n/
 read "\n"
 read "data:Kobe is greater than Griffen\n"
 read "\n"

--- a/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.and.get.data.with.newline.rpt
+++ b/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.and.get.data.with.newline.rpt
@@ -47,13 +47,13 @@ read "HTTP/1.1 200 OK\r\n"
 read "Cache-Control: no-cache\r\n"
 read "Connection: close\r\n"
 read "Content-Type: text/event-stream\r\n"
-read /Date:.*/ "\r\n"
+read /Date:.*\r\n/
 read "Server: Kaazing Gateway\r\n"
 read "X-Content-Type-Options: nosniff\r\n"
 read "\r\n"
 
 # Stream opened
-read /location:.*/ "\n\n"
+read /location:.*\n\n/
 
 read notify CONNECTED_AND_CAN_SEND_DATA_FROM_BACKEND_TO_FRONT
 

--- a/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.from.bridge.and.get.data.rpt
+++ b/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.from.bridge.and.get.data.rpt
@@ -56,7 +56,7 @@ read "Access-Control-Allow-Origin: http://localhost:8080\r\n"
 read "Cache-Control: no-cache\r\n"
 read "Connection: close\r\n"
 read "Content-Type: text/event-stream\r\n"
-read /Date:.*/ "\r\n"
+read /Date:.*\r\n/
 read "Server: Kaazing Gateway\r\n"
 read "X-Content-Type-Options: nosniff\r\n"
 read "\r\n"
@@ -67,7 +67,7 @@ read "Content-Type: text/event-stream\r\n"
 read "\r\n"
 
 # Stream opened
-read /location:.*/ "\n\n"
+read /location:.*\n\n/
 
 read notify CONNECTED_AND_CAN_SEND_DATA_FROM_BACKEND_TO_FRONT
 

--- a/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.via.dotnet.emulated.rpt
+++ b/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.via.dotnet.emulated.rpt
@@ -38,7 +38,7 @@ read "HTTP/1.1 200 OK\r\n"
 read "Cache-Control: private\r\n"
 read "Connection: close\r\n"
 read "Content-Type: text/event-stream\r\n"
-read /Date: .*/ "\r\n"
+read /Date: .*\r\n/
 read "Server: Kaazing Gateway\r\n"
 read "X-Content-Type-Options: nosniff\r\n"
 read "\r\n"

--- a/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.via.ie8.httpxe.rpt
+++ b/transport/sse/src/test/scripts/org/kaazing/gateway/transport/sse/sse.connect.via.ie8.httpxe.rpt
@@ -52,7 +52,7 @@ read "Access-Control-Allow-Origin: http://localhost:8005\r\n"
 read "Cache-Control: no-cache\r\n"
 read "Connection: close\r\n"
 read "Content-Type: text/plain\r\n"
-read /Date: .*/ "\r\n"
+read /Date: .*\r\n/
 read "Server: Kaazing Gateway\r\n"
 read "X-Content-Type-Options: nosniff\r\n"
 read "\r\n"


### PR DESCRIPTION
…ipts by including \n in the regular expression, to avoid failures when the data is fragmented. See [k3po issue #200](https://github.com/k3po/k3po/issues/200) for more background info.