### PR TITLE
WSE Spec Test

### DIFF
--- a/transport/wseb/pom.xml
+++ b/transport/wseb/pom.xml
@@ -110,13 +110,19 @@
             <classifier>keystore</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>specification.wse</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>org.kaazing</groupId>
                 <artifactId>k3po-maven-plugin</artifactId>
+                <version>${project.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/BinaryIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/BinaryIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb.specification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.net.URI;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
+
+public class BinaryIT {
+
+    private TestRule trace = new MethodExecutionTrace();
+    private K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/wse/data/binary");
+    private final TestRule timeout = new DisableOnDebug(new Timeout(15, SECONDS));
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+         // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8080/path"))
+                            .type("echo")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration, "log4j-trace.properties");
+        }
+    };
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(trace).around(timeout).around(k3po).around(gateway);
+
+    @Ignore("X-WebSocket-Version missing in handshake response")
+    @Test
+    @Specification("echo.payload.length.0/request")
+    public void shouldEchoFrameWithPayloadLength0() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("X-WebSocket-Version missing in handshake response")
+    @Test
+    @Specification("echo.payload.length.127/request")
+    public void shouldEchoFrameWithPayloadLength127() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("X-WebSocket-Version missing in handshake response")
+    @Test
+    @Specification("echo.payload.length.128/request")
+    public void shouldEchoFrameWithPayloadLength128() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("X-WebSocket-Version missing in handshake response")
+    @Test
+    @Specification("echo.payload.length.65535/request")
+    public void shouldEchoFrameWithPayloadLength65535() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("X-WebSocket-Version missing in handshake response")
+    @Test
+    @Specification("echo.payload.length.65536/request")
+    public void shouldEchoFrameWithPayloadLength65536() throws Exception {
+        k3po.finish();
+    }
+}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/BrowsersIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/BrowsersIT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb.specification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.net.URI;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
+
+public class BrowsersIT {
+
+    private TestRule trace = new MethodExecutionTrace();
+    private K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/wse/browsers");
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+         // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8080/path"))
+                            .type("echo")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration, "log4j-trace.properties");
+        }
+    };
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(trace).around(timeout).around(k3po).around(gateway);
+
+    @Ignore
+    @Test
+    @Specification("client.reconnect.downstream/request")
+    public void serverShouldSendReconnectFrameAfterDetectingNewDownstreamRequestFromClient()
+            throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification("client.send.kb.parameter.in.downstream.request/request")
+    public void serverShouldSendReconnectFrameAfterRequestedClientBufferSizeIsExceeded()
+            throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification("client.request.padded.response/request")
+    public void serverShouldSendPaddingInDownstream() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification("client.send.ksn.parameter/request")
+    public void serverShouldReadRequestSequenceNumberFromQueryParameter() throws Exception {
+        k3po.finish();
+    }
+}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/ClosingIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/ClosingIT.java
@@ -1,0 +1,67 @@
+package org.kaazing.gateway.transport.wseb.specification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.net.URI;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+/*
+ * Copyright 2014, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.kaazing.test.util.MethodExecutionTrace;
+
+public class ClosingIT {
+
+    private TestRule trace = new MethodExecutionTrace();
+    private K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/wse/closing");
+    private final TestRule timeout = new DisableOnDebug(new Timeout(15, SECONDS));
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+         // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8080/path"))
+                            .type("echo")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration, "log4j-trace.properties");
+        }
+    };
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(trace).around(timeout).around(k3po).around(gateway);
+
+    @Ignore
+    @Test
+    @Specification("client.send.close/request")
+    public void shouldEchoClientCloseFrame() throws Exception {
+        k3po.finish();
+    }
+}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/ControlIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/ControlIT.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb.specification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.net.URI;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
+
+public class ControlIT {
+
+    private TestRule trace = new MethodExecutionTrace();
+    private K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/wse/control");
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+         // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8080/path"))
+                            .type("echo")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration, "log4j-trace.properties");
+        }
+    };
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(trace).around(timeout).around(k3po).around(gateway);
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("client.send.ping/request")
+    public void shouldReplyClientPingWithPong() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("client.send.invalid.ping/request")
+    public void shouldCloseConnectionOnReceivingInvalidPingFromClient() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("client.send.unexpected.ping/request")
+    public void shouldCloseConnectionOnReceivingUnexpectedPingFromClient() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("client.send.pong/request")
+    public void shouldReceivePongFromClient() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("client.send.invalid.pong/request")
+    public void shouldCloseConnectionOnReceivingInvalidPongFromClient() throws Exception {
+        k3po.finish();
+    }
+
+}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/DownstreamIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/DownstreamIT.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb.specification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.net.URI;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
+
+public class DownstreamIT {
+
+    private TestRule trace = new MethodExecutionTrace();
+    private K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/wse/downstream");
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+         // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8080/path"))
+                            .type("echo")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration, "log4j-trace.properties");
+        }
+    };
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(trace).around(timeout).around(k3po).around(gateway);
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("binary/request.method.not.get/downstream.request")
+    public void shouldRespondWithBadRequestWhenBinaryDownstreamRequestMethodNotGet() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("binary/request.out.of.order/downstream.request")
+    public void shouldCloseConnectionWhenBinaryDownstreamRequestIsOutOfOrder() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("binary/subsequent.request.out.of.order/request")
+    public void shouldCloseConnectionWhenSubsequentBinaryDownstreamRequestIsOutOfOrder() throws Exception {
+        k3po.finish();
+    }
+
+}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/OpeningIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/OpeningIT.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb.specification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.net.URI;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
+
+public class OpeningIT {
+
+    private TestRule trace = new MethodExecutionTrace();
+    private K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/wse/opening");
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+         // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8080/path"))
+                            .type("echo")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration, "log4j-trace.properties");
+        }
+    };
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(trace).around(timeout).around(k3po).around(gateway);
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("connection.established/handshake.request")
+    public void shouldEstablishConnection() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.with.body/handshake.request")
+    public void shouldEstablishConnectionWithNonEmptyRequestBody() throws Exception {
+        k3po.finish();
+    }
+    
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.method.not.post/handshake.request")
+    public void shouldFailHandshakeWhenRequestMethodNotPost() throws Exception {
+        k3po.finish();
+    }
+    
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.header.x.sequence.number.missing/handshake.request")
+    public void shouldFailHandshakeWhenRequestHeaderXSequenceNoIsMissing() throws Exception {
+        k3po.finish();
+    }
+    
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.header.x.sequence.number.negative/handshake.request")
+    public void shouldFailHandshakeWhenRequestHeaderXSequenceNoIsNegative() throws Exception {
+        k3po.finish();
+    }
+    
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.header.x.sequence.number.non.integer/handshake.request")
+    public void shouldFailHandshakeWhenRequestHeaderXSequenceNoIsNotInteger() throws Exception {
+        k3po.finish();
+    }
+    
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.header.x.sequence.number.out.of.range/handshake.request")
+    public void shouldFailHandshakeWhenRequestHeaderXSequenceNoIsOutOfRange() throws Exception {
+        k3po.finish();
+    }
+    
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.header.x.websocket.version.missing/handshake.request")
+    public void shouldFailHandshakeWhenRequestHeaderXWebSocketVersionMissing() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.header.x.websocket.version.not.wseb-1.0/handshake.request")
+    public void shouldFailHandshakeWhenRequestHeaderXWebSocketVersionNotWseb10()
+            throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.header.x.accept.commands.not.ping/handshake.request")
+    public void shouldFailHandshakeWhenHeaderXAcceptCommandsNotPing() throws Exception {
+        k3po.finish();
+    }
+}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/ProxiesIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/ProxiesIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb.specification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.net.URI;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
+
+public class ProxiesIT {
+
+    private TestRule trace = new MethodExecutionTrace();
+    private K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/wse/proxies");
+    private final TestRule timeout = new DisableOnDebug(new Timeout(15, SECONDS));
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+         // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8080/path"))
+                            .type("echo")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration, "log4j-trace.properties");
+        }
+    };
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(trace).around(timeout).around(k3po).around(gateway);
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("client.send.overlapping.downstream.request/request")
+    public void shouldFlushAndCloseDownstreamUponReceivingOverlappingLongpollingRequest()
+            throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("client.request.heartbeat.interval/request")
+    public void shouldSendHeartbeatToClient() throws Exception {
+        k3po.finish();
+    }
+}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/UpstreamIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/UpstreamIT.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb.specification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.net.URI;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.test.util.MethodExecutionTrace;
+
+public class UpstreamIT {
+
+    private TestRule trace = new MethodExecutionTrace();
+    private K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/wse/upstream");
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+         // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8080/path"))
+                            .type("echo")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration, "log4j-trace.properties");
+        }
+    };
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(trace).around(timeout).around(k3po).around(gateway);
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.method.not.post/upstream.request")
+    public void shouldCloseConnectionWhenUpstreamRequestMethodNotPost()
+            throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("client.send.overlapping.request/upstream.request")
+    public void shouldRejectParallelUpstreamRequest() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("request.out.of.order/upstream.request")
+    public void shouldRejectOutOfOrderUpstreamRequest() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Server is not spec compliant")
+    @Test
+    @Specification("subsequent.request.out.of.order/request")
+    public void shouldCloseConnectionWhenSubsequentUpstreamRequestIsOutOfOrder() throws Exception {
+        k3po.finish();
+    }
+}


### PR DESCRIPTION
Summary of the Issues I found - 

1. The gateway is not sending X-WebSocket-Version header in the handshake response  
     *[ChrisB] This should be resolved now, Prashant changed the wse spec and test scripts not to require that header. May need to release k3po so his changes to the wse spec project get picked up*
2. The NOOP command frame is sent by the gateway as soon as the downstream is attached which is not part of the spec
     *[ChrisB] I have a fix for this for gateway.server 4.0 in my branch transport_logging_tests. Should be easy to forward port to 5.0. [ChrisB 7-Dec-15] That branch has now been merged to gateway.server 4.x. The engineering story to forward port this to 5.0 is https://github.com/kaazing/roadmap/issues/583.

We might uncover more issues.