### PR TITLE
Binding explicitly for .../;api endpoints for wsn and wseb cases

### DIFF
--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpCookiesIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpCookiesIT.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.service.http.directory;
+
+import static org.junit.rules.RuleChain.outerRule;
+
+import java.io.File;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+
+public class HttpCookiesIT {
+
+    private final GatewayRule gateway = new GatewayRule() {
+        {
+            // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .webRootDirectory(new File("src/test/webapp"))
+                        .service()
+                            .accept(URI.create("http://localhost:8000/directory"))
+                            .type("directory")
+                            .property("directory", "/public")
+                            .property("welcome-file", "index.html")
+                        .done()
+                .done();
+            // @formatter:on
+            init(configuration);
+        }
+    };
+    
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    private final K3poRule robot = new K3poRule();
+    
+    @Rule
+    public TestRule chain = outerRule(robot).around(gateway).around(timeout);
+
+    @Test
+    @Specification("get.cookies.should.return.none")
+    public void getCookiesShouldReturnNone() throws Exception {
+        robot.finish();
+    }
+
+    @Test
+    @Specification("set.cookies.should.return.set.cookie.headers")
+    public void setCookiesShouldReturnSetCookieHeaders() throws Exception {
+        robot.finish();
+    }
+
+}

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/get.cookies.should.return.none.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/get.cookies.should.return.none.rpt
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2007-2015 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+connect http://localhost:8000/directory/;api/get-cookies
+connected
+
+write method "POST"
+write header host
+write header "Content-Type" "text/plain"
+write header "User-Agent" "Java/1.8.0_45"
+write header "Accept" "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+write header "Connection" "keep-alive"
+write header "Content-Length" "3"
+write ">|<"
+write close
+
+read status "200" /.*/
+read header "Content-Length" "0"
+read closed

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/set.cookies.should.return.set.cookie.headers.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/set.cookies.should.return.set.cookie.headers.rpt
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2007-2015 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+connect http://localhost:8000/directory/;api/set-cookies
+connected
+
+write method "POST"
+write header host
+write header "Content-Type" "text/plain"
+write header "User-Agent" "Java/1.8.0_45"
+write header "Accept" "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+write header "Connection" "keep-alive"
+write header "Content-Length" "1409"
+write "KSSOID=YYID6TCCA"
+write "+WgAwIBBaEKGwhLWk5HLk5FVKIdMBugAwIBAqEUMBIbBmtyYnRndBsIS1pORy5ORVSjggOxMIIDraADAgESoQMCAQ"
+write "KiggOfBIIDm80Lf2p4wbMquSnAKAcdIiU5K+P6qHnJO1G9ii+EvfnHwBS6lqy45Tt4LGouNW6L5rw9viqpIgDUMHX"
+write "7/vG/OCgfSEzXKUJTkE1idCaUl5c8I5i6sBw6DJeK00ogilnPr2D24IAK3tFPngtVtC3/eTMRr+5UpGjuk+/hfiC3"
+write "VRFii18AdwTDZmrdUBZvzKyrrHk9cDLm9oTZROj2l613tLsFYMrqwy+sMStw6dva1i68GfI1rflNgniG1dqj/arB/"
+write "ew8aRRcbmvz3HoTkbEMroyY02OkwebxK8XLI6/h6GmEqmtL5ho4ljhVdxPV8Aam5ThPqx3WDecMsfnvgj/ZWcp8Dn"
+write "+ft6kRL0GHxe+WMzxLB4tDGcXsag1eQ4V298ILT1h0k42dRJubrbAvXZ3kXAciYxGc/pZvWHTtiMGGmoCTDocFCCPI"
+write "tTCiA/0FPBd1Txe9iQIMlOAlzmw0E86Ff2m6vSkHm35Nwb6vHAHYq84Tf8o31J8MyBSArn/nQxZXw3TCB/2nToC8qK"
+write "nvtgZOVOCm4ihX5Soq3Azt0uGiF9rS9rN9SGExoVVVb6ILNgit9pSIWWU5xFAfupjvr3T2d8Dv6XEfC6soTV3hXSAP"
+write "SsziXQN/xRujCo7roAaA0nLKRaSvh5KgJz/vXIdXaemK74joDeyTHdBAyypUL3yF0CbGSx3iyVU6do0mOWM+Set51x6"
+write "pjNnyh8wbs+kve09ZJk85qCUwNA9Spml/FwElXlx3WsFmQrRLvE502DzOnJSPI3LsGXrwlppd1rtVFzp/JoLbQYkEc"
+write "FUIEjMIsCWEuOFHhXCTwWPt2RTbwon7cvtgNMHgqPr59q1RtzkR3MwXXn7Oq0Hvaovpx4XmuNqFPavcC2c+RbABwpj"
+write "7yFqZXz/aDGlUBuZyuQI8B54YbLMDv0x8B0C2X4FSVwa+76uTznj6T7VYPa4lfEbbiHbYQC/2oicXTlWlRwFtmPxoe"
+write "ZDsZxtlLGUJkXJmyKBmOpxX8TZvmqIQ2nMYsZOooW+vlkjwSsjgQE90EDQK9uQ5DXT0+KIIXxDxxVT20fbfYpgWi/ZA"
+write "Ks278Z28SAqvJdkJhs/QkEEAIZiMDzqeViz8Ds17QOXgh2/srd5t5ASvF8dC/JvrT8osRyja4MpHhy9BhRD6gr681pY1"
+write "UZJdJyPN575bRd/2KmjBMAyzEXoCOm65m3CPYLCqKX3q05ddKTBYIGjzpPZiGMC+8Bv0Eeiz>|<MBmgAwIBF6ESBBBGc"
+write "K6owFtvUrWHx0fPvtWp>|<testUser1>|<KZNG.NET"
+
+write close
+
+read status "200" /.*/
+read header "Set-Cookie" "KSSOID=YYID6TCCA" /.*KZNG.NET/
+read header "Content-Length" "0"
+read closed

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpOperationFilter.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpOperationFilter.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 public class HttpOperationFilter extends HttpFilterAdapter<IoSessionEx> {
 
-    private static final String EXTENSION_API_PATH_PREFIX = "/;api/";
+    private static final String EXTENSION_API_PATH_PREFIX = HttpProtocolCompatibilityFilter.API_PATH + "/";
     private static final Charset UTF_8 = Charset.forName("UTF-8");
     private static final byte[] EQUAL_BYTES = "=".getBytes(UTF_8);
     private static final byte[] CRLF_BYTES = "\r\n".getBytes(UTF_8);
@@ -89,7 +89,7 @@ public class HttpOperationFilter extends HttpFilterAdapter<IoSessionEx> {
                 super.httpRequestReceived(nextFilter, session, httpRequest);
             }
             else {
-                // unrecognized operation found
+                // unrecognized operation found or httpe-1.0
                 if (logger.isDebugEnabled()) {
                     logger.debug(String.format("Rejected unrecognized operation \"%s\" for URI \"%s\" on session %s",
                             operationName, requestURI, session));
@@ -142,6 +142,10 @@ public class HttpOperationFilter extends HttpFilterAdapter<IoSessionEx> {
 
     }
 
+    /**
+     * Reads all the cookies in the request body and sets them as Set-Cookie headers in the HTTP response
+     *
+     */
     static class HttpSetCookiesOperation extends HttpOperation {
 
         private static final TypedAttributeKey<IoBufferEx> BUFFER_KEY = new TypedAttributeKey<>(HttpSetCookiesOperation.class, "buffer");
@@ -213,6 +217,9 @@ public class HttpOperationFilter extends HttpFilterAdapter<IoSessionEx> {
 
     }
 
+    /**
+     * Returns in the response body all cookies set in Cookie headers in the HttpRequest (by the web browser).
+     */
     static class HttpGetCookiesOperation extends HttpOperation {
 
         @Override

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpProtocolCompatibilityFilter.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpProtocolCompatibilityFilter.java
@@ -118,6 +118,8 @@ public class HttpProtocolCompatibilityFilter extends HttpFilterAdapter<IoSession
     private static final String PATH_ENCODED_METHOD_PREFIX = "/;";
     private static final int PATH_ENCODED_METHOD_PREFIX_LENGTH = PATH_ENCODED_METHOD_PREFIX.length();
 
+    public static final String API_PATH = "/;api";
+
     public static final AttributeKey EMPTY_PACKET_PRODUCER_FILTER = new AttributeKey(HttpProtocolCompatibilityFilter.class, "emptyPacketProducerFilter");
 
 
@@ -327,6 +329,14 @@ public class HttpProtocolCompatibilityFilter extends HttpFilterAdapter<IoSession
                     if (!PROTOCOL_HTTPXE_1_1.equals(nextProtocol)) {
                         httpRequest.setHeader(HEADER_X_NEXT_PROTOCOL, PROTOCOL_HTTPXE_1_1);
                     }
+                }
+            }
+
+            if (isApiPath(path)) {
+                if (httpRequest.getHeader(HttpHeaders.HEADER_X_ORIGIN) != null) {
+                    // Remove operation filter at http layer so that request will flow to httpxe layer
+                    session.getFilterChain().remove(HttpAcceptFilter.OPERATION.filter());
+                    httpRequest.setHeader(HEADER_X_NEXT_PROTOCOL, PROTOCOL_HTTPXE_1_1);
                 }
             }
         }
@@ -539,7 +549,7 @@ public class HttpProtocolCompatibilityFilter extends HttpFilterAdapter<IoSession
                 // XDR needs to explicitly envelope the request, so we must not treat this as requiring implicit elevation
                 return !isExplicitEnvelopedContentType(httpSession) &&
                         isLegacyClient(httpSession) &&
-                        (isEmulatedWebSocketRequest(httpSession) || isRevalidateWebSocketRequest(httpSession));
+                        (isEmulatedWebSocketRequest(httpSession) || isRevalidateWebSocketRequest(httpSession) || isApiRequest(httpSession));
             }
             return false;
         }
