### PR TITLE
Changes for Geolocation Security

### DIFF
--- a/mina.core/core/src/main/java/org/apache/mina/core/session/AbstractIoSessionInitializer.java
+++ b/mina.core/core/src/main/java/org/apache/mina/core/session/AbstractIoSessionInitializer.java
@@ -21,12 +21,9 @@ package org.apache.mina.core.session;
 
 import org.apache.mina.core.future.IoFuture;
 
-/**
- * Defines a callback for obtaining the {@link IoSession} during
- * session initialization.
- *
- * @author <a href="http://mina.apache.org">Apache MINA Project</a>
- */
-public interface IoSessionInitializer<T extends IoFuture> {
-    void initializeSession(IoSession session, T future);
+public abstract class AbstractIoSessionInitializer<T extends IoFuture> implements IoSessionInitializer<T> {
+
+    public String getRemoteHostAddress() { 
+        return null;
+	}
 }

--- a/mina.core/core/src/main/java/org/apache/mina/core/session/IoSessionInitializer.java
+++ b/mina.core/core/src/main/java/org/apache/mina/core/session/IoSessionInitializer.java
@@ -29,4 +29,6 @@ import org.apache.mina.core.future.IoFuture;
  */
 public interface IoSessionInitializer<T extends IoFuture> {
     void initializeSession(IoSession session, T future);
+
+    default String getRemoteHostAddress() { return null; }
 }

--- a/mina.core/pom.xml
+++ b/mina.core/pom.xml
@@ -78,7 +78,7 @@
                     <failIfMissing>false</failIfMissing>
                 </configuration>
             </plugin>
-            <plugin>
+            <!--plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0.2</version>
@@ -90,7 +90,7 @@
                     <optimize>true</optimize>
                     <showDeprecations>true</showDeprecations>
                 </configuration>
-            </plugin>
+            </plugin-->
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/mina.netty/pom.xml
+++ b/mina.netty/pom.xml
@@ -185,6 +185,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -196,8 +197,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <!-- ensure that only methods available in java 1.6 can
-                     be used even when compiling with java 1.7+ -->
+                <ensure that only methods available in java 1.6 can
+                     be used even when compiling with java 1.7+ >
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
                 <version>1.8</version>
@@ -213,12 +214,12 @@
 
                         <ignore>java.util.zip.Deflater</ignore>
 
-                        <!-- Used for NIO UDP multicast -->
+                        <Used for NIO UDP multicast>
                         <ignore>java.nio.channels.DatagramChannel</ignore>
                         <ignore>java.nio.channels.MembershipKey</ignore>
                         <ignore>java.net.StandardProtocolFamily</ignore>
 
-                        <!-- Used for NIO. 2 -->
+                        < Used for NIO. 2>
                         <ignore>java.nio.channels.AsynchronousChannel</ignore>
                         <ignore>java.nio.channels.AsynchronousSocketChannel</ignore>
                         <ignore>java.nio.channels.AsynchronousServerSocketChannel</ignore>
@@ -238,6 +239,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/security/src/main/java/org/kaazing/gateway/security/AccessControlLoginException.java
+++ b/security/src/main/java/org/kaazing/gateway/security/AccessControlLoginException.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.security;
+
+import javax.security.auth.login.LoginException;
+
+public class AccessControlLoginException extends LoginException {
+    private static final long serialVersionUID = 1595142940282323729L;
+
+    public AccessControlLoginException() {
+        super();
+    }
+
+    public AccessControlLoginException(String message) {
+        super(message);
+    }
+
+}

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultServiceContext.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultServiceContext.java
@@ -948,6 +948,11 @@ public class DefaultServiceContext implements ServiceContext {
         BridgeConnector connector = transport.getConnector(address);
         return connector.connect(address, connectHandler, new IoSessionInitializer<ConnectFuture>() {
             @Override
+            public String getRemoteHostAddress() {
+                return connectSessionInitializer.getRemoteHostAddress();
+            }
+
+            @Override
             public void initializeSession(IoSession session, ConnectFuture future) {
                 sessionInitializer.initializeSession(session, future);
 

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultServiceContext.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultServiceContext.java
@@ -58,6 +58,7 @@ import javax.crypto.CipherOutputStream;
 import org.apache.mina.core.buffer.IoBuffer;
 import org.apache.mina.core.future.ConnectFuture;
 import org.apache.mina.core.service.IoHandler;
+import org.apache.mina.core.session.AbstractIoSessionInitializer;
 import org.apache.mina.core.session.IoSession;
 import org.apache.mina.core.session.IoSessionInitializer;
 import org.kaazing.gateway.resource.address.Protocol;
@@ -946,10 +947,13 @@ public class DefaultServiceContext implements ServiceContext {
         Transport transport = transportFactory.getTransportForScheme(uriScheme);
 
         BridgeConnector connector = transport.getConnector(address);
-        return connector.connect(address, connectHandler, new IoSessionInitializer<ConnectFuture>() {
+        return connector.connect(address, connectHandler, new AbstractIoSessionInitializer<ConnectFuture>() {
             @Override
             public String getRemoteHostAddress() {
-                return connectSessionInitializer.getRemoteHostAddress();
+                if (connectSessionInitializer instanceof AbstractIoSessionInitializer<?>) {
+                    return ((AbstractIoSessionInitializer<?>) connectSessionInitializer).getRemoteHostAddress();
+                }
+                return null;
             }
 
             @Override

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
@@ -127,6 +127,7 @@ public class GatewayContextResolver {
 
     private static final String SERVICE_TYPE_CLASS_PREFIX = "class:";
     private static final String LOGIN_MODULE_TYPE_CLASS_PREFIX = "class:";
+    private static final String EMPTY_STRING = "";
 
     // a map of file-extension to mime-type.  For backward compatibility, we'll
     // hardcode this initial set based on the values in Dragonfire HttpUtils.getContentType().
@@ -961,7 +962,12 @@ public class GatewayContextResolver {
                             Node node = childNodes.item(i);
                             if (Node.ELEMENT_NODE == node.getNodeType()) {
                                 NodeList content = node.getChildNodes();
-                                options.put(node.getLocalName(), content.item(0).getNodeValue());
+                                if ((content != null) && (content.item(0) != null)) {
+                                    options.put(node.getLocalName(), content.item(0).getNodeValue());
+                                }
+                                else {
+                                    options.put(node.getLocalName(), EMPTY_STRING);
+                                }
                             }
                         }
                     }

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadersIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadersIT.java
@@ -21,6 +21,11 @@
 
 package org.kaazing.gateway.service.http.proxy;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import java.net.URI;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -31,11 +36,6 @@ import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-
-import java.net.URI;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
 
 public class HttpProxyHeadersIT {
 

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/completeChunkedEncoding.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/completeChunkedEncoding.rpt
@@ -39,6 +39,7 @@ accepted
 connected
 
 read "GET / HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.client.request.streaming.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.client.request.streaming.rpt
@@ -44,6 +44,7 @@ connected
 
 read "POST /echo HTTP/1.1\r\n"
 read "X-Sequence-No: 1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Kaazing Gateway\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.connect.persistence.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.connect.persistence.rpt
@@ -60,6 +60,7 @@ accepted
 connected
 
 read "GET / HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Host: localhost:8110\r\n"
@@ -89,6 +90,7 @@ write "\r\n"
 
 
 read "GET / HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.connect.persistence.timeout.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.connect.persistence.timeout.rpt
@@ -83,6 +83,7 @@ accepted
 connected
 
 read "GET / HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Host: localhost:8110\r\n"
@@ -112,6 +113,7 @@ write "\r\n"
 
 
 read "GET / HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Host: localhost:8110\r\n"
@@ -141,6 +143,7 @@ write "\r\n"
 
 
 read "GET / HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.get.method.status.401.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.get.method.status.401.rpt
@@ -39,6 +39,7 @@ accepted
 connected
 
 read "GET /manager/html?org.apache.catalina.filters.CSRF_NONCE=4658FCBFF001B039C9E963E713E47992 HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: curl/7.37.1\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.gzip.chunked.encoding.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.gzip.chunked.encoding.rpt
@@ -58,6 +58,7 @@ accepted
 connected
 
 read "GET /docs/apr.html HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:36.0) Gecko/20100101 Firefox/36.0\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.302.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.302.rpt
@@ -32,6 +32,7 @@ accepted
 connected
 
 read "HEAD /manager HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: curl/7.37.1\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.403.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.403.rpt
@@ -33,6 +33,7 @@ accepted
 connected
 
 read "HEAD /manager/ HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: curl/7.37.1\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.404.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.404.rpt
@@ -33,6 +33,7 @@ accepted
 connected
 
 read "HEAD /foo HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: curl/7.37.1\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.rpt
@@ -33,6 +33,7 @@ accepted
 connected
 
 read "HEAD /examples/jsp/num/numguess.jsp HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: curl/7.37.1\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.headers.remove.hop.by.hop.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.headers.remove.hop.by.hop.rpt
@@ -37,6 +37,7 @@ accepted
 connected
 
 read "GET / HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.origin.server.response.streaming.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.origin.server.response.streaming.rpt
@@ -45,6 +45,7 @@ connected
 
 read "GET /shield/;e/db/AkDKBgEzhWxUvxWu8Jsqnf6qCeAm8TNt HTTP/1.1\r\n"
 read "X-Sequence-No: 1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Kaazing Gateway\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.post.method.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.post.method.rpt
@@ -44,6 +44,7 @@ accepted
 connected
 
 read "POST /examples/servlets/servlet/CookieExample HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Referer: http://localhost:8080/examples/servlets/servlet/CookieExample\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.query.string.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.query.string.rpt
@@ -34,6 +34,7 @@ accepted
 connected
 
 read "GET /examples/jsp/num/numguess.jsp?guess=7 HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: curl/7.37.1\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.redirect.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.redirect.rpt
@@ -34,6 +34,7 @@ accepted
 connected
 
 read "GET /examples HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: curl/7.37.1\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.ssl.terminated.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.ssl.terminated.rpt
@@ -11,6 +11,7 @@ accepted
 connected
 
 read "GET /index.html HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read /User-Agent: .*/ "\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.status.500.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.status.500.rpt
@@ -34,6 +34,7 @@ accepted
 connected
 
 read "GET /examples/jsp/error/err.jsp?name=audi HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: curl/7.37.1\r\n"
 read "Host: localhost:8110\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.upgrade.client.disconnect.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.upgrade.client.disconnect.rpt
@@ -43,6 +43,7 @@ accepted
 connected
 
 read "GET /echo HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Upgrade: websocket\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.upgrade.server.disconnect.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.upgrade.server.disconnect.rpt
@@ -43,6 +43,7 @@ accepted
 connected
 
 read "GET /echo HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Upgrade: websocket\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.upgrade.websocket.basic.auth.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.upgrade.websocket.basic.auth.rpt
@@ -71,6 +71,7 @@ accepted
 connected
 
 read "GET /echo HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Upgrade: websocket\r\n"
@@ -91,6 +92,7 @@ write "<html><head></head><body><h1>401 Unauthorized</h1></body></html>"
 
 
 read "GET /echo HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Upgrade: websocket\r\n"

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.upgrade.websocket.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.upgrade.websocket.rpt
@@ -47,6 +47,7 @@ accepted
 connected
 
 read "GET /echo HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "Via: 1.1 kaazing\r\n"
 read "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36\r\n"
 read "Upgrade: websocket\r\n"

--- a/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/ConnectionPool.java
+++ b/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/ConnectionPool.java
@@ -148,6 +148,11 @@ class ConnectionPool {
     private ConnectFuture doConnect(final boolean preconnected, final IoSessionInitializer<ConnectFuture> connectInitializer) {
         ConnectFuture future = serviceContext.connect(connectURI, connectHandler, new IoSessionInitializer<ConnectFuture>() {
             @Override
+            public String getRemoteHostAddress() {
+                return connectInitializer.getRemoteHostAddress();
+            }
+
+            @Override
             public void initializeSession(IoSession connectSession, ConnectFuture future) {
                 if (heartbeatFilter != null) {
                     connectSession.getFilterChain().addLast("ServiceHeartbeat", heartbeatFilter);

--- a/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/ConnectionPool.java
+++ b/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/ConnectionPool.java
@@ -32,6 +32,7 @@ import org.apache.mina.core.filterchain.IoFilterAdapter;
 import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.future.ConnectFuture;
 import org.apache.mina.core.future.IoFutureListener;
+import org.apache.mina.core.session.AbstractIoSessionInitializer;
 import org.apache.mina.core.session.AttributeKey;
 import org.apache.mina.core.session.IoSession;
 import org.apache.mina.core.session.IoSessionInitializer;
@@ -146,10 +147,13 @@ class ConnectionPool {
     }
 
     private ConnectFuture doConnect(final boolean preconnected, final IoSessionInitializer<ConnectFuture> connectInitializer) {
-        ConnectFuture future = serviceContext.connect(connectURI, connectHandler, new IoSessionInitializer<ConnectFuture>() {
+        ConnectFuture future = serviceContext.connect(connectURI, connectHandler, new AbstractIoSessionInitializer<ConnectFuture>() {
             @Override
             public String getRemoteHostAddress() {
-                return connectInitializer.getRemoteHostAddress();
+                if (connectInitializer instanceof AbstractIoSessionInitializer<?>) {
+                    return ((AbstractIoSessionInitializer<?>)connectInitializer).getRemoteHostAddress();
+                }
+                return null;
             }
 
             @Override

--- a/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/ProxyServiceHandler.java
+++ b/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/ProxyServiceHandler.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import org.apache.mina.core.future.ConnectFuture;
 import org.apache.mina.core.future.IoFutureListener;
+import org.apache.mina.core.session.AbstractIoSessionInitializer;
 import org.apache.mina.core.session.IoSession;
 import org.apache.mina.core.session.IoSessionInitializer;
 import org.kaazing.gateway.transport.BridgeSession;
@@ -75,7 +76,7 @@ public class ProxyServiceHandler extends AbstractProxyAcceptHandler {
             // see commented ProxyConnectManager below for implementation hint.
             // Note: simpler to randomize order into a copy before initial connect, then consume until no connectURI
             // alternatives left
-            ConnectFuture future = getNextConnectFuture(new IoSessionInitializer<ConnectFuture>() {
+            ConnectFuture future = getNextConnectFuture(new AbstractIoSessionInitializer<ConnectFuture>() {
 
                 @Override
                 public String getRemoteHostAddress() {

--- a/service/proxy/src/test/java/org/kaazing/gateway/service/proxy/ProxyServiceExtensionTest.java
+++ b/service/proxy/src/test/java/org/kaazing/gateway/service/proxy/ProxyServiceExtensionTest.java
@@ -90,7 +90,7 @@ public class ProxyServiceExtensionTest {
 
         // connect to the service to ensure the extension is executed
         try (Socket clientSocket = new Socket("localhost", 8888)) {
-            boolean success = latch.await(50, TimeUnit.SECONDS);
+            boolean success = latch.await(5, TimeUnit.SECONDS);
             assertTrue("Failed to execute all phases of proxy service extension", success);
         } catch (Exception ex) {
             fail("Unexpected exception in client connecting to server: " + ex);

--- a/service/proxy/src/test/java/org/kaazing/gateway/service/proxy/ProxyServiceExtensionTest.java
+++ b/service/proxy/src/test/java/org/kaazing/gateway/service/proxy/ProxyServiceExtensionTest.java
@@ -90,7 +90,7 @@ public class ProxyServiceExtensionTest {
 
         // connect to the service to ensure the extension is executed
         try (Socket clientSocket = new Socket("localhost", 8888)) {
-            boolean success = latch.await(5, TimeUnit.SECONDS);
+            boolean success = latch.await(50, TimeUnit.SECONDS);
             assertTrue("Failed to execute all phases of proxy service extension", success);
         } catch (Exception ex) {
             fail("Unexpected exception in client connecting to server: " + ex);

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
@@ -615,6 +615,7 @@ public class HttpAcceptor extends AbstractBridgeAcceptor<DefaultHttpSession, Htt
         if ((loader.iterator() != null) && loader.iterator().hasNext()) {
             HttpSubjectSecurityFilter filter = loader.iterator().next();
             filter.setLogger(logger);
+            return filter;
         }
 
         return new HttpSubjectSecurityFilter(logger);

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
@@ -610,8 +610,8 @@ public class HttpAcceptor extends AbstractBridgeAcceptor<DefaultHttpSession, Htt
         }
     }
 
-    // If HTTP's X-FORWARDED-FOR header is set, then use it's value to determine the remote
-    // IP address. If X-FORWARDED-FOR header is NOT set, then use IoSession to determine
+    // If HTTP's X-Forwarded-For header is set, then use it's value to determine the remote
+    // IP address. If X-Forwarded-For header is NOT set, then use IoSession to determine
     // the remote IP address.
     private String getRemoteIpAddress(IoSession session, HttpRequestMessage httpRequest) {
         String remoteIpAddr = httpRequest.getHeader(HEADER_X_FORWARDED_FOR);
@@ -635,8 +635,8 @@ public class HttpAcceptor extends AbstractBridgeAcceptor<DefaultHttpSession, Htt
             }
         }
         else {
-            // X-FORWARDED-FOR HTTP header is inserted by proxies to identify the remote IP address.
-            // If the proxies are chained, then X-FORWARDED-FOR header can contain multiple IP
+            // X-Forwarded-For HTTP header is inserted by proxies/intermediaries to identify the remote
+            // IP address. If the proxies are chained, then X-Forwarded-For header can contain multiple IP
             // addresses separated by commas. In such a scenario, the first IP address represents
             // the remote IP address.
             int index = remoteIpAddr.indexOf(',');
@@ -645,7 +645,7 @@ public class HttpAcceptor extends AbstractBridgeAcceptor<DefaultHttpSession, Htt
             }
 
             if (logger.isDebugEnabled()) {
-                logger.debug("Using X-FORWARDED-FOR header value for remote IP address: [%s].", remoteIpAddr);
+                logger.debug("Using X-Forwarded-For header value for remote IP address: [%s].", remoteIpAddr);
             }
         }
 

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
@@ -407,7 +407,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
                                 new HttpBufferAllocator(parentAllocator));
                         parent.setAttribute(HTTP_SESSION_KEY, httpSession);
 
-                        // Set X-FORWARDED-FOR header on the HTTP session.
+                        // Set X-Forwarded-For header on the HTTP session.
                         IoSession tcpSession = getTcpSession(httpSession);
                         if (tcpSession != null) {
                             String remoteIpAddress = (String) tcpSession.getAttribute(HttpAcceptor.REMOTE_IP_ADDRESS_KEY);
@@ -416,7 +416,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
                                 InetAddress inetAddr = ((InetSocketAddress)socketAddr).getAddress();
                                 remoteIpAddress = inetAddr.getHostAddress();
                             }
-                            httpSession.setWriteHeader(HttpAcceptor.HEADER_X_FORWARDED_FOR, remoteIpAddress);
+                            httpSession.addWriteHeader(HttpAcceptor.HEADER_X_FORWARDED_FOR, remoteIpAddress);
                         }
 
                         return httpSession;

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpHeaders.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpHeaders.java
@@ -38,6 +38,7 @@ public interface HttpHeaders {
     String HEADER_X_CREATE_ENCODING = "X-Create-Encoding";
     String HEADER_X_ACCEPT_COMMANDS = "X-Accept-Commands";
     String HEADER_CACHE_CONTROL = "Cache-Control";
+    String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
 
 
     String HEADER_UPGRADE = "Upgrade";

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpBaseSecurityFilter.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpBaseSecurityFilter.java
@@ -46,7 +46,7 @@ public abstract class HttpBaseSecurityFilter extends SuspendableIoFilterAdapter 
     public static final String AUTHORIZATION_MODE_RECYCLE = "recycle";
     public static final String AUTHORIZATION_MODE_CHALLENGE = "challenge";
 
-    protected final Logger logger;
+    protected Logger logger;
 
     /**
      * Prefix to the authentication scheme to indicate that the Kaazing client application will handle the challenge rather than
@@ -66,6 +66,10 @@ public abstract class HttpBaseSecurityFilter extends SuspendableIoFilterAdapter 
 
     public Logger getLogger() {
         return logger;
+    }
+
+    public void setLogger(Logger logger) {
+        this.logger = logger;
     }
 
     /**

--- a/transport/wseb/src/main/java/org/kaazing/gateway/transport/wseb/WsebConnector.java
+++ b/transport/wseb/src/main/java/org/kaazing/gateway/transport/wseb/WsebConnector.java
@@ -230,10 +230,20 @@ public class WsebConnector extends AbstractBridgeConnector<WsebSession> {
         // initialize parent session before connection attempt
         return new IoSessionInitializer<ConnectFuture>() {
             @Override
+            public String getRemoteHostAddress() {
+                return initializer != null ? initializer.getRemoteHostAddress() : null;
+            }
+
+            @Override
             public void initializeSession(final IoSession parent, ConnectFuture future) {
                 // initializer for bridge session to specify bridge handler,
                 // and call user-defined bridge session initializer if present
                 final IoSessionInitializer<T> wseSessionInitializer = new IoSessionInitializer<T>() {
+                    @Override
+                    public String getRemoteHostAddress() {
+                        return initializer != null ? initializer.getRemoteHostAddress() : null;
+                    }
+
                     @Override
                     public void initializeSession(IoSession session, T future) {
                         WsebSession wseSession = (WsebSession) session;

--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnConnector.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnConnector.java
@@ -425,6 +425,14 @@ public class WsnConnector extends AbstractBridgeConnector<WsnSession> {
         // initialize parent session before connection attempt
         return new IoSessionInitializer<ConnectFuture>() {
             @Override
+            public String getRemoteHostAddress() {
+                if (initializer == null) {
+                    return null;
+                }
+                return initializer.getRemoteHostAddress();
+            }
+
+            @Override
             public void initializeSession(final IoSession parent, ConnectFuture future) {
                 // initializer for bridge session to specify bridge handler,
                 // and call user-defined bridge session initializer if present

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/proxy/ProxyOrphanedConnectionIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/proxy/ProxyOrphanedConnectionIT.java
@@ -21,23 +21,31 @@
 
 package org.kaazing.gateway.transport.wsn.proxy;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.transport.wsn.WsnConnectorRule;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
 
 public class ProxyOrphanedConnectionIT {
+    private final K3poRule k3po = new K3poRule();
 
-    private K3poRule robot = new K3poRule();
-    
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    public final TestRule testExecutionTrace = new MethodExecutionTrace();
+
     public GatewayRule gateway = new GatewayRule() {
         {
             // @formatter:off
@@ -54,13 +62,13 @@ public class ProxyOrphanedConnectionIT {
             init(configuration);
         }
     };
-    
+
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public final TestRule chain = outerRule(testExecutionTrace).around(k3po).around(gateway).around(timeout);
 
     @Specification("connectToFrontEndProxyAndKillFrontBeforeBackendIsEstablished")
-    @Test(timeout = 5000)
+    @Test
     public void closeOnFrontBeforeConnectedFullyOnBackShouldKillBack() throws Exception {
-        robot.finish();
+        k3po.finish();
     }
 }

--- a/transport/wsn/src/test/scripts/org/kaazing/gateway/transport/wsn/proxy/connectToFrontEndProxyAndKillFrontBeforeBackendIsEstablished.rpt
+++ b/transport/wsn/src/test/scripts/org/kaazing/gateway/transport/wsn/proxy/connectToFrontEndProxyAndKillFrontBeforeBackendIsEstablished.rpt
@@ -60,6 +60,7 @@ accept tcp://localhost:8556
 accepted
 connected
 read "GET / HTTP/1.1\r\n"
+read "X-Forwarded-For: 127.0.0.1\r\n"
 read "User-Agent: Kaazing Gateway\r\n"
 read "Upgrade: websocket\r\n"
 read "Sec-WebSocket-Version: 13\r\n"


### PR DESCRIPTION
Add hooks in Gateway so that we can register enterprise-specific Callbacks used in enterprise-specific LoginModules. Propagate remote IP address from the accept side to the connect side when proxies are used. Updated test scripts with to include "X-Forwarded-For" HTTP header.