### PR TITLE
doc link changes

### DIFF
--- a/doc/about/about.md
+++ b/doc/about/about.md
@@ -6,8 +6,8 @@ This topic contains the following sections:
 -   [About URI Syntax](#about-uri-syntax)
 -   [About Domain Names](#about-domain-names)
 -   [About Ports](#about-ports)
--   [About KAAZING\_HOME](#about-kaazing_home)
--   [About GATEWAY\_HOME](#about-gateway_home)
+-   [About KAAZING_HOME](#about-kaazing_home)
+-   [About GATEWAY_HOME](#about-gateway_home)
 
 Text Conventions
 ---------------------------------------------
@@ -83,14 +83,14 @@ The following table lists ports that are commonly used in the documentation.
 | 61616-61617 | Default Apache ActiveMQ TCP and SSL ports                                                                                                  |
 | 61222       | Default Apache ActiveMQ XMPP port                                                                                                          |
 
-About KAAZING\_HOME
+About KAAZING_HOME
 ---------------------------------------------
 
-By default, when you install or upgrade KAAZING Gateway, the `_KAAZING\_HOME_` directory is created. This top-level directory contains the KAAZING Gateway directory (referred to as *GATEWAY\_HOME*)   and Gateway components. The value of *GATEWAY\_HOME* depends on the operating system. See [About GATEWAY\_HOME](#about-gateway_home) to learn more about Gateway directory destinations.
+By default, when you install or upgrade KAAZING Gateway, the `KAAZING_HOME` directory is created. This top-level directory contains the KAAZING Gateway directory (referred to as `GATEWAY_HOME`)   and Gateway components. The value of `GATEWAY_HOME` depends on the operating system. See [About GATEWAY_HOME](#about-gateway_home) to learn more about Gateway directory destinations.
 
 This documentation assumes you are running the Gateway from the default location. You may override the default and install KAAZING Gateway into a directory of your choice.
 
-About GATEWAY\_HOME
+About GATEWAY_HOME
 ---------------------------------------------
 
 This is the directory that contains KAAZING Gateway and its components. The default Gateway home is represented in the documentation as `GATEWAY_HOME` because the actual directory destination depends on your operating system and the method you use to install the Gateway:

--- a/doc/about/setup-guide.md
+++ b/doc/about/setup-guide.md
@@ -21,7 +21,7 @@ Setting up KAAZING Gateway on your local computer is recommended if you want to 
 
 To download and set up the Gateway on your local computer, perform the following steps:
 
-1.  Ensure your system meets the system requirements. See the [README.md](../README.md), or you can find the `README.txt` in the `GATEWAY_HOME` directory if you have already unpacked the the Gateway distribution.
+1.  Ensure your system meets the system requirements. See the [README.md](https://github.com/kaazing/gateway/blob/master/README.md), or you can find the `README.txt` in the `GATEWAY_HOME` directory if you have already unpacked the the Gateway distribution.
 2.  Download the Gateway or fork the Gateway GitHub repository from [kaazing.org](http://kaazing.org):
     -   For Linux, Unix, and Mac: kaazing-gateway-community-5.0.*x*-unix.tar.gz
     -   For Windows: kaazing-gateway-community-5.0.*x*-windows.zip

--- a/doc/admin-reference/r_configure_gateway_element_skeleton.md
+++ b/doc/admin-reference/r_configure_gateway_element_skeleton.md
@@ -76,7 +76,7 @@ You can view and link to all Gateway configuration elements and properties using
             -   [ssl.protocols](r_configure_gateway_service.md#sslprotocols-and-sockssslprotocols)
             -   [ssl.encryption](r_configure_gateway_service.md#sslencryption)
             -   [socks.mode](r_configure_gateway_service.md#socksmode) ![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
-            -   [socks.timeout](r_configure_gateway_service.md#conn_sockstimeout) ![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
+            -   [socks.timeout](r_configure_gateway_service.md#sockstimeout) ![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
             -   [socks.ssl.ciphers](r_configure_gateway_service.md#sockssslciphers) ![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
             -   [socks.ssl.protocols](r_configure_gateway_service.md#sslprotocols-and-sockssslprotocols) ![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
             -   [socks.ssl.verify-client](r_configure_gateway_service.md#sockssslverify-client) ![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)

--- a/doc/admin-reference/r_configure_gateway_security.md
+++ b/doc/admin-reference/r_configure_gateway_security.md
@@ -253,7 +253,7 @@ This element configures the login module, which communicates with a user databas
 | options | The configuration options specific to the type of login module (see [options login-module](#options-login-module)).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 
-##### options (`login-module`)
+##### <a name="options-login-module"></a>options (`login-module`)
 
 **Required?** Optional; **Occurs:** zero or one
 
@@ -266,7 +266,7 @@ This is the element for adding options to specific types of login modules. The o
 | debug         | `file`                       | If `true`, then the login module sends debug information (at the DEBUG level) to the logger. If `false` (the default), then the login module disables sending logging information to the logger. This is the default. |
 | tryFirstToken | `gss`                        |    If `true`, then the login module looks in the JAAS shared state for a token using the key: `com.kaazing.gateway.server.auth.gss.token`. If `false` (the default), then the login module uses a CallbackHandler to discover the token from `LoginContext`.  |
 
-##### Example of a `file` Login Module
+##### <a name="example-of-a-file-login-module"></a>Example of a `file` Login Module
 
 The following example shows a `file`-based `login-module` element that uses the flat XML file,` jaas-config.xml`:
 
@@ -284,7 +284,7 @@ The following example shows a `file`-based `login-module` element that uses the 
 
 For information about the `file` login module options, see the table in the [options (login-module)](#options-login-module) section.
 
-##### Example of a `ldap` login module
+##### <a name="example-of-a-ldap-login-module"></a>Example of a `ldap` login module
 
 The following example shows an LDAP-based `login-module` element:
 
@@ -305,7 +305,7 @@ The following example shows an LDAP-based `login-module` element:
 
 For information about configuring the LDAP login-module options, see the [Class LDAPLoginModule documentation](http://docs.oracle.com/javase/7/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/LdapLoginModule.html).
 
-##### Example of `kerberos5` login module
+##### <a name="example-of-kerberos5-login-module"></a>Example of `kerberos5` login module
 
 The following example shows a `kerberos5`-based `login-module` element. You must use the `kerberos5` and [`gss`](#gss-login-module) elements together, and in that sequence. Both of these login modules are required when using the `Negotiate` or `Application Negotiate` [schemes](#authentication):
 
@@ -326,7 +326,7 @@ The following example shows a `kerberos5`-based `login-module` element. You must
 
 For information about configuring the Kerberos login module options, see the [Krb5LoginModule](http://docs.oracle.com/javase/7/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/Krb5LoginModule.html "Krb5LoginModule (Java Authentication and Authorization Service )") documentation. For information about how to use KAAZING Gateway with Kerberos, see [Configure Kerberos V5 Network Authentication](../security/o_auth_configure.md).
 
-##### `gss` login module
+##### <a name="gss-login-module"></a>`gss` login module
 
 The following example shows a `gss`-based `login-module` element that you define after the Kerberos login module in the chain to enable the Kerberos tokens to travel over the Web. Both of these login modules are required when using the `Negotiate` or `Application Negotiate` [schemes](#authentication):
 
@@ -339,7 +339,7 @@ The following example shows a `gss`-based `login-module` element that you define
 
 For information about the `gss` login module options, see the table in the [options (login-module)](#options-login-module) section. The `gss` login-module element requires no options but must follow the [kerberos5](#example-of-kerberos5-login-module) login-module element, because the `gss` login-module element uses the credentials obtained by the [kerberos5](#example-of-kerberos5-login-module) login-module element to verify the service ticket presented by the client. See [Configure Kerberos V5 Network Authentication](../security/u_kerberos_configure.md) and [Using Kerberos V5 Network Authentication with the Gateway](../security/u_kerberos_configure.md) for more information.
 
-##### Example of a `jndi` login module
+##### <a name="example-of-a-jndi-login-module"></a>Example of a `jndi` login module
 
 The following example shows a jndi-based `login-module` element. It translates the examples for the login module in the [JndiLoginModule](http://docs.oracle.com/javase/7/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/JndiLoginModule.html) javadoc into the XML you would use in the `security.realm` section of the Gateway configuration:
 
@@ -358,7 +358,7 @@ The following example shows a jndi-based `login-module` element. It translates t
 
 For information about configuring the JNDI login-module options, see the [JndiLoginModule](http://docs.oracle.com/javase/7/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/JndiLoginModule.html) documentation.
 
-##### Example of a `keystore` login module
+##### <a name="example-of-a-keystore-login-module"></a>Example of a `keystore` login module
 
 The following example shows a keystore-based `login-module` element. It translates the examples in the [KeyStoreLoginModule](http://docs.oracle.com/javase/7/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/KeyStoreLoginModule.html) javadoc into the XML you would use in the `security.realm` section of the Gateway configuration:
 
@@ -377,7 +377,7 @@ The following example shows a keystore-based `login-module` element. It translat
 
 For information about configuring the keystore login-module options, see the [KeyStoreLoginModule](http://docs.oracle.com/javase/7/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/KeyStoreLoginModule.html) documentation.
 
-##### Example of a `custom` login module
+##### <a name="example-of-a-custom-login-module"></a>Example of a `custom` login module
 
 KAAZING Gateway also supports a plugin mechanism for integration with custom authentication modules based on the Java LoginModule API.
 

--- a/doc/admin-reference/r_configure_gateway_service.md
+++ b/doc/admin-reference/r_configure_gateway_service.md
@@ -506,7 +506,7 @@ Use the `proxy`, `amqp.proxy`, or `jms.proxy` service to enable a client to make
 
 The following descriptions will help you understand when and how to configure properties for the `proxy` service and  `amqp.proxy` service. See the [jms.proxy](../admin-reference/r_conf_jms.md) ![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png) reference for details about that feature. 
 
-#### `maximum.pending.bytes`
+#### <a name="maximumpendingbytes"></a>`maximum.pending.bytes`
 
 **Required?** Optional
 
@@ -519,7 +519,7 @@ The Gateway uses this buffer when the speed of the data coming into the service 
 
 For example, suppose you set this property to `128kB`. If the back-end service or message broker sends 256kB of data to a client and the client has only consumed 128kB, the remaining 128kB (the limit you set in the property) is buffered. At this time, the Gateway suspends reading the data from the back-end service or message broker; as the client consumes the buffered data, the size of the buffered data decreases. When the buffered data falls below 64kB, the Gateway resumes reading the data from the back-end service or message broker.
 
-#### `maximum.recovery.interval`
+#### <a name="maximumrecoveryinterval"></a>`maximum.recovery.interval`
 
 **Required?** Optional
 
@@ -531,7 +531,7 @@ If the back-end service or message broker becomes unavailable or the Gateway can
 
 During this recovery phase, the Gateway unbinds the service, and clients attempting to connect to this service receive a "404 Not Found" error. Once the back-end service or message broker recovers and the Gateway establishes a connection, the Gateway binds the service and clients can connect to the service. See the "Examples" section below the table for a code snippet using this property.
 
-#### `prepared.connection.count`
+#### <a name="preparedconnectioncount"></a>`prepared.connection.count`
 
 **Required?** Optional
 
@@ -539,7 +539,7 @@ Set this property in either of the following use cases:
 - Set this property when configuring your proxy service, which is the most common use case for `prepared.connection.count`. In this case, setting `prepared.connection.count` sets the number of connections the Gateway creates (or *prepares*) to the back-end service or message broker specified by the [`connect`](#connect) element in addition to the client connections. When the Gateway starts, it creates the specified number of connections to the back-end service or message broker, thus creating a *prepared connection*. When an incoming client connection uses a prepared connection, the Gateway creates another connection to the back-end service or message broker, thus maintaining the specified number of prepared connections to the back-end service or message broker.
 - Set this property when configuring Enterprise Shield™. See [Configure Enterprise Shield™](https://github.com/kaazing/enterprise.gateway/blob/develop/doc/enterprise-shield/p_enterprise_shield_config.md) for detailed configuration information. If you do not set this property, then the Gateway does not prepare connections to the back-end service or message broker.
 
-#### `virtual.host`
+#### <a name="virtualhost"></a>`virtual.host`
 
 **Required?** Optional
 
@@ -752,7 +752,7 @@ Use the `connect-options` element to add options to all connections for the serv
 | ssl.encryption | yes | yes | Signals KAAZING Gateway to enable or disable encryption on incoming traffic. |
 | ssl.verify-client | yes | no | Signals KAAZING Gateway to require a client to provide a digital certificate that the Gateway can use to verify the client’s identity. |
 | socks.mode ![This feature is available in KAAZING Gateway - EnterpriseEdition.](../images/enterprise-feature.png) | yes | yes | The mode that you can optionally set to forward or reverse to tell the Gateway how to interpret SOCKS URIs to initiate the connection. See [socks.mode](#socksmode). |
-| socks.timeout ![This feature is available in KAAZING Gateway -Enterprise Edition.](../images/enterprise-feature.png) | no | yes | Specifies the length of time (in seconds) to wait for SOCKS connectionsto form. If the connection does not succeed within the specified time, then the connection fails and is closed and the client must reconnect. For more information, see [socks.timeout](#conn_sockstimeout). |
+| socks.timeout ![This feature is available in KAAZING Gateway -Enterprise Edition.](../images/enterprise-feature.png) | no | yes | Specifies the length of time (in seconds) to wait for SOCKS connectionsto form. If the connection does not succeed within the specified time, then the connection fails and is closed and the client must reconnect. For more information, see [socks.timeout](#sockstimeout). |
 | socks.ssl.ciphers ![This feature is available in KAAZING Gateway - Enterprise Edition.](../images/enterprise-feature.png) | yes | yes | Lists the cipher strings and cipher suite names used by the secure SOCKS connection. |
 | socks.ssl.protocols ![This feature is available in KAAZING Gateway - Enterprise Edition.](../images/enterprise-feature.png) | yes | yes | Lists the TLS/SSL protocol names on which the Gateway can accept connections for Enterprise Shield™ configurations that are running the SOCKS protocol over SSL. See [ssl.protocols and socks.ssl.protocols](#sslprotocols-and-sockssslprotocols). |
 | socks.ssl.verify-client ![This feature is available in KAAZING Gateway - Enterprise Edition.](../images/enterprise-feature.png) | yes | yes | A connect mode you can set to required, optional, or none to verify how to secure the SOCKS proxy against unauthorized use by forcing the use of TLS/SSL connections with a particular certificate. When required,the DMZ Gateway expects the internal Gateway to prove its trustworthiness by presenting certificates during the TLS/SSL handshake. |
@@ -1316,7 +1316,7 @@ The following example shows a `connect-options` element with the `socks.mode` se
 </service>
 ```
 
-#### <a name="conn_sockstimeout"></a>socks.timeout![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
+#### socks.timeout![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
 
 **Required?** Optional; **Occurs:** zero or one
 
@@ -1356,7 +1356,7 @@ The following example shows a `socks.timeout` that is set to 10 seconds. If the 
 </service>
 ```
 
-#### <a name="sockssslciphers"></a>socks.ssl.ciphers![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
+#### socks.ssl.ciphers![This feature is available in KAAZING Gateway - Enterprise Edition](../images/enterprise-feature.png)
 
 **Required?** Optional; **Occurs:** zero or one; **Values:** cipher strings and cipher suite names for [OPENSSL](http://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS) and [Java 7](http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider).
 

--- a/doc/kaazing-glossary.md
+++ b/doc/kaazing-glossary.md
@@ -25,7 +25,7 @@ Android is an SDK that is used for the development and deployment of Java-based 
 
 The mechanism by which a system identifies a user and verifies whether or not the user really is who he represents himself to be. To start the authentication process, the Gateway issues a standard challenge using the `HTTP 401 Authorization Required` code. The browser or client then responds by providing the requested authentication information.
 
-**<a name="ajax"></a>authorization**
+**<a name="authorization"></a>authorization**
 
 The mechanism by which a system determines what level of access a particular user has. Even after a user is successfully authenticated for general access, the user is not necessarily entitled to perform any operation. Access rights are typically stored in the policy store that is associated with the application.
 
@@ -91,21 +91,21 @@ Web-based communication between a browser and server where messages are sent and
 G
 -
 
-**<span id="gateway_home"></span></a>GATEWAY\_HOME**![This feature is available in KAAZING Gateway - Enterprise Edition.](images/enterprise-feature.png)
+**<span id="gateway_home"></span></a>GATEWAY_HOME**![This feature is available in KAAZING Gateway - Enterprise Edition.](images/enterprise-feature.png)
 
 This is the directory that contains KAAZING Gateway and its components. The default Gateway home is represented in the documentation as `GATEWAY_HOME` because the actual directory destination depends on your operating system and the method you use to install the Gateway:
 
 -   If you download and unpack the Gateway using the standalone method, then you can unpack the download into a directory of your choice (for example, `C:\kaazing` or `/home/username/kaazing`).
 -   If you install the Gateway using the Windows or Linux Installer, then the installation creates the destination directory location as described in the following table, where *edition* refers to the product edition (for example, JMS, XMPP, or AMQP) and *version* refers to the version number (for example, 4.0):
 
-| Operating System                                        | *GATEWAY\_HOME*                                          |
+| Operating System                                        | *GATEWAY_HOME*                                          |
 |---------------------------------------------------------|----------------------------------------------------------|
 | Windows: 32-bit                                         | `C:\Program Files\Kaazing\edition\version\Gateway`       |
 | Windows: 64-bit                                         | `C:\Program Files\Kaazing\edition\version\Gateway`       |
 | Windows: 32-bit installation on a 64-bit Windows system | `C:\Program Files (x86)\Kaazing\edition\version\Gateway` |
 | Linux: Debian-based system                              | `/usr/share/kaazing/edition/version/`**                  |
 
-You can find more information about `GATEWAY_HOME` and the directory structure that is set up during installation in *Setting Up KAAZING Gateway*. To read this document, go to the [Kaazing Documentation home page](index.md), choose the edition (for example, HTML5 or JMS) of the Gateway you are running, and open *Setting Up KAAZING Gateway*. See also [*KAAZING\_HOME*](#kaazing_home).
+You can find more information about `GATEWAY_HOME` and the directory structure that is set up during installation in *Setting Up KAAZING Gateway*. To read this document, go to the [Kaazing Documentation home page](index.md), choose the edition (for example, HTML5 or JMS) of the Gateway you are running, and open *Setting Up KAAZING Gateway*. See also [*KAAZING_HOME*](#kaazing_home).
 
 H
 -
@@ -173,9 +173,9 @@ A mechanism for distributing and publishing messages to multiple [JMS consumers/
 K
 -
 
-**<a name="kaazing_home"></a>KAAZING\_HOME**![This feature is available in KAAZING Gateway - Enterprise Edition.](images/enterprise-feature.png)
+**<a name="kaazing_home"></a>KAAZING_HOME**![This feature is available in KAAZING Gateway - Enterprise Edition.](images/enterprise-feature.png)
 
-By default, when you install or upgrade KAAZING Gateway, the *KAAZING\_HOME* directory is created. This top-level directory contains the KAAZING Gateway directory (referred to as *GATEWAY\_HOME*), a message broker home (depending on the Gateway edition you are running), and Gateway components. The value of *GATEWAY\_HOME* depends on the operating system. See [*GATEWAY\_HOME*](#gateway_home) to learn more about Gateway directory destinations.
+By default, when you install or upgrade KAAZING Gateway, the *KAAZING_HOME* directory is created. This top-level directory contains the KAAZING Gateway directory (referred to as *GATEWAY_HOME*), a message broker home (depending on the Gateway edition you are running), and Gateway components. The value of *GATEWAY_HOME* depends on the operating system. See [*GATEWAY_HOME*](#gateway_home) to learn more about Gateway directory destinations.
 
 This documentation assumes you are running the Gateway from the default location. You may override the default and install KAAZING Gateway into a directory of your choice.
 


### PR DESCRIPTION
Updates doc to address link issues. Made some syntax changes like replacing `\_` with just `_` to reflect GFM. Added/removed html name tags when necessary and corrected links.

See [ticket](https://github.com/kaazing/roadmap/issues/419)