### PR TITLE
Upstream and downstream shouldn't have to go through authentication.

### DIFF
--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebAuthIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebAuthIT.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb;
+
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.apache.log4j.PropertyConfigurator;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.net.URI;
+import java.security.Principal;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.rules.RuleChain.outerRule;
+
+public class WsebAuthIT {
+
+    private final K3poRule robot = new K3poRule();
+
+    @BeforeClass
+    public static void init() throws Exception {
+        PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
+    }
+
+    @Rule
+    public TestRule timeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+    
+    public GatewayRule gateway = new GatewayRule() {
+        {
+            GatewayConfiguration configuration = new GatewayConfigurationBuilder()
+                .service()
+                    .accept(URI.create("wse://localhost:8001/basic"))
+                    .type("echo")
+                    .realmName("basic")
+                    .crossOrigin()
+                        .allowOrigin("*")
+                    .done()
+                    .authorization()
+                        .requireRole("AUTHORIZED")
+                    .done()
+                .done()
+                .security()
+                    .realm()
+                        .name("basic")
+                        .description("Kaazing WebSocket Gateway Demo")
+                        .httpChallengeScheme("Basic")
+                        .loginModule()
+                            .type("class:" + TestLoginModule.class.getName())
+                            .success("requisite")
+                        .done()
+                    .done()
+                .done()
+            .done();
+
+            init(configuration);
+        }
+    };
+
+    @Rule
+    public TestRule chain = outerRule(robot).around(gateway);
+
+    @Before
+    public void initLoginModule() {
+        TestLoginModule.once = false;
+    }
+
+    // Tests to make sure up and down streams don't go through authentication
+    @Test
+    @Specification("up.and.down.streams.httpxe.no.authentication")
+    public void httpxeAuthentication() throws Exception {
+        robot.finish();
+    }
+
+    @Test
+    @Specification("up.and.down.streams.http.no.authentication")
+    public void httpAuthentication() throws Exception {
+        robot.finish();
+    }
+
+    /*
+     * A login module which succeeds only first time (i.e for create requests)
+     */
+    public static class TestLoginModule implements LoginModule {
+        // LoginContext.login() creates new instance of the LoginModule
+        // Hence using a static field
+        static boolean once;
+        private static final Principal ROLE_PRINCIPAL = new RolePrincipal();
+
+        private Subject subject;
+
+        @Override
+        public void initialize(Subject subject, CallbackHandler callbackHandler,
+                    Map<String, ?> sharedState, Map<String, ?> options) {
+            this.subject = subject;
+        }
+
+        @Override
+        public boolean login() throws LoginException {
+            if (once) {
+                throw new LoginException("LoginModule shouldn't be invoked for upstream and downstream requests");
+            }
+            once = true;
+            return true;
+        }
+
+        @Override
+        public boolean commit() throws LoginException {
+            subject.getPrincipals().add(ROLE_PRINCIPAL);
+            return true;
+        }
+
+        @Override
+        public boolean abort() throws LoginException {
+            return true;
+        }
+
+        @Override
+        public boolean logout() throws LoginException {
+            return true;
+        }
+
+    }
+
+    static class RolePrincipal implements Principal {
+        @Override
+        public String getName() {
+            return "AUTHORIZED";
+        }
+    }
+
+}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebCrossOriginIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebCrossOriginIT.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import java.net.URI;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+
+public class WsebCrossOriginIT {
+
+    private final K3poRule robot = new K3poRule();
+
+    private final GatewayRule gateway = new GatewayRule() {
+        {
+            // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8000/echo"))
+                            .type("echo")
+                            .crossOrigin()
+                                .allowOrigin("*")
+                            .done()
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration);
+        }
+    };
+
+    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
+
+    @Rule
+    public TestRule chain = outerRule(robot).around(gateway).around(timeout);
+
+    @Test
+    @Specification("wse.down.stream.cross.origin.request")
+    public void downStreamCrossOriginRequest() throws Exception {
+        robot.finish();
+    }
+
+}

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/echo.text.and.binary.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/echo.text.and.binary.rpt
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
+#
+
+# create request for text
+
+connect tcp://localhost:8000
+connected
+
+write "GET /echo/;e/ct HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "Connection: keep-alive\r\n"
+write "Host: localhost:8000\r\n"
+write "Referer: http://localhost:8000/?.kr=xs\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36\r\n"
+write "X-Origin: http://localhost:8000\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Content-Length: 196\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read "\r\n"
+read "http://localhost:8000/echo/;e/ut" /(?<upct>.*)/ "\n"
+read "http://localhost:8000/echo/;e/dt" /(?<downct>.*)/ "\n"
+
+close
+closed
+
+
+# create request for binary
+
+connect tcp://localhost:8000
+connected
+
+# Send create request
+
+write "POST /;post/echo/;e/cb HTTP/1.1\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Accept-Commands: ping\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8000\r\n"
+write "Content-Length: 3\r\n"
+write "Expect: 100-continue\r\n"
+write "Connection: Keep-Alive\r\n"
+write "\r\n"
+write ">|<"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Content-Length: 196\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+# read "Content-Length: 132\r\n"
+read "\r\n"
+# Example: http://localhost:8000/echo/;e/ub/fUOutUjjl9sgFumZWv1XySfdooieOf7e
+read "http://localhost:8000/echo/;e/ub" /(?<upcb>.*)/ "\n"
+read "http://localhost:8000/echo/;e/db" /(?<downcb>.*)/ "\n"
+
+close
+closed
+

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/up.and.down.streams.http.no.authentication.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/up.and.down.streams.http.no.authentication.rpt
@@ -1,0 +1,155 @@
+##
+# Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
+#
+
+## Scenario is: upstream and downstream requests shouldn't go through authentication
+
+# Conversation 1: create and upstream
+# -----------------------------------
+
+connect tcp://127.0.0.1:8001
+connected
+
+write "GET /basic/;e/ct HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Content-Type: text/plain; charset=utf-8\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Language: en-US\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko\r\n"
+write "Host: localhost:8001\r\n"
+write "Connection: Keep-Alive\r\n"
+write "Authorization: Basic am9lOndlbGNvbWU=\r\n"
+write "\r\n"
+
+read "HTTP/1.1 201 Created\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Content-Length: 134\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "http://localhost:8001" /(?<up>.*)/ "\n"
+read "http://localhost:8001" /(?<down>.*)/ "\n"
+
+write "POST "
+write ${up}
+write " HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Content-Type: text/plain; charset=utf-8\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Language: en-US\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko\r\n"
+write "Host: localhost:8001\r\n"
+write "Content-Length: 10\r\n"
+write "Connection: Keep-Alive\r\n"
+write "Cache-Control: no-cache\r\n"
+#write "Authorization: Basic am9lOndlbGNvbWU=\r\n"
+write "\r\n"
+
+# Message "Hi"
+write [0xc2 0x80 0x02]
+write "Hi"
+
+# reconnect
+write [0x01 0x30 0x31 0xc3 0xbf]
+
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Length: 0\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+
+read notify CREATED
+
+write await RESPONSE_RECEIVED
+
+# Do a clean close according to the wseb spec
+write "POST "
+write ${up}
+write " HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Content-Type: text/plain; charset=utf-8\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Language: en-US\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko\r\n"
+write "Host: localhost:8001\r\n"
+write "Content-Length: 10\r\n"
+write "Connection: Keep-Alive\r\n"
+write "Cache-Control: no-cache\r\n"
+write "Authorization: Basic am9lOndlbGNvbWU=\r\n"
+write "\r\n"
+
+# Request WS Connection Close
+write [0x01 0x30 0x32 0xc3 0xbf]
+
+# always end with reconnect frame per wseb spec
+write [0x01 0x30 0x31 0xc3 0xbf]
+
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Length: 0\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+
+close
+closed
+
+
+# Conversation 2: downstream
+# --------------------------
+
+connect tcp://127.0.0.1:8001
+connected
+
+write await CREATED
+
+write "GET "
+write ${down}
+write " HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Language: en-US\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko\r\n"
+write "Host: localhost:8001\r\n"
+write "Connection: Keep-Alive\r\n"
+#write "Authorization: Basic am9lOndlbGNvbWU=\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: private\r\n"
+read "Connection: close\r\n"
+read /Content-Type:.*/ "\r\n"
+read /Content-Type:.*/ "\r\n"
+read /Date:.*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+
+read [0x01 0x30 0x30 0xff]
+
+read [0x80 0x02]
+read "Hi"
+
+# Padding
+read [0x01]
+# N occurrences of 0x30
+read [0..2040]
+read [0xff]
+
+
+read notify RESPONSE_RECEIVED
+
+# close command
+read [0x01 0x30 0x32 0xff]
+# reconnect command
+read [0x01 0x30 0x31 0xff]
+
+closed

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/up.and.down.streams.httpxe.no.authentication.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/up.and.down.streams.httpxe.no.authentication.rpt
@@ -1,0 +1,177 @@
+##
+# Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
+#
+
+##################################################################################################
+## This script reflects Kaazing 4.0 JavaScript client running in IE11 doing emulated WebSocket
+##################################################################################################
+## Scenario is: upstream and downstream requests shouldn't go through authentication
+
+# Conversation 1: create and upstream
+# -----------------------------------
+
+connect tcp://127.0.0.1:8001
+connected
+
+write "GET /basic/;e/ctm?.kn=1902872333548104 HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Content-Type: text/plain; charset=utf-8\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Accept-Commands: ping\r\n"
+write "X-WebSocket-Protocol: x-kaazing-bump\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Language: en-US\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko\r\n"
+write "Host: localhost:8001\r\n"
+write "DNT: 1\r\n"
+write "Connection: Keep-Alive\r\n"
+write "Authorization: Basic am9lOndlbGNvbWU=\r\n"
+write "\r\n"
+
+# Enveloped HTTP response
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read /Content-Length: .*/ "\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+# Example: read "Date: Fri, 19 Dec 2014 05:01:28 GMT\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read "\r\n"
+read "http://localhost:8001" /(?<up>.*)/ "\n"
+read "http://localhost:8001" /(?<down>.*)/ "\n"
+
+write "POST "
+write ${up}
+write " HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Content-Type: text/plain; charset=utf-8\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Language: en-US\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko\r\n"
+write "Host: localhost:8001\r\n"
+write "Content-Length: 10\r\n"
+write "DNT: 1\r\n"
+write "Connection: Keep-Alive\r\n"
+write "Cache-Control: no-cache\r\n"
+#write "Authorization: Basic am9lOndlbGNvbWU=\r\n"
+write "\r\n"
+
+# Message "Hi"
+write [0xc2 0x80 0x02]
+write "Hi"
+
+# reconnect
+write [0x01 0x30 0x31 0xc3 0xbf]
+
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Length: 19\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+read notify CREATED
+
+write await RESPONSE_RECEIVED
+
+# Do a clean close according to the wseb spec
+write "POST "
+write ${up}
+write " HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Content-Type: text/plain; charset=utf-8\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Language: en-US\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko\r\n"
+write "Host: localhost:8001\r\n"
+write "Content-Length: 10\r\n"
+write "DNT: 1\r\n"
+write "Connection: Keep-Alive\r\n"
+write "Cache-Control: no-cache\r\n"
+write "Authorization: Basic am9lOndlbGNvbWU=\r\n"
+write "\r\n"
+
+# Request WS Connection Close
+write [0x01 0x30 0x32 0xc3 0xbf]
+
+# always end with reconnect frame per wseb spec
+write [0x01 0x30 0x31 0xc3 0xbf]
+
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Length: 19\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+close
+closed
+
+# Conversation 2: downstream
+# --------------------------
+
+connect tcp://127.0.0.1:8001
+connected
+
+write await CREATED
+
+write "GET "
+write ${down}
+write "?.kc=text/plain;charset=windows-1252&.kb=4096&.kid=891691231737601 HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Language: en-US\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko\r\n"
+write "Host: localhost:8001\r\n"
+write "DNT: 1\r\n"
+write "Connection: Keep-Alive\r\n"
+#write "Authorization: Basic am9lOndlbGNvbWU=\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: private\r\n"
+read "Connection: close\r\n"
+read "Content-Type: text/plain;charset=windows-1252\r\n"
+read /Date:.*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Type: text/plain;charset=windows-1252\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+
+read [0x01 0x30 0x30 0xff]
+
+read [0x80 0x02]
+read "Hi"
+
+# Padding
+read [0x01]
+# N occurrences of 0x30
+read [0..2040]
+read [0xff]
+
+read notify RESPONSE_RECEIVED
+
+# close command
+read [0x01 0x30 0x32 0xff]
+# reconnect command
+read [0x01 0x30 0x31 0xff]
+
+closed

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/wse.down.stream.cross.origin.request.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/wse.down.stream.cross.origin.request.rpt
@@ -1,0 +1,193 @@
+#
+# Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
+#
+
+# create request
+
+connect tcp://localhost:8000
+connected
+
+write "GET /echo/;e/ct HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "Connection: keep-alive\r\n"
+write "Host: localhost:8000\r\n"
+write "Referer: http://localhost:8000/?.kr=xs\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36\r\n"
+write "X-Origin: http://localhost:8006\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "\r\n"
+
+write notify CREATE_REQUESTED
+
+read await CREATE_REQUESTED
+
+read "HTTP/1.1 200 OK\r\n"
+read "Access-Control-Allow-Credentials: true\r\n"
+read "Access-Control-Allow-Headers: content-type\r\n"
+read "Access-Control-Allow-Headers: authorization\r\n"
+read "Access-Control-Allow-Headers: x-websocket-extensions\r\n"
+read "Access-Control-Allow-Headers: x-websocket-version\r\n"
+read "Access-Control-Allow-Headers: x-websocket-protocol\r\n"
+read "Access-Control-Allow-Origin: http://localhost:8006\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Content-Length: 196\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read "\r\n"
+read "http://localhost:8000" /(?<up>.*)/ "\n"
+read "http://localhost:8000" /(?<down>.*)/ "\n"
+
+read notify CREATED
+close
+closed
+
+# downstream request (may not be thread aligned - different TCP connection)
+connect tcp://localhost:8000
+connected
+
+write await CREATED
+
+write "POST "
+write ${down}
+write " HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 3\r\n"
+write "Host: localhost:8000\r\n"
+write "Referer: http://localhost:8000/?.kr=xs\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36\r\n"
+write "X-Origin: http://localhost:8006\r\n"
+write "\r\n"
+
+# payload sent by Flash client runtime to prevent the POST converting to GET and stripping the headers off the request (!)
+write ">|<"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Access-Control-Allow-Credentials: true\r\n"
+read "Access-Control-Allow-Headers: content-type\r\n"
+read "Access-Control-Allow-Headers: authorization\r\n"
+read "Access-Control-Allow-Headers: x-websocket-extensions\r\n"
+read "Access-Control-Allow-Headers: x-websocket-version\r\n"
+read "Access-Control-Allow-Headers: x-websocket-protocol\r\n"
+read "Access-Control-Allow-Origin: http://localhost:8006\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Connection: close\r\n"
+read "Content-Type: text/plain;charset=windows-1252\r\n"
+read "Date: "
+read /.*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Type: text/plain; charset=windows-1252\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+
+read [0x01 0x30 0x30 0xff]
+
+read [0x80 0x11]
+read "Hello, WebSocket1"
+
+read [0x80 0x11]
+read "Hello, WebSocket2"
+
+# close command
+read [0x01 0x30 0x32 0xff]
+# reconnect command
+read [0x01 0x30 0x31 0xff]
+
+closed
+
+# upstream request (may not be thread aligned - different TCP connection)
+connect tcp://localhost:8000
+connected
+
+write await CREATED
+
+write "POST "
+write ${up}
+write " HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 25\r\n"
+write "Content-Type: text/plain; charset=UTF-8\r\n"
+write "Host: localhost:8000\r\n"
+write "Origin: http://localhost:8000\r\n"
+write "Referer: http://localhost:8000/?.kr=xs\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36\r\n"
+write "X-Origin: http://localhost:8006\r\n"
+write "\r\n"
+
+write [0xc2 0x80 0x11]
+write "Hello, WebSocket1"
+
+write [0x01 0x30 0x31 0xc3 0xbf]    # wse.reconnect
+
+read "HTTP/1.1 200 OK\r\n"
+read "Access-Control-Allow-Credentials: true\r\n"
+read "Access-Control-Allow-Headers: content-type\r\n"
+read "Access-Control-Allow-Headers: authorization\r\n"
+read "Access-Control-Allow-Headers: x-websocket-extensions\r\n"
+read "Access-Control-Allow-Headers: x-websocket-version\r\n"
+read "Access-Control-Allow-Headers: x-websocket-protocol\r\n"
+read "Access-Control-Allow-Origin: http://localhost:8006\r\n"
+read /Content-Length: .*/ "\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read "Date: "
+read /.*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+write "POST "
+write ${up}
+write " HTTP/1.1\r\n"
+write "Accept: */*\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 30\r\n"
+write "Content-Type: text/plain; charset=UTF-8\r\n"
+write "Host: localhost:8000\r\n"
+write "Origin: http://localhost:8000\r\n"
+write "Referer: http://localhost:8000/?.kr=xs\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36\r\n"
+write "X-Origin: http://localhost:8006\r\n"
+write "\r\n"
+
+write [0xc2 0x80 0x11]
+write "Hello, WebSocket2"
+
+write [0x01 0x30 0x32 0xc3 0xbf]    # wse.close
+write [0x01 0x30 0x31 0xc3 0xbf]    # wse.reconnect
+
+read "HTTP/1.1 200 OK\r\n"
+read "Access-Control-Allow-Credentials: true\r\n"
+read "Access-Control-Allow-Headers: content-type\r\n"
+read "Access-Control-Allow-Headers: authorization\r\n"
+read "Access-Control-Allow-Headers: x-websocket-extensions\r\n"
+read "Access-Control-Allow-Headers: x-websocket-version\r\n"
+read "Access-Control-Allow-Headers: x-websocket-protocol\r\n"
+read "Access-Control-Allow-Origin: http://localhost:8006\r\n"
+read /Content-Length: .*/ "\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read "Date: "
+read /.*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+close
+closed


### PR DESCRIPTION
* Upstream and downstream don't have to go through authentication
There are two code paths for wse:
1) tcp | http | httpxe | wse
2) tcp | http | wse

In the second case, http layer doesn't get REALM_NAME security option for
upstream/downstream addresses. But in the first case, it does get REALM_NAME
security option. Hence, the security filters try to do authentication for
upstream and downstream requests. This needs to be fixed similar to the second case.

* cross-site-constraint is not getting propagated to httpxe layer while
constructing upstream and downstream resource addresses. This causes
issues if the page is loaded from some other website even though
the <cross-site-constraint> specified to be "*"