@@ -555,6 +565,15 @@ public class HttpProtocolCompatibilityFilter extends HttpFilterAdapter<IoSession
             req.setRequestURI(session.getRequestURI());
             req.setSecure(session.isSecure());
             req.setCookies(session.getReadCookies());
+            // Populate with incomplete content message so that HttpRequestMessage.isComplete() returns correctly
+            // This logic is based on Content-Length, otherwise, DefaultHttpSession needs to be populated
+            // when it is constructed in HttpAcceptor and then use it to populate here.
+            String contentLengthStr = session.getReadHeader("Content-Length");
+            if (contentLengthStr != null && !"0".equals(contentLengthStr)) {
+                IoBufferAllocatorEx<? extends HttpBuffer> allocator = session.getBufferAllocator();
+                HttpContentMessage httpContent = new HttpContentMessage(allocator.wrap(allocator.allocate(0)), false);
+                req.setContent(httpContent);
+            }
 
             // establish all the headers (mutable) and then restrict to just the ones we want.
             Map<String,List<String>> requestHeaders = new HashMap<>(session.getReadHeaders());
@@ -581,6 +600,12 @@ public class HttpProtocolCompatibilityFilter extends HttpFilterAdapter<IoSession
         // EmulatedWebSocket requests need elevating.
         // they're elevated from the session data.
         return isEmulatedWebSocketPath(session.getRequestURI().getPath());
+    }
+
+    private static boolean isApiRequest(HttpAcceptSession session) {
+        // /;api requests need elevating.
+        // they're elevated from the session data.
+        return isApiPath(session.getRequestURI().getPath());
     }
 
     private static boolean isRevalidateWebSocketRequest(HttpRequestMessage message) {
@@ -629,6 +654,10 @@ public class HttpProtocolCompatibilityFilter extends HttpFilterAdapter<IoSession
             }
         }
         return false;
+    }
+
+    private static boolean isApiPath(String path) {
+        return path != null && path.contains(API_PATH);
     }
 
     public static class HttpConditionalWrappedResponseFilter extends HttpFilterAdapter<IoSessionEx> {

--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/WsAcceptor.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/WsAcceptor.java
@@ -39,9 +39,11 @@ import javax.annotation.Resource;
 
 import org.apache.mina.core.future.IoFuture;
 import org.apache.mina.core.service.IoHandler;
+import org.apache.mina.core.session.IoSession;
 import org.kaazing.gateway.resource.address.ResourceAddress;
 import org.kaazing.gateway.transport.BridgeAcceptor;
 import org.kaazing.gateway.transport.BridgeSessionInitializer;
+import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.gateway.transport.ws.extension.WebSocketExtensionFactory;
 import org.kaazing.mina.core.future.DefaultUnbindFuture;
 import org.kaazing.mina.core.future.UnbindFuture;
@@ -61,6 +63,9 @@ public class WsAcceptor implements BridgeAcceptor {
     private static final String WSE_PROTOCOL_NAME = "wse/1.0";
     private static final String WS_DRAFT_PROTOCOL_NAME = "ws/draft-7x";
     private static final String WS_NATIVE_PROTOCOL_NAME = "ws/rfc6455";
+
+    // handler for /;api endpoint requests
+    public static final IoHandler API_PATH_HANDLER = new IoHandlerAdapter<IoSession>() {};
 
     private static Logger logger = LoggerFactory.getLogger(WsAcceptor.class);
 

--- a/transport/wseb/src/main/java/org/kaazing/gateway/transport/wseb/WsebAcceptor.java
+++ b/transport/wseb/src/main/java/org/kaazing/gateway/transport/wseb/WsebAcceptor.java
@@ -27,6 +27,7 @@ import static org.kaazing.gateway.resource.address.ResourceAddress.ALTERNATE;
 import static org.kaazing.gateway.resource.address.ResourceAddress.BIND_ALTERNATE;
 import static org.kaazing.gateway.resource.address.ResourceAddress.NEXT_PROTOCOL;
 import static org.kaazing.gateway.resource.address.ResourceAddress.TRANSPORT;
+import static org.kaazing.gateway.resource.address.URLUtils.*;
 import static org.kaazing.gateway.resource.address.URLUtils.appendURI;
 import static org.kaazing.gateway.resource.address.URLUtils.ensureTrailingSlash;
 import static org.kaazing.gateway.resource.address.URLUtils.modifyURIScheme;
@@ -52,6 +53,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.Resource;
 
+import org.kaazing.gateway.resource.address.URLUtils;
 import org.kaazing.gateway.transport.http.HttpHeaders;
 import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.future.CloseFuture;
@@ -92,6 +94,7 @@ import org.kaazing.gateway.transport.http.HttpProtocol;
 import org.kaazing.gateway.transport.http.HttpStatus;
 import org.kaazing.gateway.transport.http.HttpUtils;
 import org.kaazing.gateway.transport.http.bridge.filter.HttpLoginSecurityFilter;
+import org.kaazing.gateway.transport.http.bridge.filter.HttpProtocolCompatibilityFilter;
 import org.kaazing.gateway.transport.ws.WsAcceptor;
 import org.kaazing.gateway.transport.ws.WsProtocol;
 import org.kaazing.gateway.transport.ws.bridge.filter.WsBuffer;
@@ -297,6 +300,8 @@ public class WsebAcceptor extends AbstractBridgeAcceptor<WsebSession, Binding> {
                 }
             };
 
+            bindApiPath(address);
+
             BridgeAcceptor transportAcceptor = bridgeServiceFactory.newBridgeAcceptor(transportAddress);
             transportAcceptor.bind(transportAddress, createHandler, wrapperHttpInitializer);
 
@@ -304,6 +309,48 @@ public class WsebAcceptor extends AbstractBridgeAcceptor<WsebSession, Binding> {
             throw new RuntimeException("Unable to bind address " + address + ": " + e.getMessage(),e );
         }
 
+    }
+
+    private void bindApiPath(ResourceAddress address) {
+        ResourceAddress apiHttpAddress = createApiHttpAddress(address.getTransport());
+        bridgeServiceFactory.newBridgeAcceptor(apiHttpAddress).bind(apiHttpAddress, WsAcceptor.API_PATH_HANDLER, null);
+
+        ResourceAddress apiHttpxeAddress = address.getTransport().getOption(ALTERNATE);
+        if (apiHttpxeAddress != null) {
+            apiHttpxeAddress = createApiHttpxeAddress(apiHttpxeAddress);
+            bridgeServiceFactory.newBridgeAcceptor(apiHttpxeAddress).bind(apiHttpxeAddress, WsAcceptor.API_PATH_HANDLER, null);
+        }
+    }
+
+    private void unbindApiPath(ResourceAddress address) {
+        ResourceAddress apiHttpAddress = createApiHttpAddress(address.getTransport());
+        bridgeServiceFactory.newBridgeAcceptor(apiHttpAddress).unbind(apiHttpAddress);
+
+        ResourceAddress apiHttpxeAddress = address.getTransport().getOption(ALTERNATE);
+        if (apiHttpxeAddress != null) {
+            apiHttpxeAddress = createApiHttpxeAddress(apiHttpxeAddress);
+            bridgeServiceFactory.newBridgeAcceptor(apiHttpxeAddress).unbind(apiHttpxeAddress);
+        }
+    }
+
+    private ResourceAddress createApiHttpAddress(ResourceAddress httpTransport) {
+        String path = appendURI(ensureTrailingSlash(httpTransport.getExternalURI()), HttpProtocolCompatibilityFilter.API_PATH).getPath();
+
+        URI httpLocation = modifyURIPath(httpTransport.getExternalURI(), path);
+        ResourceOptions httpOptions = ResourceOptions.FACTORY.newResourceOptions(httpTransport);
+        httpOptions.setOption(NEXT_PROTOCOL, null);       // terminal endpoint, so next protocol null
+        httpOptions.setOption(ALTERNATE, null);
+        return resourceAddressFactory.newResourceAddress(httpLocation, httpOptions);
+    }
+
+    private ResourceAddress createApiHttpxeAddress(ResourceAddress httpxeTransport) {
+        String path = appendURI(ensureTrailingSlash(httpxeTransport.getExternalURI()), HttpProtocolCompatibilityFilter.API_PATH).getPath();
+
+        httpxeTransport = httpxeTransport.resolve(path);
+        URI httpxeLocation = modifyURIPath(httpxeTransport.getExternalURI(), path);
+        ResourceOptions httpxeOptions = ResourceOptions.FACTORY.newResourceOptions(httpxeTransport);
+        httpxeOptions.setOption(NEXT_PROTOCOL, null);       // terminal endpoint, so next protocol null
+        return resourceAddressFactory.newResourceAddress(httpxeLocation, httpxeOptions);
     }
 
     private void bindCookiesHandler(ResourceAddress address) {
@@ -335,6 +382,8 @@ public class WsebAcceptor extends AbstractBridgeAcceptor<WsebSession, Binding> {
     @Override
     protected UnbindFuture unbindInternal(ResourceAddress address, IoHandler handler,
             BridgeSessionInitializer<? extends IoFuture> initializer) {
+
+        unbindApiPath(address);
 
         final ResourceAddress transportAddress = address.getTransport();
         URI transportURI = transportAddress.getExternalURI();

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebCookiesIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebCookiesIT.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb;
+
+import static org.junit.rules.RuleChain.outerRule;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+
+public class WsebCookiesIT {
+
+    private final GatewayRule gateway = new GatewayRule() {
+        {
+            // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wse://localhost:8000/echo"))
+                            .type("echo")
+                            .crossOrigin()
+                                .allowOrigin("*")
+                            .done()
+                        .done()
+                .done();
+            // @formatter:on
+            init(configuration);
+        }
+    };
+    
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    private final K3poRule robot = new K3poRule();
+    
+    @Rule
+    public final TestRule chain = outerRule(robot).around(gateway).around(timeout);
+
+    // httpe should give wrapped response (Flash client)
+    @Test
+    @Specification("httpe.get.cookies.should.return.none")
+    public void httpeGetCookiesShouldReturnNone() throws Exception {
+        robot.finish();
+    }
+
+    // httpe should give wrapped response (Flash client)
+    @Test
+    @Specification("httpe.set.cookies.should.return.set.cookie.headers")
+    public void httpeSetCookiesShouldReturnSetCookieHeaders() throws Exception {
+        robot.finish();
+    }
+}

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/httpe.get.cookies.should.return.none.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/httpe.get.cookies.should.return.none.rpt
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2007-2015 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+connect http://localhost:8000/echo/;api/get-cookies
+connected
+
+# The following corresponds to the 4.0 Flash client
+write method "POST"
+write header "Accept" "*/*"
+write header "Referer" "http://localhost:8002/?.kr=xsa"
+write header "Content-Type" "text/plain"
+write header "Content-Length" "3"
+write header "X-Origin" "null"
+write header "X-Http-Version" "httpe-1.0"
+write header "User-Agent" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)"
+write header host
+write header "DNT" "1"
+write header "Connection" "Keep-Alive"
+write header "Cache-Control" "no-cache"
+write ">|<"
+write close
+
+read status "200" /.*/
+read header "Content-Length" /.*/
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Type: text/plain; charset=UTF-8\r\n"
+read "\r\n"
+read closed

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/httpe.set.cookies.should.return.set.cookie.headers.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/httpe.set.cookies.should.return.set.cookie.headers.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2007-2015 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+connect http://localhost:8000/echo/;api/set-cookies
+connected
+
+write method "POST"
+write header "Accept" "*/*"
+write header "Referer" "http://localhost:8002/?.kr=xsa"
+write header "Content-Type" "text/plain"
+write header "Content-Length" "1409"
+write header "X-Origin" "null"
+write header "X-Http-Version" "httpe-1.0"
+write header "User-Agent" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)"
+write header host
+write header "DNT" "1"
+write header "Connection" "Keep-Alive"
+write header "Cache-Control" "no-cache"
+write "KSSOID=YYID6TCCA"
+write "+WgAwIBBaEKGwhLWk5HLk5FVKIdMBugAwIBAqEUMBIbBmtyYnRndBsIS1pORy5ORVSjggOxMIIDraADAgESoQMCAQ"
+write "KiggOfBIIDm80Lf2p4wbMquSnAKAcdIiU5K+P6qHnJO1G9ii+EvfnHwBS6lqy45Tt4LGouNW6L5rw9viqpIgDUMHX"
+write "7/vG/OCgfSEzXKUJTkE1idCaUl5c8I5i6sBw6DJeK00ogilnPr2D24IAK3tFPngtVtC3/eTMRr+5UpGjuk+/hfiC3"
+write "VRFii18AdwTDZmrdUBZvzKyrrHk9cDLm9oTZROj2l613tLsFYMrqwy+sMStw6dva1i68GfI1rflNgniG1dqj/arB/"
+write "ew8aRRcbmvz3HoTkbEMroyY02OkwebxK8XLI6/h6GmEqmtL5ho4ljhVdxPV8Aam5ThPqx3WDecMsfnvgj/ZWcp8Dn"
+write "+ft6kRL0GHxe+WMzxLB4tDGcXsag1eQ4V298ILT1h0k42dRJubrbAvXZ3kXAciYxGc/pZvWHTtiMGGmoCTDocFCCPI"
+write "tTCiA/0FPBd1Txe9iQIMlOAlzmw0E86Ff2m6vSkHm35Nwb6vHAHYq84Tf8o31J8MyBSArn/nQxZXw3TCB/2nToC8qK"
+write "nvtgZOVOCm4ihX5Soq3Azt0uGiF9rS9rN9SGExoVVVb6ILNgit9pSIWWU5xFAfupjvr3T2d8Dv6XEfC6soTV3hXSAP"
+write "SsziXQN/xRujCo7roAaA0nLKRaSvh5KgJz/vXIdXaemK74joDeyTHdBAyypUL3yF0CbGSx3iyVU6do0mOWM+Set51x6"
+write "pjNnyh8wbs+kve09ZJk85qCUwNA9Spml/FwElXlx3WsFmQrRLvE502DzOnJSPI3LsGXrwlppd1rtVFzp/JoLbQYkEc"
+write "FUIEjMIsCWEuOFHhXCTwWPt2RTbwon7cvtgNMHgqPr59q1RtzkR3MwXXn7Oq0Hvaovpx4XmuNqFPavcC2c+RbABwpj"
+write "7yFqZXz/aDGlUBuZyuQI8B54YbLMDv0x8B0C2X4FSVwa+76uTznj6T7VYPa4lfEbbiHbYQC/2oicXTlWlRwFtmPxoe"
+write "ZDsZxtlLGUJkXJmyKBmOpxX8TZvmqIQ2nMYsZOooW+vlkjwSsjgQE90EDQK9uQ5DXT0+KIIXxDxxVT20fbfYpgWi/ZA"
+write "Ks278Z28SAqvJdkJhs/QkEEAIZiMDzqeViz8Ds17QOXgh2/srd5t5ASvF8dC/JvrT8osRyja4MpHhy9BhRD6gr681pY1"
+write "UZJdJyPN575bRd/2KmjBMAyzEXoCOm65m3CPYLCqKX3q05ddKTBYIGjzpPZiGMC+8Bv0Eeiz>|<MBmgAwIBF6ESBBBGc"
+write "K6owFtvUrWHx0fPvtWp>|<testUser1>|<KZNG.NET"
+
+write close
+
+read status "200" /.*/
+read header "Content-Length" /.*/
+read header "Content-Type" "text/plain;charset=UTF-8"
+read header "Set-Cookie" /KSSOID=YYID6TCCA.*KZNG.NET/
+read "HTTP/1.1 200 OK\r\n\r\n"
+
+read closed

--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
@@ -23,8 +23,12 @@ package org.kaazing.gateway.transport.wsn;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static org.kaazing.gateway.resource.address.ResourceAddress.BIND_ALTERNATE;
 import static org.kaazing.gateway.resource.address.ResourceAddress.NEXT_PROTOCOL;
 import static org.kaazing.gateway.resource.address.ResourceAddress.TRANSPORT;
+import static org.kaazing.gateway.resource.address.URLUtils.appendURI;
+import static org.kaazing.gateway.resource.address.URLUtils.ensureTrailingSlash;
+import static org.kaazing.gateway.resource.address.URLUtils.modifyURIPath;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.REALM_CHALLENGE_SCHEME;
 import static org.kaazing.gateway.resource.address.ws.WsResourceAddress.CODEC_REQUIRED;
 import static org.kaazing.gateway.resource.address.ws.WsResourceAddress.INACTIVITY_TIMEOUT;
@@ -420,6 +424,8 @@ public class WsnAcceptor extends AbstractBridgeAcceptor<WsnSession, WsnBindings.
             }
         };
 
+        bindApiPath(address);
+
         BridgeAcceptor acceptor = bridgeServiceFactory.newBridgeAcceptor(address.getTransport());
         try {
             ResourceAddress transport = address.getTransport();
@@ -433,9 +439,36 @@ public class WsnAcceptor extends AbstractBridgeAcceptor<WsnSession, WsnBindings.
     @Override
     protected UnbindFuture unbindInternal(ResourceAddress address, IoHandler handler,
             BridgeSessionInitializer<? extends IoFuture> initializer) {
+        unbindApiPath(address);
         ResourceAddress transport = address.getTransport();
         BridgeAcceptor acceptor = bridgeServiceFactory.newBridgeAcceptor(transport);
         return acceptor.unbind(address.getTransport());
+    }
+
+    private void bindApiPath(ResourceAddress address) {
+        String scheme = address.getExternalURI().getScheme();
+        ResourceAddress apiAddress = createApiAddress(address);
+        bridgeServiceFactory.newBridgeAcceptor(apiAddress).bind(apiAddress, WsAcceptor.API_PATH_HANDLER, null);
+    }
+
+    private void unbindApiPath(ResourceAddress address) {
+        String scheme = address.getExternalURI().getScheme();
+        ResourceAddress apiAddress = createApiAddress(address);
+        bridgeServiceFactory.newBridgeAcceptor(apiAddress).unbind(apiAddress);
+    }
+
+    private ResourceAddress createApiAddress(ResourceAddress address) {
+        ResourceAddress transport = address.getTransport();
+
+        ResourceOptions apiAddressOptions = ResourceOptions.FACTORY.newResourceOptions(transport);
+        // /;api/operation is a terminal endpoint so next protocol should be null
+        apiAddressOptions.setOption(NEXT_PROTOCOL, null);
+        // even if the address has an alternate, do not bind the alternate
+        apiAddressOptions.setOption(BIND_ALTERNATE, Boolean.FALSE);
+
+        String path = appendURI(ensureTrailingSlash(address.getExternalURI()), HttpProtocolCompatibilityFilter.API_PATH).getPath();
+        URI apiLocation = modifyURIPath(transport.getResource(), path);
+        return resourceAddressFactory.newResourceAddress(apiLocation, apiAddressOptions);
     }
 
     private IoHandler selectHandler(ResourceAddress address) {

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnCookiesIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnCookiesIT.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kaazing.gateway.transport.wsn;
+
+import static org.junit.rules.RuleChain.outerRule;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+
+public class WsnCookiesIT {
+
+    private final GatewayRule gateway = new GatewayRule() {
+        {
+            // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(URI.create("wsn://localhost:8000/echo"))
+                            .type("echo")
+                            .crossOrigin()
+                                .allowOrigin("*")
+                            .done()
+                        .done()
+                .done();
+            // @formatter:on
+            init(configuration);
+        }
+    };
+    
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
+
+    private final K3poRule robot = new K3poRule();
+    
+    @Rule
+    public final TestRule chain = outerRule(robot).around(gateway).around(timeout);
+
+    @Test
+    @Specification("ws.get.cookies.should.return.none")
+    public void wsGetCookiesShouldReturnNone() throws Exception {
+        robot.finish();
+    }
+
+    @Test
+    @Specification("ws.set.cookies.should.return.set.cookie.headers")
+    public void wsSetCookiesShouldReturnSetCookieHeaders() throws Exception {
+        robot.finish();
+    }
+
+}

--- a/transport/wsn/src/test/scripts/org/kaazing/gateway/transport/wsn/ws.get.cookies.should.return.none.rpt
+++ b/transport/wsn/src/test/scripts/org/kaazing/gateway/transport/wsn/ws.get.cookies.should.return.none.rpt
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2007-2015 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+connect http://localhost:8000/echo/;api/get-cookies
+connected
+
+write method "POST"
+write header host
+write header "Content-Type" "text/plain"
+write header "User-Agent" "Java/1.8.0_45"
+write header "Accept" "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+write header "Connection" "keep-alive"
+write header "Content-Length" "3"
+write ">|<"
+write close
+
+read status "200" /.*/
+read header "Content-Length" "0"
+read closed

--- a/transport/wsn/src/test/scripts/org/kaazing/gateway/transport/wsn/ws.set.cookies.should.return.set.cookie.headers.rpt
+++ b/transport/wsn/src/test/scripts/org/kaazing/gateway/transport/wsn/ws.set.cookies.should.return.set.cookie.headers.rpt
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2007-2015 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+connect http://localhost:8000/echo/;api/set-cookies
+connected
+
+write method "POST"
+write header host
+write header "Content-Type" "text/plain"
+write header "User-Agent" "Java/1.8.0_45"
+write header "Accept" "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+write header "Connection" "keep-alive"
+write header "Content-Length" "1409"
+write "KSSOID=YYID6TCCA"
+write "+WgAwIBBaEKGwhLWk5HLk5FVKIdMBugAwIBAqEUMBIbBmtyYnRndBsIS1pORy5ORVSjggOxMIIDraADAgESoQMCAQ"
+write "KiggOfBIIDm80Lf2p4wbMquSnAKAcdIiU5K+P6qHnJO1G9ii+EvfnHwBS6lqy45Tt4LGouNW6L5rw9viqpIgDUMHX"
+write "7/vG/OCgfSEzXKUJTkE1idCaUl5c8I5i6sBw6DJeK00ogilnPr2D24IAK3tFPngtVtC3/eTMRr+5UpGjuk+/hfiC3"
+write "VRFii18AdwTDZmrdUBZvzKyrrHk9cDLm9oTZROj2l613tLsFYMrqwy+sMStw6dva1i68GfI1rflNgniG1dqj/arB/"
+write "ew8aRRcbmvz3HoTkbEMroyY02OkwebxK8XLI6/h6GmEqmtL5ho4ljhVdxPV8Aam5ThPqx3WDecMsfnvgj/ZWcp8Dn"
+write "+ft6kRL0GHxe+WMzxLB4tDGcXsag1eQ4V298ILT1h0k42dRJubrbAvXZ3kXAciYxGc/pZvWHTtiMGGmoCTDocFCCPI"
+write "tTCiA/0FPBd1Txe9iQIMlOAlzmw0E86Ff2m6vSkHm35Nwb6vHAHYq84Tf8o31J8MyBSArn/nQxZXw3TCB/2nToC8qK"
+write "nvtgZOVOCm4ihX5Soq3Azt0uGiF9rS9rN9SGExoVVVb6ILNgit9pSIWWU5xFAfupjvr3T2d8Dv6XEfC6soTV3hXSAP"
+write "SsziXQN/xRujCo7roAaA0nLKRaSvh5KgJz/vXIdXaemK74joDeyTHdBAyypUL3yF0CbGSx3iyVU6do0mOWM+Set51x6"
+write "pjNnyh8wbs+kve09ZJk85qCUwNA9Spml/FwElXlx3WsFmQrRLvE502DzOnJSPI3LsGXrwlppd1rtVFzp/JoLbQYkEc"
+write "FUIEjMIsCWEuOFHhXCTwWPt2RTbwon7cvtgNMHgqPr59q1RtzkR3MwXXn7Oq0Hvaovpx4XmuNqFPavcC2c+RbABwpj"
+write "7yFqZXz/aDGlUBuZyuQI8B54YbLMDv0x8B0C2X4FSVwa+76uTznj6T7VYPa4lfEbbiHbYQC/2oicXTlWlRwFtmPxoe"
+write "ZDsZxtlLGUJkXJmyKBmOpxX8TZvmqIQ2nMYsZOooW+vlkjwSsjgQE90EDQK9uQ5DXT0+KIIXxDxxVT20fbfYpgWi/ZA"
+write "Ks278Z28SAqvJdkJhs/QkEEAIZiMDzqeViz8Ds17QOXgh2/srd5t5ASvF8dC/JvrT8osRyja4MpHhy9BhRD6gr681pY1"
+write "UZJdJyPN575bRd/2KmjBMAyzEXoCOm65m3CPYLCqKX3q05ddKTBYIGjzpPZiGMC+8Bv0Eeiz>|<MBmgAwIBF6ESBBBGc"
+write "K6owFtvUrWHx0fPvtWp>|<testUser1>|<KZNG.NET"
+
+write close
+
+read status "200" /.*/
+read header "Set-Cookie" "KSSOID=YYID6TCCA" /.*KZNG.NET/
+read header "Content-Length" "0"
+read closed


### PR DESCRIPTION
- HttpOperationFilter is removed in http layer when the request is httpxe
- /;api requests with X-Origin are elevated to httpxe
- HttpRequestMessage.isComplete() returns correctly if there is data
in the request