### PR TITLE
(#267) Ignore OcspIT.testGoodCertificate since we have not yet found …

### DIFF
--- a/management/src/test/java/org/kaazing/gateway/management/jmx/JmxManagementServiceHandlerTest.java
+++ b/management/src/test/java/org/kaazing/gateway/management/jmx/JmxManagementServiceHandlerTest.java
@@ -21,10 +21,15 @@
 
 package org.kaazing.gateway.management.jmx;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.kaazing.test.util.ITUtil.createTimeout;
+
 import java.net.URI;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -36,6 +41,9 @@ public class JmxManagementServiceHandlerTest {
     private final URI BACKEND_URI_1 = URI.create("tcp://localhost:9123");
     private final URI BACKEND_URI_2 = URI.create("tcp://localhost:9124");
     private final String PROXY = "proxy";
+
+    @Rule
+    public TestRule timeoutRule = createTimeout(20, SECONDS);
 
     @Test
     public void testNoJMXBindingNameConflictsOnMultiServicesUsingSameConnect() throws Exception {

--- a/service/broadcast/src/test/java/org/kaazing/gateway/service/broadcast/BroadcastServiceIT.java
+++ b/service/broadcast/src/test/java/org/kaazing/gateway/service/broadcast/BroadcastServiceIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.service.broadcast;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -55,22 +55,22 @@ public class BroadcastServiceIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
 	@Specification("broadcast.backend.tcp.connect.and.close")
-	@Test(timeout = 5000)
+	@Test
 	public void tcpConnectionToBackendAndClose() throws Exception {
 		robot.finish();
 	}
 
 	@Specification("broadcast.backend.tcp.connect.send.and.close")
-	@Test(timeout = 5000)
+	@Test
 	public void tcpConnectionToBackendSendAndClose() throws Exception {
         robot.finish();
 	}
 
 	@Specification("broadcast.frontend.tcp.connect.and.close")
-	@Test(timeout = 5000)
+	@Test
 	public void TcpConnectToFrontendAndClose() throws Exception {
         robot.finish();
 	}

--- a/service/http.balancer/src/test/java/org/kaazing/gateway/service/http/balancer/WsebBalancerIT.java
+++ b/service/http.balancer/src/test/java/org/kaazing/gateway/service/http/balancer/WsebBalancerIT.java
@@ -22,27 +22,22 @@
 package org.kaazing.gateway.service.http.balancer;
 
 
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+import java.net.URI;
+
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
-import java.net.URI;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.rules.RuleChain.outerRule;
-
 public class WsebBalancerIT {
 
     private final K3poRule robot = new K3poRule();
-
-    private final TestRule timeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
 
     private final GatewayRule gateway = new GatewayRule() {
         {
@@ -74,7 +69,7 @@ public class WsebBalancerIT {
 
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Test
     @Specification("wse.balancer.request")

--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/DirectoryServiceEmbeddedGWTestIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/DirectoryServiceEmbeddedGWTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.service.http.directory;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.net.URI;
@@ -37,9 +37,9 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 
 public class DirectoryServiceEmbeddedGWTestIT {
 
-    private static String DIRECTORY_SERVICE_ACCEPT = "http://localhost:8000/"; 
+    private static String DIRECTORY_SERVICE_ACCEPT = "http://localhost:8000/";
     private static String AUTH_DIRECTORY_SERVICE_ACCEPT = "http://localhost:8008/auth";
-    
+
     private final K3poRule robot = new K3poRule();
     private final GatewayRule gateway = new GatewayRule() {
         {
@@ -63,31 +63,31 @@ public class DirectoryServiceEmbeddedGWTestIT {
                             .authorization()
                                  .requireRole("AUTHORIZED")
                             .done()
-                        .done()     
+                        .done()
                         .security()
                             .realm()
                                 .name("demo")
                                 .description("Kaazing WebSocket Gateway Demo")
-                                .httpChallengeScheme("Application Token")   
+                                .httpChallengeScheme("Application Token")
                                 .authorizationMode("challenge")
-                                .loginModule()                          
+                                .loginModule()
                                 .type("class:org.kaazing.gateway.security.auth.YesLoginModule")
                                     .success("requisite")
                                     .option("roles", "AUTHORIZED, ADMINISTRATOR")
                             .done()
-                        .done()                 
+                        .done()
                      .done()
                 .done();
             // @formatter:on
             init(configuration);
         }
     };
-   
+
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("get.content.type.xsj")
-    @Test(timeout = 5000)
+    @Test
     public void testGetContentTypeXSJ() throws Exception {
         robot.finish();
     }

--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceAuthorizationIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceAuthorizationIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.service.http.directory;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,7 +44,7 @@ public class HttpDirectoryServiceAuthorizationIT {
     private static String BASIC_AUTH_DIRECTORY_SERVICE_ACCEPT = "http://localhost:8008/auth";
     private static String APP_BASIC_AUTH_DIRECTORY_SERVICE_ACCEPT = "http://localhost:8009/auth";
     private static String TOKEN_AUTH_DIRECTORY_SERVICE_ACCEPT = "http://localhost:8010/auth";
-    
+
     private final K3poRule robot = new K3poRule();
 
     private final GatewayRule gateway = new GatewayRule() {
@@ -107,9 +107,9 @@ public class HttpDirectoryServiceAuthorizationIT {
                             .realm()
                                 .name("token")
                                 .description("Kaazing WebSocket Gateway Demo")
-                                .httpChallengeScheme("Application Token")   
+                                .httpChallengeScheme("Application Token")
                                 .authorizationMode("challenge")
-                                .loginModule()                          
+                                .loginModule()
                                     .type("class:org.kaazing.gateway.service.http.directory.TokenLoginModule")
                                     .success("requisite")
                                     .option("roles", "AUTHORIZED, ADMINISTRATOR")
@@ -145,59 +145,59 @@ public class HttpDirectoryServiceAuthorizationIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     // //////////////////////// AUTHORIZATION //////////////////
     @Specification("auth/app.basic.authorized.access.with.valid.credentials")
-    @Test(timeout = 500000)
+    @Test
     public void testAppBasicAuthorizedWithValidCredentials() throws Exception {
         robot.finish();
     }
 
     @Specification("auth/app.basic.authorized.access.with.invalid.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testAppBasicAuthorizedWithInvalidCredentials() throws Exception {
         robot.finish();
     }
 
     @Specification("auth/app.basic.authorized.directory.access.no.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testAppBasicAuthorizedWithoutCredentials() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("auth/basic.authorized.access.with.valid.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testBasicAuthorizedWithValidCredentials() throws Exception {
         robot.finish();
     }
 
     @Specification("auth/basic.authorized.access.with.invalid.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testBasicAuthorizedWithInvalidCredentials() throws Exception {
         robot.finish();
     }
 
     @Specification("auth/basic.authorized.directory.access.no.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testBasicAuthorizedWithoutCredentials() throws Exception {
         robot.finish();
     }
 
     @Specification("auth/token.authorized.access.with.valid.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testTokenAuthorizedWithValidCredentials() throws Exception {
         robot.finish();
     }
 
     @Specification("auth/token.authorized.access.with.invalid.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testTokenAuthorizedWithInValidCredentials() throws Exception {
         robot.finish();
     }
 
     @Specification("auth/token.authorized.directory.access.no.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testTokenAuthorizedWithoutCredentials() throws Exception {
         robot.finish();
     }

--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.service.http.directory;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.net.URI;
@@ -96,35 +96,35 @@ public class HttpDirectoryServiceIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("get.index.check.status.code.200")
-    @Test(timeout = 8000)
+    @Test
     public void testGetIndexAndStatusCode200() throws Exception {
         robot.finish();
     }
 
     @Specification("no.server.header")
-    @Test(timeout = 8000)
+    @Test
     public void testNoServerHeader() throws Exception {
         robot.finish();
     }
 
     @Specification("get.nonexistent.page.check.status.code.404")
-    @Test(timeout = 8000)
+    @Test
     public void testGetNonexistantPageCheckStatusCode404() throws Exception {
         robot.finish();
     }
 
     @Specification("get.nonexistent.page.check.http.keepalive.timeout")
-    @Test(timeout = 8000)
+    @Test
     // keepalive timeout is set at 3 secs so this should suffice to see the server disconnect
     public void testGetNonexistantPageCheckConnectionTimesOut() throws Exception {
         robot.finish();
     }
 
     @Specification("tcp.connect.and.close.to.directory.service")
-    @Test(timeout = 8000)
+    @Test
     public void testTcpConnectAndClose() throws Exception {
         robot.finish();
     }
@@ -134,130 +134,130 @@ public class HttpDirectoryServiceIT {
      */
     @Ignore
     @Specification("tcp.connect.and.wait.for.close.to.directory.service")
-    @Test(timeout = 35000)
+    @Test
     public void testTcpConnectAndWaitForClose() throws Exception {
         robot.finish();
     }
 
     @Specification("get.index.check.whole.response")
-    @Test(timeout = 8000)
+    @Test
     public void testGetIndexCheckWholeResponse() throws Exception {
         robot.finish();
     }
 
     @Specification("post.large.data")
-    @Test(timeout = 25000)
+    @Test
     public void testPostLargeData() throws Exception {
         robot.finish();
     }
 
     @Specification("get.forbidden.file.exists")
-    @Test(timeout = 5000)
+    @Test
     public void testGetForbiddenFileExists() throws Exception {
         robot.finish();
     }
 
     // /////////////////// HOST HEADER ///////////////////////
     @Specification("host/host.empty.header.with.absolute.uri")
-    @Test(timeout = 5000)
+    @Test
     public void testEmptyHostHeaderWithAbsoluteUri() throws Exception {
         robot.finish();
     }
 
     @Specification("host/host.empty.header.with.relative.uri")
-    @Test(timeout = 5000)
+    @Test
     public void testEmptyHostHeaderWithRelativeUri() throws Exception {
         robot.finish();
     }
 
     @Specification("host/host.header.invalid")
-    @Test(timeout = 5000)
+    @Test
     public void testInvalidHostHeader() throws Exception {
         robot.finish();
     }
 
     @Specification("host/host.header.not.present")
-    @Test(timeout = 5000)
+    @Test
     public void testAbsentHostHeader() throws Exception {
         robot.finish();
     }
 
     @Specification("host/host.header.port.not.set")
-    @Test(timeout = 5000)
+    @Test
     public void testAbsentPortInHostHeader() throws Exception {
         robot.finish();
     }
 
     @Specification("host/host.valid.header.with.absolute.uri")
-    @Test(timeout = 5000)
+    @Test
     public void testValidHostHeaderWithAbsoluteUri() throws Exception {
         robot.finish();
     }
 
     @Specification("host/host.no.header.with.absolute.uri")
-    @Test(timeout = 5000)
+    @Test
     public void testNoHostHeaderWithAbsoluteUri() throws Exception {
         robot.finish();
     }
 
     // ///////////////////// METHOD //////////////////////
     @Specification("method/method.connect")
-    @Test(timeout = 5000)
+    @Test
     public void testConnectMethod() throws Exception {
         robot.finish();
     }
 
     @Specification("method/method.delete")
-    @Test(timeout = 5000)
+    @Test
     public void testDeleteMethod() throws Exception {
         robot.finish();
     }
 
     @Specification("method/method.head")
-    @Test(timeout = 5000)
+    @Test
     public void testHeadMethod() throws Exception {
         robot.finish();
     }
 
     @Specification("method/method.options")
-    @Test(timeout = 5000)
+    @Test
     public void testOptionsMethod() throws Exception {
         robot.finish();
     }
 
     @Specification("method/method.bogus")
-    @Test(timeout = 5000)
+    @Test
     public void testBogusMethod() throws Exception {
         robot.finish();
     }
 
     @Specification("method/method.post")
-    @Test(timeout = 5000)
+    @Test
     public void testPostMethod() throws Exception {
         robot.finish();
     }
 
     // //////////////// URI ////////////////////////
     @Specification("uri.hex.encoded")
-    @Test(timeout = 5000)
+    @Test
     public void testHexEncodedUri() throws Exception {
         robot.finish();
     }
 
     @Specification("uri.too.long")
-    @Test(timeout = 5000)
+    @Test
     public void testUriTooLong() throws Exception {
         robot.finish();
     }
 
     @Specification("invalid.uri.with.space")
-    @Test(timeout = 5000)
+    @Test
     public void testInvalidUri() throws Exception {
         robot.finish();
     }
 
     @Specification("uri.with.params")
-    @Test(timeout = 5000)
+    @Test
     public void testUriWithParams() throws Exception {
         robot.finish();
     }
@@ -265,92 +265,92 @@ public class HttpDirectoryServiceIT {
     // ////////////////// CROSS-ORIGIN ACCESS ////////////////////
 
     @Specification("origin/same.origin.constraint.not.set")
-    @Test(timeout = 5000)
+    @Test
     public void testSameOriginConstraintNotSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/different.origin.constraint.not.set")
-    @Test(timeout = 5000)
+    @Test
     public void testDifferentOriginConstraintNotSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/missing.origin.header.constraint.not.set")
-    @Test(timeout = 5000)
+    @Test
     public void testMissingOriginHeaderConstraintNotSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/wrong.host.constraint.set")
-    @Test(timeout = 5000)
+    @Test
     public void testWrongHostConstraintSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/wrong.port.constraint.set")
-    @Test(timeout = 5000)
+    @Test
     public void testWrongPortConstraintSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/missing.origin.header.constraint.set")
-    @Test(timeout = 5000)
+    @Test
     public void testMissingOriginHeaderConstraintSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/empty.origin.header.constraint.set")
-    @Test(timeout = 5000)
+    @Test
     public void testEmptyOriginHeaderConstraintSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/empty.origin.header.constraint.not.set")
-    @Test(timeout = 5000)
+    @Test
     public void testEmptyOriginHeaderConstraintNotSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/different.origin.constraint.asterisk")
-    @Test(timeout = 5000)
+    @Test
     public void testDifferentOriginConstraintAsterisk() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/empty.origin.header.constraint.asterisk")
-    @Test(timeout = 5000)
+    @Test
     public void testEmptyOriginHeaderConstraintAsterisk() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/missing.origin.header.constraint.asterisk")
-    @Test(timeout = 5000)
+    @Test
     public void testMissingOriginHeaderConstraintAsterisk() throws Exception {
         robot.finish();
     }
 
 
     @Specification("origin/not.allowed.method")
-    @Test(timeout = 5000)
+    @Test
     public void testNotAllowedMethodConstraintSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/not.allowed.header")
-    @Test(timeout = 5000)
+    @Test
     public void testNotAllowedHeaderConstraintSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/allowed.method")
-    @Test(timeout = 5000)
+    @Test
     public void testAllowedMethodConstraintSet() throws Exception {
         robot.finish();
     }
 
     @Specification("origin/allowed.header")
-    @Test(timeout = 5000)
+    @Test
     public void testAllowedHeaderConstraintSet() throws Exception {
         robot.finish();
     }

--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpPipeliningIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpPipeliningIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.service.http.directory;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.net.URI;
@@ -86,11 +86,11 @@ public class HttpPipeliningIT {
 	};
 
 	@Rule
-	public TestRule chain = outerRule(robot).around(gateway);
+	public TestRule chain = createRuleChain(gateway, robot);
 
 	// KG-6739
 	@Specification("request1.request2.response1.response2")
-	@Test(timeout = 8000)
+	@Test
 	public void twoRequestsBeforeReponseOK() throws Exception {
 		robot.finish();
 	}

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyChunkingIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyChunkingIT.java
@@ -32,7 +32,7 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 
 import java.net.URI;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 public class HttpProxyChunkingIT {
 
@@ -56,16 +56,16 @@ public class HttpProxyChunkingIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("completeChunkedEncoding")
-    @Test(timeout = 8000)
+    @Test
     public void completeChunkedEncoding() throws Exception {
         robot.finish();
     }
 
     @Specification("http.proxy.gzip.chunked.encoding")
-    @Test(timeout = 8000)
+    @Test
     public void gzipChunkedEncoding() throws Exception {
         robot.finish();
     }

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadMethodIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadMethodIT.java
@@ -32,7 +32,7 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 
 import java.net.URI;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 public class HttpProxyHeadMethodIT {
 
@@ -56,29 +56,29 @@ public class HttpProxyHeadMethodIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
 
     @Specification( "http.proxy.head.method")
-    @Test(timeout = 5000)
+    @Test
     public void headMethod() throws Exception {
         robot.finish();
     }
 
     @Specification( "http.proxy.head.method.404")
-    @Test(timeout = 5000)
+    @Test
     public void headMethod404() throws Exception {
         robot.finish();
     }
 
     @Specification( "http.proxy.head.method.302")
-    @Test(timeout = 5000)
+    @Test
     public void headMethod302() throws Exception {
         robot.finish();
     }
 
     @Specification( "http.proxy.head.method.403")
-    @Test(timeout = 5000)
+    @Test
     public void headMethod403() throws Exception {
         robot.finish();
     }

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadersIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadersIT.java
@@ -21,27 +21,21 @@
 
 package org.kaazing.gateway.service.http.proxy;
 
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+import java.net.URI;
+
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
-
-import java.net.URI;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
 
 public class HttpProxyHeadersIT {
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
-    private final TestRule trace = new MethodExecutionTrace();
     private final K3poRule k3po = new K3poRule();
     private final GatewayRule gateway = new GatewayRule() {
         {
@@ -61,7 +55,7 @@ public class HttpProxyHeadersIT {
     };
 
     @Rule
-    public final TestRule chain = outerRule(trace).around(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Test
     @Specification("http.proxy.headers.remove.hop.by.hop")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyPersistenceIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyPersistenceIT.java
@@ -21,27 +21,21 @@
 
 package org.kaazing.gateway.service.http.proxy;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class HttpProxyPersistenceIT {
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
-    private final TestRule trace = new MethodExecutionTrace();
     private final K3poRule k3po = new K3poRule();
 
     private final GatewayRule gateway = new GatewayRule() {
@@ -63,7 +57,7 @@ public class HttpProxyPersistenceIT {
 
 
     @Rule
-    public final TestRule chain = outerRule(trace).around(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Test
     @Specification( "http.proxy.connect.persistence")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRedirectIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRedirectIT.java
@@ -32,7 +32,7 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 
 import java.net.URI;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 public class HttpProxyRedirectIT {
 
@@ -56,10 +56,10 @@ public class HttpProxyRedirectIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("http.proxy.redirect")
-    @Test(timeout = 8000)
+    @Test
     public void httpProxyRedirect() throws Exception {
         robot.finish();
     }

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRequestIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRequestIT.java
@@ -32,7 +32,7 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 
 import java.net.URI;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 public class HttpProxyRequestIT {
 
@@ -56,28 +56,28 @@ public class HttpProxyRequestIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification( "http.proxy.query.string")
-    @Test(timeout = 5000)
+    @Test
     public void queryString() throws Exception {
         robot.finish();
     }
 
     @Specification( "http.proxy.post.method")
-    @Test(timeout = 5000)
+    @Test
     public void postMethod() throws Exception {
         robot.finish();
     }
 
     @Specification( "http.proxy.status.500")
-    @Test(timeout = 5000)
+    @Test
     public void status500() throws Exception {
         robot.finish();
     }
 
     @Specification( "http.proxy.get.method.status.401")
-    @Test(timeout = 5000)
+    @Test
     public void getMethodStatus401() throws Exception {
         robot.finish();
     }

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxySecureIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxySecureIT.java
@@ -21,10 +21,9 @@
 
 package org.kaazing.gateway.service.http.proxy;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -42,15 +41,12 @@ import org.apache.log4j.BasicConfigurator;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class HttpProxySecureIT {
     private static KeyStore keyStore;
@@ -84,8 +80,6 @@ public class HttpProxySecureIT {
     }
 
     private final K3poRule k3po = new K3poRule();
-    private final TestRule trace = new MethodExecutionTrace();
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
 
     private final GatewayRule gateway = new GatewayRule() {{
 
@@ -110,7 +104,7 @@ public class HttpProxySecureIT {
     }};
 
     @Rule
-    public final TestRule chain = outerRule(trace).around(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     // Test for gateway's ssl termination
     @Specification( "http.proxy.ssl.terminated")
@@ -124,7 +118,7 @@ public class HttpProxySecureIT {
             assertEquals("<html>Hellooo</html>", line);
             assertNull(null, r.readLine());
         }
-        
+
         k3po.finish();
     }
 

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyStreamingIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyStreamingIT.java
@@ -21,8 +21,7 @@
 
 package org.kaazing.gateway.service.http.proxy;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -31,20 +30,15 @@ import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class HttpProxyStreamingIT {
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
-    private final TestRule trace = new MethodExecutionTrace();
     private final K3poRule k3po = new K3poRule();
 
     private final GatewayRule gateway = new GatewayRule() {
@@ -65,7 +59,7 @@ public class HttpProxyStreamingIT {
     };
 
     @Rule
-    public final TestRule chain = outerRule(trace).around(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Test
     @Specification("http.proxy.origin.server.response.streaming")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyUpgradeIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyUpgradeIT.java
@@ -21,27 +21,21 @@
 
 package org.kaazing.gateway.service.http.proxy;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class HttpProxyUpgradeIT {
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
-    private final TestRule trace = new MethodExecutionTrace();
     private final K3poRule k3po = new K3poRule();
 
     private final GatewayRule gateway = new GatewayRule() {
@@ -61,7 +55,7 @@ public class HttpProxyUpgradeIT {
     };
 
     @Rule
-    public final TestRule chain = outerRule(trace).around(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Specification("http.proxy.upgrade.websocket")
     @Test

--- a/test.util/pom.xml
+++ b/test.util/pom.xml
@@ -41,6 +41,11 @@
             <groupId>org.jmock</groupId>
             <artifactId>jmock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>k3po.junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
+++ b/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
@@ -58,9 +58,19 @@ public final class ITUtil {
      * @return         A TestRule which should be the only public @Rule in our robot tests
      */
     public static RuleChain createRuleChain(K3poRule robot, long timeout, TimeUnit timeUnit) {
-        TestRule timeoutRule = new DisableOnDebug(new Timeout(timeout, timeUnit));
+        TestRule timeoutRule = createTimeout(timeout, timeUnit);
         TestRule trace = new MethodExecutionTrace();
         return RuleChain.outerRule(trace).around(timeoutRule).around(robot);
+    }
+
+    /**
+     * Creates a Timeout will which is disabled when debugging and has the option to look for a stuck thread
+     * @param timeout  The maximum allowed time duration of the test
+     * @param timeUnit The unit for the timeout
+     * @return
+     */
+    public static TestRule createTimeout(long timeout, TimeUnit timeUnit) {
+        return new DisableOnDebug(Timeout.builder().withTimeout(timeout, timeUnit).withLookingForStuckThread(true).build());
     }
 
 

--- a/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
+++ b/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
+ */
+
+package org.kaazing.test.util;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.rules.K3poRule;
+
+public final class ITUtil {
+
+    /**
+     * Creates a rule (chain) out of a k3po rule and gateway rule, adding extra rules as follows:<ol>
+     * <li> a timeout rule to have tests time out if they run for more than 10 seconds
+     * <li> a rule to print console messages at the start and end of each test method and print trace level
+     * log messages on test failure.
+     * </ol>
+     * @param gateway  Rule to start up and shut down the gateway
+     * @param robot    Rule to startup and stop k3po
+     * @return         A TestRule which should be the only public @Rule in our robot tests
+     */
+    public static TestRule createRuleChain(TestRule gateway, K3poRule robot) {
+        return createRuleChain(robot, 10, SECONDS).around(gateway);
+    }
+
+    /**
+     * Creates a rule (chain) out of a k3po rule and gateway rule, adding extra rules as follows:<ol>
+     * <li> a timeout rule
+     * <li> a rule to print console messages at the start and end of each test method and print trace level
+     * log messages on test failure.
+     * </ol>
+     * @param gateway  Rule to start up and shut down the gateway
+     * @param robot    Rule to startup and stop k3po
+     * @param timeout  The maximum allowed time duration of each test (including Gateway and robot startup and shutdown)
+     * @param timeUnit The unit for the timeout
+     * @return         A TestRule which should be the only public @Rule in our robot tests
+     */
+    public static TestRule createRuleChain(TestRule gateway, K3poRule robot, long timeout, TimeUnit timeUnit) {
+        return createRuleChain(robot, timeout, timeUnit).around(gateway);
+    }
+
+    /**
+     * Creates a rule (chain) out of a k3po rule, adding extra rules as follows:<ol>
+     * <li> a timeout rule
+     * <li> a rule to print console messages at the start and end of each test method and print trace level
+     * log messages on test failure.
+     * </ol>
+     * @param robot    Rule to startup and stop k3po
+     * @param timeout  The maximum allowed time duration of each test (including Gateway and robot startup and shutdown)
+     * @param timeUnit The unit for the timeout
+     * @return         A TestRule which should be the only public @Rule in our robot tests
+     */
+    public static RuleChain createRuleChain(K3poRule robot, long timeout, TimeUnit timeUnit) {
+        TestRule timeoutRule = new DisableOnDebug(new Timeout(timeout, timeUnit));
+        TestRule trace = new MethodExecutionTrace();
+        return RuleChain.outerRule(trace).around(timeoutRule).around(robot);
+    }
+
+
+    private ITUtil() {
+
+    }
+
+}

--- a/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
+++ b/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
@@ -26,8 +26,8 @@ public final class ITUtil {
      * @param robot    Rule to startup and stop k3po
      * @return         A TestRule which should be the only public @Rule in our robot tests
      */
-    public static TestRule createRuleChain(TestRule gateway, K3poRule robot) {
-        return createRuleChain(robot, 10, SECONDS).around(gateway);
+    public static RuleChain createRuleChain(TestRule gateway, K3poRule robot) {
+        return createRuleChain(gateway, robot, 10, SECONDS);
     }
 
     /**
@@ -42,7 +42,7 @@ public final class ITUtil {
      * @param timeUnit The unit for the timeout
      * @return         A TestRule which should be the only public @Rule in our robot tests
      */
-    public static TestRule createRuleChain(TestRule gateway, K3poRule robot, long timeout, TimeUnit timeUnit) {
+    public static RuleChain createRuleChain(TestRule gateway, K3poRule robot, long timeout, TimeUnit timeUnit) {
         return createRuleChain(robot, timeout, timeUnit).around(gateway);
     }
 

--- a/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
+++ b/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
@@ -36,7 +36,7 @@ public final class ITUtil {
      * <li> a rule to print console messages at the start and end of each test method and print trace level
      * log messages on test failure.
      * </ol>
-     * @param gateway  Rule to start up and shut down the gateway
+     * @param gateway  Rule to start up and shut down the gateway (or acceptor or etc)
      * @param robot    Rule to startup and stop k3po
      * @param timeout  The maximum allowed time duration of each test (including Gateway and robot startup and shutdown)
      * @param timeUnit The unit for the timeout

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/ClientAccessPolicyIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/ClientAccessPolicyIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.http;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -43,7 +43,7 @@ public class ClientAccessPolicyIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
-            
+
                         // allow *
                         .service()
                             .accept(URI.create("http://localhost:8001/echo"))
@@ -52,7 +52,7 @@ public class ClientAccessPolicyIT {
                                 .allowOrigin("*")
                             .done()
                         .done()
-                        
+
                         // allow specific origin
                         .service()
                             .accept(URI.create("http://localhost:8002/echo"))
@@ -61,7 +61,7 @@ public class ClientAccessPolicyIT {
                                 .allowOrigin("http://localhost:8000")
                             .done()
                         .done()
-                        
+
                         // overlapping services on specific origin
                         .service()
                             .accept(URI.create("http://localhost:8003/echo2"))
@@ -77,7 +77,7 @@ public class ClientAccessPolicyIT {
                                 .allowOrigin("*")
                             .done()
                         .done()
-                        
+
                         // multiple origins allowed
                         .service()
                             .accept(URI.create("http://localhost:8004/echo"))
@@ -92,15 +92,15 @@ public class ClientAccessPolicyIT {
                                 .allowOrigin("http://localhost:8002")
                             .done()
                         .done()
-                        
+
                         // no cross-site-constraint
                         .service()
                             .accept(URI.create("http://localhost:8005/echo"))
                             .type("echo")
                         .done()
-                        
 
-// TODO: create robot test for multiple accepts 
+
+// TODO: create robot test for multiple accepts
 //                        .service()
 //                             .accept(URI.create("ws://localhost:8007/echo"))
 //                             .accept(URI.create("ws://localhost:8007/echo2"))
@@ -110,8 +110,8 @@ public class ClientAccessPolicyIT {
 //                                .allowOrigin("http://localhost:8000")
 //                            .done()
 //                        .done()
-                            
-                        
+
+
                     .done();
             // @formatter:on
             init(configuration);
@@ -119,41 +119,41 @@ public class ClientAccessPolicyIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("client.access.policy.resource.path.starred.constraints")
-    @Test(timeout = 3000)
+    @Test
     public void clientAccessPolicyStarredAllowOriginTest() throws Exception {
         robot.finish();
     }
 
     @Specification("client.access.policy.resource.path.specific.origin.constraints")
-    @Test(timeout = 3000)
+    @Test
     public void clientAccessPolicySpecificAllowOriginTest() throws Exception {
         robot.finish();
     }
 
     @Specification("client.access.policy.resource.path.overlapping.constraints")
-    @Test(timeout = 3000)
+    @Test
     public void clientAccessPolicyOverlappingAllowOriginTest() throws Exception {
         robot.finish();
     }
 
     //@Ignore("Test is not deterministic because the policies can appear in any order, but keeping it in case we make it deterministic, or get robot feature to improve")
     @Specification("client.access.policy.multiple.constraints")
-    @Test(timeout = 3000)
+    @Test
     public void clientAccessPolicyOverMultipleOriginTest() throws Exception {
         robot.finish();
     }
 
     @Specification("client.access.policy.no.constraints")
-    @Test(timeout = 3000)
+    @Test
     public void clientAccessPolicyNoConstraintTest() throws Exception {
     	robot.finish();
     }
-    
+
     @Specification("client.access.policy.test.cache")
-    @Test(timeout = 10000)
+    @Test
     public void clientAccessPolicyTestCache() throws Exception {
         robot.finish();
     }

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpAcceptorIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpAcceptorIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,6 +21,7 @@
 
 package org.kaazing.gateway.transport.http;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.jmock.lib.script.ScriptedAction.perform;
 import static org.kaazing.gateway.resource.address.ResourceAddressFactory.newResourceAddressFactory;
@@ -28,6 +29,7 @@ import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.INJE
 import static org.kaazing.gateway.transport.http.HttpMatchers.hasMethod;
 import static org.kaazing.gateway.transport.http.HttpMatchers.hasReadHeader;
 import static org.kaazing.gateway.transport.http.HttpMethod.POST;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 import java.util.Collections;
@@ -44,14 +46,15 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.kaazing.gateway.resource.address.ResourceAddress;
 import org.kaazing.gateway.resource.address.ResourceAddressFactory;
 import org.kaazing.gateway.resource.address.ResourceOptions;
 import org.kaazing.gateway.resource.address.http.HttpInjectableHeader;
 import org.kaazing.gateway.transport.BridgeServiceFactory;
 import org.kaazing.gateway.transport.TransportFactory;
-import org.kaazing.gateway.transport.test.Expectations;
 import org.kaazing.gateway.transport.nio.internal.NioSocketAcceptor;
+import org.kaazing.gateway.transport.test.Expectations;
 import org.kaazing.gateway.util.scheduler.SchedulerProvider;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
@@ -61,8 +64,10 @@ public class HttpAcceptorIT {
     private HttpAcceptor httpAcceptor;
     private ResourceAddress httpAddress;
 
+    private K3poRule robot = new K3poRule();
+
     @Rule
-    public K3poRule robot = new K3poRule();
+    public TestRule chain = createRuleChain(robot, 10, SECONDS);
 
     @Rule
     public JUnitRuleMockery mockery = new JUnitRuleMockery() { {
@@ -113,7 +118,7 @@ public class HttpAcceptorIT {
     }
 
     @Specification("should.receive.echoed.post.body.in.response.body")
-    @Test(timeout=5000)
+    @Test
     public void shouldEchoHttpPostBodyinHttpResponseBody() throws Exception {
 
         final IoHandler handler = mockery.mock(IoHandler.class);

--- a/transport/nio/src/test/java/org/kaazing/gateway/transport/tcp/TcpAcceptorIT.java
+++ b/transport/nio/src/test/java/org/kaazing/gateway/transport/tcp/TcpAcceptorIT.java
@@ -17,8 +17,8 @@
 package org.kaazing.gateway.transport.tcp;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
 import static org.kaazing.gateway.resource.address.ResourceAddressFactory.newResourceAddressFactory;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -32,9 +32,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.resource.address.ResourceAddress;
 import org.kaazing.gateway.resource.address.ResourceAddressFactory;
 import org.kaazing.gateway.transport.IoHandlerAdapter;
@@ -53,13 +51,11 @@ public class TcpAcceptorIT {
 
     private final K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/tcp/rfc793");
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
-
     private NioSocketAcceptor acceptor;
     private SchedulerProvider schedulerProvider;
-    
+
     @Rule
-    public final TestRule chain = outerRule(k3po).around(timeout);
+    public TestRule chain = createRuleChain(k3po, 5, SECONDS);
 
     @Before
     public void before() throws Exception {
@@ -68,28 +64,28 @@ public class TcpAcceptorIT {
         acceptor.setResourceAddressFactory(newResourceAddressFactory());
     }
 
-    private void bindTo8080(IoHandlerAdapter handler) {
+    private void bindTo8080(IoHandlerAdapter<IoSessionEx> handler) {
         ResourceAddressFactory addressFactory = ResourceAddressFactory.newResourceAddressFactory();
 
         Map<String, Object> acceptOptions = new HashMap<>();
-        
+
         final String connectURIString = "tcp://127.0.0.1:8080";
         final ResourceAddress bindAddress =
                 addressFactory.newResourceAddress(
                         URI.create(connectURIString),
                         acceptOptions);
-        
+
         acceptor.bind(bindAddress, handler, null);
     }
-    
+
     private void writeStringMessageToSession(String message, IoSession session) {
         ByteBuffer data = ByteBuffer.allocate(message.length());
         data.put(message.getBytes());
-        
+
         data.flip();
 
         IoBufferAllocatorEx<?> allocator = ((IoSessionEx) session).getBufferAllocator();
-        
+
         session.write(allocator.wrap(data.duplicate(), IoBufferEx.FLAG_SHARED));
     }
 
@@ -101,13 +97,13 @@ public class TcpAcceptorIT {
             acceptor.dispose();
         }
     }
-    
+
     @Test
     @Specification({
         "establish.connection/tcp.client"
         })
     public void establishConnection() throws Exception {
-        bindTo8080(new IoHandlerAdapter());
+        bindTo8080(new IoHandlerAdapter<IoSessionEx>());
         k3po.finish();
     }
 
@@ -116,13 +112,13 @@ public class TcpAcceptorIT {
         "server.sent.data/tcp.client"
         })
     public void serverSentData() throws Exception {
-        bindTo8080(new IoHandlerAdapter(){
+        bindTo8080(new IoHandlerAdapter<IoSessionEx>(){
             @Override
-            protected void doSessionOpened(IoSession session) throws Exception {
+            protected void doSessionOpened(IoSessionEx session) throws Exception {
                 writeStringMessageToSession("server data", session);
             }
         });
-        
+
         k3po.finish();
     }
 
@@ -131,7 +127,7 @@ public class TcpAcceptorIT {
         "client.sent.data/tcp.client"
         })
     public void clientSentData() throws Exception {
-        bindTo8080(new IoHandlerAdapter());
+        bindTo8080(new IoHandlerAdapter<IoSessionEx>());
         k3po.finish();
     }
 
@@ -140,13 +136,13 @@ public class TcpAcceptorIT {
         "bidirectional.data/tcp.client"
         })
     public void bidirectionalData() throws Exception {
-        bindTo8080(new IoHandlerAdapter(){
+        bindTo8080(new IoHandlerAdapter<IoSessionEx>(){
             private int counter = 1;
             private DataMatcher dataMatch = new DataMatcher("client data " + counter);
             @Override
-            protected void doMessageReceived(IoSession session, Object message) throws Exception {
+            protected void doMessageReceived(IoSessionEx session, Object message) throws Exception {
                 String decoded = new String(((IoBuffer) message).array());
-                
+
                 if (dataMatch.addFragment(decoded)) {
                     writeStringMessageToSession("server data " + counter, session);
                     counter++;
@@ -154,8 +150,8 @@ public class TcpAcceptorIT {
                 }
             }
         });
-        
-        
+
+
         k3po.finish();
     }
 
@@ -164,13 +160,13 @@ public class TcpAcceptorIT {
         "server.close/tcp.client"
         })
     public void serverClose() throws Exception {
-        bindTo8080(new IoHandlerAdapter(){
+        bindTo8080(new IoHandlerAdapter<IoSessionEx>(){
             @Override
-            protected void doSessionOpened(IoSession session) throws Exception {
-                session.close();
+            protected void doSessionOpened(IoSessionEx session) throws Exception {
+                session.close(true);
             }
         });
-        
+
         k3po.finish();
     }
 
@@ -179,7 +175,7 @@ public class TcpAcceptorIT {
         "client.close/tcp.client"
         })
     public void clientClose() throws Exception {
-        bindTo8080(new IoHandlerAdapter());
+        bindTo8080(new IoHandlerAdapter<IoSessionEx>());
         k3po.finish();
     }
 
@@ -188,23 +184,23 @@ public class TcpAcceptorIT {
         "concurrent.connections/tcp.client"
         })
     public void concurrentConnections() throws Exception {
-        bindTo8080(new IoHandlerAdapter(){
+        bindTo8080(new IoHandlerAdapter<IoSessionEx>(){
 
             @Override
-            protected void doSessionOpened(IoSession session) throws Exception {
+            protected void doSessionOpened(IoSessionEx session) throws Exception {
                 session.setAttribute("dataMatch", new DataMatcher("Hello"));
             }
-            
+
             @Override
-            protected void doMessageReceived(IoSession session, Object message) throws Exception {
+            protected void doMessageReceived(IoSessionEx session, Object message) throws Exception {
                 String decoded = new String(((IoBuffer) message).array());
                 DataMatcher dataMatch = (DataMatcher) session.getAttribute("dataMatch");
-                
+
                 if (dataMatch.addFragment(decoded)) {
                     if (dataMatch.target.equals("Hello")) {
                         dataMatch = new DataMatcher("Goodbye");
                         writeStringMessageToSession("Hello", session);
-                        
+
                     } else {
                         dataMatch = new DataMatcher("");
                         writeStringMessageToSession("Goodbye", session);

--- a/transport/sse/src/test/java/org/kaazing/gateway/transport/sse/SseCrossOriginIT.java
+++ b/transport/sse/src/test/java/org/kaazing/gateway/transport/sse/SseCrossOriginIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,26 +21,20 @@
 
 package org.kaazing.gateway.transport.sse;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class SseCrossOriginIT {
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
 
     private GatewayRule gateway = new GatewayRule() {
@@ -63,24 +57,24 @@ public class SseCrossOriginIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(timeout).around(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("sse.connect.from.bridge.and.get.data")
     @Test
     public void sseConnectFromBridgeAndGetDataThroughBroadcast() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sse.connect.and.get.data")
     @Test
     public void sseConnectAndGetDataThroughBroadcast() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sse.connect.and.get.data.with.newline")
     @Test
     public void sseCheckNewLineThroughBroadcast() throws Exception {
         robot.finish();
     }
-    
+
 }

--- a/transport/sse/src/test/java/org/kaazing/gateway/transport/sse/SseSameOriginIT.java
+++ b/transport/sse/src/test/java/org/kaazing/gateway/transport/sse/SseSameOriginIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,26 +21,20 @@
 
 package org.kaazing.gateway.transport.sse;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class SseSameOriginIT {
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private K3poRule robot = new K3poRule();
 
     private GatewayRule gateway = new GatewayRule() {
@@ -60,7 +54,7 @@ public class SseSameOriginIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("sse.connect.via.dotnet.emulated")
     @Test

--- a/transport/ssl/src/test/java/org/kaazing/gateway/transport/ssl/OcspIT.java
+++ b/transport/ssl/src/test/java/org/kaazing/gateway/transport/ssl/OcspIT.java
@@ -21,9 +21,10 @@
 
 package org.kaazing.gateway.transport.ssl;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -44,6 +45,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.log4j.BasicConfigurator;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -111,7 +113,7 @@ public class OcspIT {
     };
 
     @Rule
-    public final TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot, 20, SECONDS);
 
     /*
      * client <---> Gateway(localhost:9558) <---> robot/ocsp responder (localhost:8192)
@@ -119,7 +121,9 @@ public class OcspIT {
      * goes through
      */
     @Specification("ocspGoodCertificate")
-    @Test(timeout = 17000)
+    @Test
+    @Ignore // issue #267: robot response is rejected by jdk 1.8.0_51 with exception
+            // java.security.cert.CertPathValidatorException: Response is unreliable: its validity interval is out-of-date
     public void testGoodCertificate() throws Exception {
         KeyStore clientStore = KeyStore.getInstance("JCEKS");
         InputStream cis = getClass().getClassLoader().getResourceAsStream("ocsp.db");

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WseHandshakeIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WseHandshakeIT.java
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wseb;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.net.URI;
@@ -60,22 +60,22 @@ public class WseHandshakeIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("wse.handshake.send.receive.3_5")
-    @Test(timeout = 5000)
+    @Test
     public void testHandshakeSendReceiveVersion3_5() throws Exception {
         robot.finish();
     }
 
     @Specification("wse.handshake.send.receive")
-    @Test(timeout = 5000)
+    @Test
     public void testHandshakeSendReceive() throws Exception {
         robot.finish();
     }
 
     @Specification("closeDownstreamShouldUnbindUpstream")
-    @Test(timeout = 5000)
+    @Test
     public void closeDownstreamShouldUnbindUpstream() throws Exception {
         robot.finish();
     }

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebAsyncAuthIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebAsyncAuthIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wseb;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -68,10 +68,10 @@ public class WsebAsyncAuthIT {
     };
 
 	@Rule
-	public TestRule chain = outerRule(robot).around(gateway);
+	public TestRule chain = createRuleChain(gateway, robot);
 
 	@Specification("asyncAuthWsebSuccess")
-    @Test(timeout = 5000)
+    @Test
 	public void asyncAuthWsebSuccess() throws Exception {
 		robot.finish();
 	}

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebAuthIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebAuthIT.java
@@ -21,44 +21,32 @@
 
 package org.kaazing.gateway.transport.wseb;
 
-import org.kaazing.gateway.server.test.GatewayRule;
-import org.kaazing.gateway.server.test.config.GatewayConfiguration;
-import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.kaazing.k3po.junit.annotation.Specification;
-import org.kaazing.k3po.junit.rules.K3poRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.Map;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
-import java.net.URI;
-import java.security.Principal;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import static org.junit.rules.RuleChain.outerRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
 
 public class WsebAuthIT {
 
     private final K3poRule robot = new K3poRule();
 
-    @BeforeClass
-    public static void init() throws Exception {
-        PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-    }
-
-    @Rule
-    public TestRule timeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
-    
-    public GatewayRule gateway = new GatewayRule() {
+    private GatewayRule gateway = new GatewayRule() {
         {
             GatewayConfiguration configuration = new GatewayConfigurationBuilder()
                 .service()
@@ -90,7 +78,7 @@ public class WsebAuthIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Before
     public void initLoginModule() {

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebCrossOriginIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebCrossOriginIT.java
@@ -21,21 +21,16 @@
 
 package org.kaazing.gateway.transport.wseb;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
-
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebCrossOriginIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebCrossOriginIT.java
@@ -22,7 +22,7 @@
 package org.kaazing.gateway.transport.wseb;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -61,10 +61,8 @@ public class WsebCrossOriginIT {
         }
     };
 
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
-
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Test
     @Specification("wse.down.stream.cross.origin.request")

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebInactivityTimeoutIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebInactivityTimeoutIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,17 +21,14 @@
 
 package org.kaazing.gateway.transport.wseb;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -41,7 +38,6 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class WsebInactivityTimeoutIT {
 
     private final K3poRule k3po = new K3poRule();
-    private final TestRule timeout = new DisableOnDebug(new Timeout(15, SECONDS));
 
     private final GatewayRule gateway = new GatewayRule() {
         {
@@ -62,7 +58,7 @@ public class WsebInactivityTimeoutIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Specification("echo.inactivity.timeout.should.close")
     @Test

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebProxyTestIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebProxyTestIT.java
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wseb;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.FileInputStream;
 import java.net.URI;
@@ -47,7 +47,7 @@ public class WsebProxyTestIT {
     private GatewayRule gateway = new GatewayRule() {
         {
             try {
-                keyStore = KeyStore.getInstance("JCEKS");              
+                keyStore = KeyStore.getInstance("JCEKS");
                 FileInputStream in = new FileInputStream("target/truststore/keystore.db");
                 keyStore.load(in, password);
             } catch (Exception e) {
@@ -87,45 +87,45 @@ public class WsebProxyTestIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
-    
+
     @Specification("VerifyProxyModeFallbackFromInsecureToSecureInWseb")
-    @Test(timeout = 1500)
+    @Test
     @Ignore("KG-11239")
     public void VerifyProxyModeFallbackFromInsecureToSecureInWseb() throws Exception {
         robot.finish();
     }
-   
+
     @Specification("BluecoatHeaderDetectionAndFallbackToProxyMode")
-    @Test(timeout = 1500)
+    @Test
     @Ignore("KG-11239")
     public void BluecoatHeaderDetectionAndFallbackToProxyMode() throws Exception {
         robot.finish();
     }
 
     @Specification("wsebLongPolling")
-    @Test(timeout = 7500)
+    @Test
     public void wsebLongPolling() throws Exception {
         robot.finish();
     }
 
     @Specification("wsebLongPollingWithSequenceNumber")
-    @Test(timeout = 7500)
+    @Test
     public void wsebLongPollingWithSequenceNumber() throws Exception {
         robot.finish();
     }
 
     @Specification("wsebSecureLongPolling")
-    @Test(timeout = 7500)
+    @Test
     public void wsebSecureLongPolling() throws Exception {
         robot.finish();
     }
 
     @Specification("wsebLongPollingByHeader")
-    @Test(timeout = 7500)
+    @Test
     public void wsebLongPollingTriggeredByHeader() throws Exception {
         robot.finish();
     }
-       
+
 }

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebSubjectPropagationIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebSubjectPropagationIT.java
@@ -4,18 +4,17 @@
 
 package org.kaazing.gateway.transport.wseb;
 
-import static org.kaazing.gateway.util.Utils.asByteBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.gateway.util.Utils.asByteBuffer;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.IOException;
 import java.net.URI;
 import java.security.Principal;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
@@ -26,20 +25,16 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.kaazing.gateway.transport.IoHandlerAdapter;
-import org.kaazing.gateway.service.ServiceContext;
-import org.kaazing.gateway.service.Service;
 import org.kaazing.gateway.server.Gateway;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.service.Service;
+import org.kaazing.gateway.service.ServiceContext;
+import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.kaazing.mina.core.buffer.IoBufferEx;
@@ -51,18 +46,6 @@ import org.kaazing.mina.core.session.IoSessionEx;
 public class WsebSubjectPropagationIT {
 
     private K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-    @BeforeClass
-    public static void init()
-            throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
-
-    @Rule
-    public TestRule timeout = new DisableOnDebug(new Timeout(10, TimeUnit.SECONDS));
 
     public GatewayRule gateway = new GatewayRule() {
         {
@@ -120,7 +103,7 @@ public class WsebSubjectPropagationIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("shouldPropagateSubjectBasic")
     @Test

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebTransportIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebTransportIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,26 +22,21 @@
 package org.kaazing.gateway.transport.wseb;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class WsebTransportIT {
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
 
     private final GatewayRule gateway = new GatewayRule() {
@@ -69,9 +64,8 @@ public class WsebTransportIT {
         }
     };
 
-
     @Rule
-    public TestRule chain = outerRule(trace).around(timeout).around(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot, 10, SECONDS);
 
     @Specification("echo.aligned.downstream")
     @Test

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebTransportIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebTransportIT.java
@@ -21,7 +21,6 @@
 
 package org.kaazing.gateway.transport.wseb;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
@@ -65,7 +64,7 @@ public class WsebTransportIT {
     };
 
     @Rule
-    public TestRule chain = createRuleChain(gateway, robot, 10, SECONDS);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("echo.aligned.downstream")
     @Test

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebTransportIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebTransportIT.java
@@ -59,7 +59,7 @@ public class WsebTransportIT {
                         .done()
                     .done();
             // @formatter:on
-            init(configuration, "log4j-trace.properties");
+            init(configuration);
         }
     };
 

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/connector/WsebConnectorIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/connector/WsebConnectorIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,14 +21,11 @@
 
 package org.kaazing.gateway.transport.wseb.connector;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.gateway.transport.wseb.test.WsebConnectorRule;
 import org.kaazing.k3po.junit.annotation.Specification;
@@ -39,20 +36,19 @@ public class WsebConnectorIT {
 
     private final K3poRule robot = new K3poRule();
     private final WsebConnectorRule connector = new WsebConnectorRule();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
 
     @Rule
-    public TestRule chain = outerRule(connector).around(robot).around(timeout);
+    public TestRule chain = createRuleChain(connector, robot);
 
     @Specification("shouldReplyPongToPing")
     // TODO: remove this once we enable spec test ControlIT
     @Test
     public void shouldReplyPongToPing() throws Exception {
         connector.connect("wse://localhost:8011/path", null, new IoHandlerAdapter<IoSessionEx>() {
-            
+
         });
         //future.getSession().write(new WsebBufferAllocator(SimpleBufferAllocator.BUFFER_ALLOCATOR).wrap(Utils.asByteBuffer("Message from connector")));
         robot.finish();
     }
-    
+
 }

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/extensions/test/WsebExtensionWithFilterIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/extensions/test/WsebExtensionWithFilterIT.java
@@ -21,9 +21,8 @@
 
 package org.kaazing.gateway.transport.wseb.extensions.test;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
 import static org.kaazing.gateway.util.Utils.asByteArray;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.ProtocolException;
 import java.net.URI;
@@ -34,9 +33,7 @@ import org.apache.mina.core.session.IoSession;
 import org.apache.mina.core.write.WriteRequest;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.resource.address.ws.WsResourceAddress;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
@@ -49,12 +46,9 @@ import org.kaazing.gateway.transport.ws.extension.WebSocketExtensionFactorySpi;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.kaazing.mina.core.session.IoSessionEx;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class WsebExtensionWithFilterIT {
 
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
 
     private GatewayRule gateway = new GatewayRule() {
@@ -73,7 +67,7 @@ public class WsebExtensionWithFilterIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("should.transform.messages")
     @Test

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/handshake/FlashWseEmulatedResponseOnChromeTestIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/handshake/FlashWseEmulatedResponseOnChromeTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wseb.handshake;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -63,7 +63,7 @@ public class FlashWseEmulatedResponseOnChromeTestIT {
 	                        .allowOrigin("*")
 	                    .done()
 	                .done()
-				    .security()		
+				    .security()
 					// TODO: keyStoreFile and keyStorePasswordFile are
 					// deprecated method which will be removed eventually(4.0.1
 					// time frame) and keyStore + keyStorePassword should be
@@ -76,20 +76,20 @@ public class FlashWseEmulatedResponseOnChromeTestIT {
 				        .realm()
 				          	.name("demo")
 				          	.description("Kaazing WebSocket Gateway Demo")
-				          	.httpChallengeScheme("Basic")	
+				          	.httpChallengeScheme("Basic")
 				        .done()
-			        .done()			            
-				   .done(); 
+			        .done()
+				   .done();
 			init(configuration);
 
 		}
 	};
 
 	@Rule
-	public TestRule chain = outerRule(robot).around(gateway);
+	public TestRule chain = createRuleChain(gateway, robot);
 
 	@Specification("connectToAEchoServiceUsingFlashWseAndGetAnEmulatedWrappedResponse")
-	@Test(timeout = 1500)
+	@Test
 	public void connectToAEchoServiceUsingFlashWseAndGetAnEmulatedWrappedResponse()
 			throws Exception {
 		robot.finish();

--- a/transport/wseb/src/test/java/org/kaazing/specification/wse/connector/CloseIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/specification/wse/connector/CloseIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,15 +21,12 @@
 
 package org.kaazing.specification.wse.connector;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.gateway.transport.wseb.test.WsebConnectorRule;
 import org.kaazing.k3po.junit.annotation.Specification;
@@ -41,22 +38,21 @@ public class CloseIT {
     private final K3poRule robot = new K3poRule()
     .setScriptRoot("org/kaazing/specification/wse/closing");
     private final WsebConnectorRule connector = new WsebConnectorRule();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
 
     @Rule
-    public TestRule chain = outerRule(connector).around(robot).around(timeout);
-    
-    
-    
+    public TestRule chain = createRuleChain(connector, robot);
+
+
+
     @Specification("client.send.close/response")
     @Test
     @Ignore // Issue #188: WsebConnector should set Content-Type header on the upstream request
     public void shouldEchoClientCloseFrame() throws Exception {
         connector.connect("wse://localhost:8080//path", null, new IoHandlerAdapter<IoSessionEx>() {
-            
+
         });
-        
+
         robot.finish();
     }
-    
+
 }

--- a/transport/wseb/src/test/java/org/kaazing/specification/wse/connector/ControlIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/specification/wse/connector/ControlIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,14 +22,12 @@
 package org.kaazing.specification.wse.connector;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.gateway.transport.wseb.test.WsebConnectorRule;
 import org.kaazing.k3po.junit.annotation.Specification;
@@ -41,10 +39,9 @@ public class ControlIT {
     private final K3poRule robot = new K3poRule()
     .setScriptRoot("org/kaazing/specification/wse/control");
     private final WsebConnectorRule connector = new WsebConnectorRule();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
 
     @Rule
-    public TestRule chain = outerRule(connector).around(robot).around(timeout);
+    public TestRule chain = createRuleChain(robot, 10, SECONDS);
 
     @Specification("server.send.ping/response")
     @Test
@@ -52,7 +49,7 @@ public class ControlIT {
     // TODO: when this test is enabled, remove WsebConnectorIT.shouldReplyPongToPing
     public void serverSendPing() throws Exception {
         connector.connect("wse://localhost:8080/path?query", null, new IoHandlerAdapter<IoSessionEx>() {
-            
+
         });
         robot.finish();
     }

--- a/transport/wsn/pom.xml
+++ b/transport/wsn/pom.xml
@@ -109,6 +109,12 @@
         </dependency>
         <dependency>
             <groupId>org.kaazing</groupId>
+            <artifactId>test.util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
             <artifactId>k3po.junit</artifactId>
         </dependency>
         <dependency>

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/HttpBindingsIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/HttpBindingsIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,12 +21,10 @@
 
 package org.kaazing.gateway.transport.wsn;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -39,15 +37,6 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class HttpBindingsIT {
 
     private K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-    @BeforeClass
-    public static void init()
-            throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
 
     public GatewayRule gateway = new GatewayRule() {
         {
@@ -75,10 +64,10 @@ public class HttpBindingsIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("connectingOnService1ShouldNotGetAccessToService2")
-    @Test(timeout = 8 * 1000) //4s should suffice (twice the expected 2 second timeout), but leave a margin just in case
+    @Test
     // Test case for KG-10516
     public void connectingOnService1ShouldNotGetAccessToService2() throws Exception {
         robot.finish();

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/HttpOriginSecurityFilterIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/HttpOriginSecurityFilterIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -59,10 +59,10 @@ public class HttpOriginSecurityFilterIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("test.privileged.origin.request.connect")
-    @Test(timeout = 5000)
+    @Test
     public void testPrivilegedOriginRequest() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/OpeningHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/OpeningHandshakeIT.java
@@ -4,37 +4,29 @@
 
 package org.kaazing.gateway.transport.wsn;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
 import org.apache.mina.core.future.ConnectFuture;
 import org.apache.mina.core.service.IoHandler;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.kaazing.mina.core.session.IoSessionEx;
-import org.kaazing.test.util.MethodExecutionTrace;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.rules.RuleChain.outerRule;
 
 
 public class OpeningHandshakeIT {
 
     private final K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/ws/opening");
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
-
     private final WsnConnectorRule connectorRule = new WsnConnectorRule();
 
-    public final TestRule testExecutionTrace = new MethodExecutionTrace();
-
     @Rule
-    public final TestRule chain = outerRule(testExecutionTrace).around(connectorRule).around(k3po).around(timeout);
+    public TestRule chain = createRuleChain(connectorRule, k3po);
 
     @Test
     @Specification({"response.header.sec.websocket.accept.missing/handshake.response"})

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/SslEncryptionIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/SslEncryptionIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -61,16 +61,16 @@ public class SslEncryptionIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("ssl.encryption.disabled")
-    @Test(timeout = 1500)
+    @Test
     public void sslEncryptionDisabled() throws Exception {
         robot.finish();
     }
 
     @Specification("ssl.encryption.connect.option.disabled")
-    @Test(timeout = 1500)
+    @Test
     public void sslEncryptionConnectOptionDisabled() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/UnresolvableHostnameIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/UnresolvableHostnameIT.java
@@ -21,12 +21,10 @@
 
 package org.kaazing.gateway.transport.wsn;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -39,15 +37,6 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class UnresolvableHostnameIT {
 
     private K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-    @BeforeClass
-    public static void init()
-            throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
 
     public GatewayRule gateway = new GatewayRule() {
         {
@@ -63,10 +52,10 @@ public class UnresolvableHostnameIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("connectingToUnresolvableHostnameWithBind")
-    @Test(timeout = 2000)
+    @Test
     // Test case for KG-5301
     public void connectingOnService1ShouldNotGetAccessToService2() throws Exception {
         robot.finish();

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WebSocketBindTestIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WebSocketBindTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -58,47 +58,47 @@ public class WebSocketBindTestIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("canConnectUsingNormalWebSocketURI")
-    @Test(timeout = 8000)
+    @Test
     public void canConnectUsingNormalWebSocketURI() throws Exception {
         robot.finish();
     }
 
     @Specification("canConnectUsingNormalWebSocketURIWithExtraSlashAfterEcho")
-    @Test(timeout = 8000)
+    @Test
     public void canConnectUsingNormalWebSocketURIWithExtraSlash() throws Exception {
         robot.finish();
     }
 
     @Specification("canConnectUsingNormalWebSocketURIWithoutLoadBalancing")
-    @Test(timeout = 8000)
+    @Test
     //TODO:KG-8523
     public void canConnectUsingNormalWebSocketURIWithoutLoadBalancing() throws Exception {
         robot.finish();
     }
 
     @Specification("cannotConnectUsingWebSocketURIWithExtraPathElement")
-    @Test(timeout = 1500)
+    @Test
     public void cannotConnectUsingWebSocketURIWithExtraPathElement() throws Exception {
         robot.finish();
     }
 
     @Specification("canConnectUsingPathlessWebSocketURI")
-    @Test(timeout = 8000)
+    @Test
     public void canConnectUsingPathlessWebSocketURI() throws Exception {
         robot.finish();
     }
 
     @Specification("canConnectUsingPathlessWebSocketURIWithExtraSlash")
-    @Test(timeout = 8000)
+    @Test
     public void canConnectUsingPathlessWebSocketURIWithExtraSlash() throws Exception {
         robot.finish();
     }
 
     @Specification("cannotConnectToPathlessWebSocketURIWithExtraPathElement")
-    @Test(timeout = 8000)
+    @Test
     public void cannotConnectToPathlessWebSocketURIWithExtraPathElement() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsBinaryContinuationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsBinaryContinuationIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -57,10 +57,10 @@ public class WsBinaryContinuationIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("basicBinaryContinuation")
-    @Test(timeout = 5000)
+    @Test
     public void basicBinaryContinuation() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsTextContinuationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsTextContinuationIT.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+If * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,8 @@
 
 package org.kaazing.gateway.transport.wsn;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -57,7 +58,7 @@ public class WsTextContinuationIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot, 20, SECONDS);
 
     @Specification("basicTextContinuation")
     @Test(timeout = 5000)

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnIPv6IT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnIPv6IT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,14 +21,12 @@
 
 package org.kaazing.gateway.transport.wsn;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.InetAddress;
 import java.net.URI;
 
-import org.apache.log4j.PropertyConfigurator;
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,15 +41,6 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class WsnIPv6IT {
 
     private K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-
-    @BeforeClass
-    public static void init() throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
 
     public GatewayRule gateway = new GatewayRule() {
         {
@@ -71,7 +60,7 @@ public class WsnIPv6IT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("echoTextFrameInIPv6Service")
     @Test
@@ -81,5 +70,5 @@ public class WsnIPv6IT {
 
         robot.finish();
     }
-    
+
 }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnInactivityTimeoutIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnInactivityTimeoutIT.java
@@ -26,8 +26,6 @@ import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -40,15 +38,6 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class WsnInactivityTimeoutIT {
 
     private final K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-    @BeforeClass
-    public static void init()
-            throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
 
     public GatewayRule gateway = new GatewayRule() {
         {

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnInactivityTimeoutIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnInactivityTimeoutIT.java
@@ -22,7 +22,7 @@
 package org.kaazing.gateway.transport.wsn;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -30,21 +30,15 @@ import org.apache.log4j.PropertyConfigurator;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class WsnInactivityTimeoutIT {
 
-    private TestRule trace = new MethodExecutionTrace();
-    //4s should suffice (twice the expected 2 second timeout), but leave a margin just in case:
-    private TestRule timeout = new DisableOnDebug(new Timeout(8, SECONDS));
     private final K3poRule robot = new K3poRule();
 
     private static final boolean ENABLE_DIAGNOSTICS = false;
@@ -83,10 +77,11 @@ public class WsnInactivityTimeoutIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    //4s should suffice (twice the expected 2 second timeout), but leave a margin just in case:
+    public TestRule chain = createRuleChain(gateway, robot, 8, SECONDS);
 
     @Specification("shouldInactivityTimeout")
-    @Test(timeout = 8 * 1000) //2s should suffice (twice the expected 2 second timeout), but leave a margin just in case
+    @Test
     public void shouldInactivityTimeout() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnSubjectPropagationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnSubjectPropagationIT.java
@@ -26,8 +26,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -50,15 +48,6 @@ import org.kaazing.mina.core.session.IoSessionEx;
 public class WsnSubjectPropagationIT {
 
     private final K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-    @BeforeClass
-    public static void init()
-            throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
 
     public GatewayRule gateway = new GatewayRule() {
         {

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnSubjectPropagationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnSubjectPropagationIT.java
@@ -5,11 +5,11 @@
 package org.kaazing.gateway.transport.wsn;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.kaazing.gateway.util.Utils.asByteBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.gateway.util.Utils.asByteBuffer;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.IOException;
 import java.net.URI;
@@ -30,21 +30,18 @@ import org.apache.log4j.PropertyConfigurator;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.kaazing.gateway.transport.IoHandlerAdapter;
-import org.kaazing.gateway.service.ServiceContext;
-import org.kaazing.gateway.service.Service;
 import org.kaazing.gateway.server.Gateway;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
-import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.gateway.service.Service;
+import org.kaazing.gateway.service.ServiceContext;
+import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
 import org.kaazing.mina.core.buffer.IoBufferEx;
 import org.kaazing.mina.core.session.IoSessionEx;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 /**
  * This test verifies that the authenticated Subject is made available on the WsnSession, including when
@@ -52,8 +49,6 @@ import org.kaazing.test.util.MethodExecutionTrace;
  */
 public class WsnSubjectPropagationIT {
 
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
     private final K3poRule robot = new K3poRule();
 
     private static final boolean ENABLE_DIAGNOSTICS = false;
@@ -72,7 +67,7 @@ public class WsnSubjectPropagationIT {
                     .service()
                         .accept(URI.create("ws://localhost:8001/subject"))
                         .type("class:" + SubjectService.class.getName())
-                    // Websocket level  authentication with revalidate
+                    // Websocket level  authentication with revalidateif
                     .realmName("demo")
                     .crossOrigin()
                         .allowOrigin("*")
@@ -99,7 +94,7 @@ public class WsnSubjectPropagationIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot, 20, SECONDS);
 
     @Specification("shouldPropagateSubject")
     @Test

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/ApplicationTokenIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/ApplicationTokenIT.java
@@ -21,27 +21,21 @@
 
 package org.kaazing.gateway.transport.wsn.auth;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class ApplicationTokenIT {
 
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
 
     public GatewayRule gateway = new GatewayRule() {
@@ -74,10 +68,10 @@ public class ApplicationTokenIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("should.get.403.response.when.trying.native.connect")
-    @Test(timeout = 8 * 1000)
+    @Test
     public void connectingFromRFC6455NonKaazingClientShouldFail() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/AsyncBasicLoginModuleTestIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/AsyncBasicLoginModuleTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.auth;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -67,16 +67,16 @@ public class AsyncBasicLoginModuleTestIT {
     };
 
 	@Rule
-	public TestRule chain = outerRule(robot).around(gateway);
+	public TestRule chain = createRuleChain(gateway, robot);
 
 	@Specification("asyncBasicLoginModuleSuccess")
-	@Test(timeout = 5000)
+	@Test
 	public void asyncBasicLoginModuleSuccess() throws Exception {
 		robot.finish();
 	}
 
     @Specification("asyncBasicLoginModuleFailure")
-    @Test(timeout = 5000)
+    @Test
     public void asyncBasicLoginModuleFailure() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/BasicLoginModuleTestIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/BasicLoginModuleTestIT.java
@@ -21,16 +21,13 @@
 
 package org.kaazing.gateway.transport.wsn.auth;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -38,8 +35,6 @@ import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
 public class BasicLoginModuleTestIT {
-
-    private TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
 
     private K3poRule robot = new K3poRule();
 
@@ -72,7 +67,7 @@ public class BasicLoginModuleTestIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
 	@Specification("basicLoginModuleFirstRequestSuccess")
 	@Test

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/EchoServiceAuthorizationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/EchoServiceAuthorizationIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.auth;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -43,7 +43,7 @@ public class EchoServiceAuthorizationIT {
     private static final String ECHO_SERVICE_ACCEPT = "ws://localhost:8000/echo";
     private static final String APP_BASIC_AUTH_ECHO_SERVICE_ACCEPT = "ws://localhost:8008/echo";
     private static final String APP_TOKEN_AUTH_ECHO_SERVICE_ACCEPT = "ws://localhost:8009/echo";
-    
+
     private final K3poRule robot = new K3poRule();
 
     private final GatewayRule gateway = new GatewayRule() {
@@ -122,29 +122,29 @@ public class EchoServiceAuthorizationIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     // //////////////////////// AUTHORIZATION //////////////////
     @Specification("app.basic.authorized.access.with.valid.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testAuthorizedWithValidCredentials() throws Exception {
         robot.finish();
     }
 
     @Specification("app.basic.authorized.access.with.invalid.credentials")
-    @Test(timeout = 5000)
+    @Test
     public void testAppBasicAuthorizedWithInvalidCredentials() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("app.token.three.attempts.failure")
-    @Test(timeout = 5000)
+    @Test
     public void testAppTokenThreeAttemptsThenFailure() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("app.token.success")
-    @Test(timeout = 5000)
+    @Test
     public void testAppTokenSuccess() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/MismatchedAuthSchemeSendsExtended400AuthTestIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/auth/MismatchedAuthSchemeSendsExtended400AuthTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,8 @@
 
 package org.kaazing.gateway.transport.wsn.auth;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.FileInputStream;
 import java.net.URI;
@@ -45,51 +46,51 @@ public class MismatchedAuthSchemeSendsExtended400AuthTestIT {
 	public GatewayRule gateway = new GatewayRule() {
 		{
 			try {
-				KeyStore keyStore = KeyStore.getInstance("JCEKS");				
+				KeyStore keyStore = KeyStore.getInstance("JCEKS");
 				FileInputStream in = new FileInputStream(
 						"target/truststore/keystore.db");
 				keyStore.load(in, password);
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}
-             
+
 			GatewayConfiguration configuration = new GatewayConfigurationBuilder()
 					.service()
 			            .accept(URI.create("ws://localhost:8001/echoAuth"))
 			            .type("echo")
-			            .realmName("demo")  
+			            .realmName("demo")
 			            .authorization()
 			                .requireRole("AUTHORIZED")
 			            .done()
 			        .done()
-			        .security()		           
+			        .security()
 			            .keyStore(keyStore)
 			             .realm()
 			                 .name("demo")
 			          		 .httpChallengeScheme("Application Token")
-			          		 .loginModule()			          		
+			          		 .loginModule()
 			          		 .type("class:org.kaazing.gateway.security.auth.YesLoginModule")
 			          		     .success("requisite")
 			          			 .option("roles", "AUTHORIZED, ADMINISTRATOR")
 			          		  .done()
 			            .done()
-			         .done()			            
-			        .done(); 
+			         .done()
+			        .done();
 			init(configuration);
 		}
 	};
 
 	@Rule
-	public TestRule chain = outerRule(robot).around(gateway);
+	public TestRule chain = createRuleChain(gateway, robot, 1500, MILLISECONDS);
 
 	@Specification("shouldFailDueToMismatchedAuthSchemes")
-	@Test(timeout = 1500)
+	@Test
 	public void shouldFailDueToMismatchedAuthSchemes() throws Exception {
 		robot.finish();
 	}
 
 	@Specification("shouldNotFailDueToMatchingAuthScheme")
-	@Test(timeout = 1500)
+	@Test
 	public void shouldNotFailDueToMatchingAuthScheme() throws Exception {
 		robot.finish();
 	}

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/closehandling/CloseHandlingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/closehandling/CloseHandlingIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,8 @@
 
 package org.kaazing.gateway.transport.wsn.autobahn.closehandling;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -52,254 +53,254 @@ public class CloseHandlingIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
- 
+    public TestRule chain = createRuleChain(gateway, robot, 1500, MILLISECONDS);
+
     @Specification("sendTextMessageThenCloseFrame")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageThenCloseFrame() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTwoCloseFrames")
-    @Test(timeout = 1500)
+    @Test
     public void sendTwoCloseFrames() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendPingAfterCloseMessage")
-    @Test(timeout = 1500)
+    @Test
     public void sendPingAfterCloseMessage() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageAfterCloseFrame")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageAfterCloseFrame() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithPayloadLengthZero")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseFrameWithPayloadLengthZero() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithCloseCode")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseFrameWithCloseCode() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithCloseCodeAndCloseReason")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseFrameWithCloseCodeAndCloseReason() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithCloseCodeAndCloseReasonOfMaximumLength")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseFrameWithCloseCodeAndCloseReasonOfMaximumLength() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1000")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1000() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1001")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1001() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1002")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1002() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1003")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1003() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1007")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1007() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1008")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1008() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1009")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1009() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1010")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1010() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode1011")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode1011() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithValidCloseCode3000")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode3000() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseWithValidCloseCode3999")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode3999() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseWithValidCloseCode4000")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode4000() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseWithValidCloseCode4999")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithValidCloseCode4999() throws Exception {
         robot.finish();
     }
 
     @Specification("sendCloseWithInvalidCloseCodeZero")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithInvalidCloseCodeZero() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendMessageFragment1FollowedByCloseThenFragment")
-    @Test(timeout = 1500)
+    @Test
     public void sendMessageFragment1FollowedByCloseThenFragment() throws Exception {
         robot.finish();
     }
- 
+
     @Specification("sendCloseWithInvalidCloseCode1005")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseWithInvalidCloseCode1005() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithPayloadLength1")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithPayloadLength1() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendCloseFrameWithInvalidUTF8Payload")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidUTF8Payload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode999")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode999() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode1004")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode1004() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode1006")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode1006() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode1012")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode1012() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode1013")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode1013() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode1014")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode1014() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode1015")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode1015() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode1016")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode1016() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode1100")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode1100() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode2000")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode2000() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithInvalidCloseCode2999")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithInvalidCloseCode2999() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendCloseFrameWithCloseCodeAndCloseReasonWhichIsTooLong")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseFrameWithCloseCodeAndCloseReasonWhichIsTooLong() throws Exception {
         robot.finish();
     }
 
     @Ignore("KG-12377")
     @Specification("send256KMessageFollowedByCloseThenPing")
-    @Test(timeout = 1500)
+    @Test
     public void	send256KMessageFollowedByCloseThenPing() throws Exception {
         robot.finish();
     }
 
     // behavior is undefined by spec but appears reasonable
     @Specification("sendCloseWithCloseCode5000")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseWithCloseCode5000() throws Exception {
         robot.finish();
     }
-    
+
     // behavior is undefined by spec but appears reasonable
     @Specification("sendCloseWithCloseCode65535")
-    @Test(timeout = 1500)
+    @Test
     public void	sendCloseWithCloseCode65535() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/fragmentation/FragmentationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/fragmentation/FragmentationIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.autobahn.fragmentation;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -51,124 +51,124 @@ public class FragmentationIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("sendContinuationFrameWithFINEqualsFalseWhenThereIsNothingToContinueThenTextMessageInTwoFragmentsTwice")
-    @Test(timeout = 6500)
+    @Test
     public void sendContinuationFrameWithFINEqualsFalseWhenThereIsNothingToContinueThenTextMessageInTwoFragmentsTwice() throws Exception {
         robot.finish();
     }
-   
+
     @Specification("sendContinuationFrameWithFINEqualsTrueWhenThereIsNothingToContinueThenTextMessageInTwoFragmentsTwice")
-    @Test(timeout = 6500)
+    @Test
     public void sendContinuationFrameWithFINEqualsTrueWhenThereIsNothingToContinueThenTextMessageInTwoFragmentsTwice() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendPingInTwoFragments")
-    @Test(timeout = 6500)
+    @Test
     public void sendPingInTwoFragments() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendPongInTwoFragments")
-    @Test(timeout = 6500)
+    @Test
     public void sendPongInTwoFragments() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageAfterContinuationframeWithFINEqualsFalseWhenThereIsNothingToContinueInFrameWiseChops")
-    @Test(timeout = 6500)
+    @Test
     public void sendTextMessageAfterContinuationframeWithFINEqualsFalseWhenThereIsNothingToContinueInFrameWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageAfterContinuationframeWithFINEqualsFalseWhenThereIsNothingToContinueSentInOctetWiseChops")
-    @Test(timeout = 6500)
+    @Test
     public void sendTextMessageAfterContinuationframeWithFINEqualsFalseWhenThereIsNothingToContinueSentInOctetWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageAfterContinuationFrameWithFINEqualsFalseWhenThereIsNothingToContinueSentInOneChop")
-    @Test(timeout = 6500)
+    @Test
     public void sendTextMessageAfterContinuationFrameWithFINEqualsFalseWhenThereIsNothingToContinueSentInOneChop() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageAfterContinuationFrameWithFINEqualsTrueWhenNothingToContinueSentInFrameWiseChops")
-    @Test(timeout = 6500)
+    @Test
     public void sendTextMessageAfterContinuationFrameWithFINEqualsTrueWhenNothingToContinueSentInFrameWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageAfterContinuationFrameWithFINEqualsTrueWhenThereIsNothingToContinueSentInOctetWiseChops")
-    @Test(timeout = 6500)
+    @Test
     public void sendTextMessageAfterContinuationFrameWithFINEqualsTrueWhenThereIsNothingToContinueSentInOctetWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageAfterContinuationFrameWithFINEqualsTrueWhenThereIsNothingToContinueSentInOneChop")
-    @Test(timeout = 6500)
+    @Test
     public void sendTextMessageAfterContinuationFrameWithFINEqualsTrueWhenThereIsNothingToContinueSentInOneChop() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInMultipleFramesWithPingsWithPayloadsInBetween")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInMultipleFramesWithPingsWithPayloadsInBetween() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInMultipleFramesWithPingsWithPayloadsInBetweenAndAllFramesWithSYNCEqualsTrue")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInMultipleFramesWithPingsWithPayloadsInBetweenAndAllFramesWithSYNCEqualsTrue() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInTwoFragments")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInTwoFragments() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInTwoFragmentsInFrameWiseChops")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInTwoFragmentsInFrameWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInTwoFragmentsInOctetWiseChops")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInTwoFragmentsInOctetWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInTwoFragmentsThenContinuationWithFINEqualsFalseAndNothingToContinueThenUnfragmentedTextMessage")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInTwoFragmentsThenContinuationWithFINEqualsFalseAndNothingToContinueThenUnfragmentedTextMessage() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInTwoFragmentsWithBothFrameOpcodesSetToText")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInTwoFragmentsWithBothFrameOpcodesSetToText() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInTwoFragmentsWithOnePingWithPayloadInBetween")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInTwoFragmentsWithOnePingWithPayloadInBetween() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInTwoFragmentsWithOnePingWithPayloadInBetweenInFrameWiseChops")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInTwoFragmentsWithOnePingWithPayloadInBetweenInFrameWiseChopss() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageInTwoFragmentsWithOnePingWithPayloadInBetweenInOctetWiseChops")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageInTwoFragmentsWithOnePingWithPayloadInBetweenInOctetWiseChops() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/framing/FramingBinaryMessagesIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/framing/FramingBinaryMessagesIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.autobahn.framing;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -52,50 +52,50 @@ public class FramingBinaryMessagesIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("sendBinaryMessageWithPayloadLength125")
     @Test(timeout = 1500)
     public void sendBinaryMessageWithPayloadLength125() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendBinaryMessageWithPayloadLength126")
     @Test(timeout = 1500)
     public void sendBinaryMessageWithPayloadLength126() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendBinaryMessageWithPayloadLength127")
     @Test(timeout = 1500)
     public void sendBinaryMessageWithPayloadLength127() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendBinaryMessageWithPayloadLength128")
     @Test(timeout = 1500)
     public void sendBinaryMessageWithPayloadLength128() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendBinaryMessageWithPayloadLength65535")
     @Test(timeout = 1500)
     public void sendBinaryMessageWithPayloadLength65535() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendBinaryMessageWithPayloadLength65536")
     @Test(timeout = 1500)
     public void sendBinaryMessageWithPayloadLength65536() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendBinaryMessageWithPayloadLength65536InChopsOf997Octets")
     @Test(timeout = 1500)
     public void sendBinaryMessageWithPayloadLength65536InChopsOf997Octets() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12366")
     @Specification("sendBinaryMessageWithPayloadLengthZero")
     @Test(timeout = 1500)

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/framing/FramingTextMessagesIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/framing/FramingTextMessagesIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.autobahn.framing;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -52,45 +52,45 @@ public class FramingTextMessagesIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
+
     @Specification("sendTextMessageWithPayloadLength125")
     @Test(timeout = 1500)
     public void sendTextMessageWithPayloadLength125() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithPayloadLength126")
     @Test(timeout = 1500)
     public void sendTextMessageWithPayloadLength126() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithPayloadLength127")
     @Test(timeout = 1500)
     public void sendTextMessageWithPayloadLength127() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithPayloadLength128")
     @Test(timeout = 1500)
     public void sendTextMessageWithPayloadLength128() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithPayloadLength65535")
     @Test(timeout = 1500)
     public void sendTextMessageWithPayloadLength65535() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithPayloadLength65536")
     @Test(timeout = 1500)
     public void sendTextMessageWithPayloadLength65536() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithPayloadLength65536InChopsOf997Octets")
     @Test(timeout = 1500)
     public void sendTextMessageWithPayloadLength65536InChopsOf997Octets() throws Exception {

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/opcodes/OpcodesIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/opcodes/OpcodesIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.autobahn.opcodes;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -51,64 +51,64 @@ public class OpcodesIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("sendFrameWithReservedNonControlOpcodeEquals3")
-    @Test(timeout = 1500)
+    @Test
     public void sendFrameWithReservedNonControlOpcodeEquals3() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendFrameWithReservedNonControlOpcodeEquals4AndNonEmptyPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendFrameWithReservedNonControlOpcodeEquals4AndNonEmptyPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallTextMessageThenFrameWithReservedNonControlOpcodeEquals5ThenPing")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageThenFrameWithReservedNonControlOpcodeEquals5ThenPing() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallTextMessageThenFrameWithReservedNonControlOpcodeEquals6AndNonEmptyPayloadThenPing")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageThenFrameWithReservedNonControlOpcodeEquals6AndNonEmptyPayloadThenPing() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallTextMessageThenFrameWithReservedNonControlOpcodeEquals7AndNonEmptyPayloadThenPing")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageThenFrameWithReservedNonControlOpcodeEquals7AndNonEmptyPayloadThenPing() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendFrameWithReservedControlOpcodeEquals11")
-    @Test(timeout = 1500)
+    @Test
     public void sendFrameWithReservedControlOpcodeEquals11() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendFrameWithReservedControlOpcodeEquals12AndNonEmptyPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendFrameWithReservedControlOpcodeEquals12AndNonEmptyPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendFrameWithReservedControlOpcodeEquals13ThenPing")
-    @Test(timeout = 1500)
+    @Test
     public void sendFrameWithReservedNonControlOpcodeEquals13ThenPing() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallTextMessageThenFrameWithReservedControlOpcodeEquals14AndNonEmptyPayloadThenPing")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageThenFrameWithReservedControlOpcodeEquals14AndNonEmptyPayloadThenPing() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallTextMessageThenFrameWithReservedControlOpcodeEquals15AndNonEmptyPayloadThenPing")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageThenFrameWithReservedControlOpcodeEquals15AndNonEmptyPayloadThenPing() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/pingsandpongs/PingsAndPongsIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/pingsandpongs/PingsAndPongsIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.autobahn.pingsandpongs;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -52,71 +52,71 @@ public class PingsAndPongsIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("sendPingWithoutPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendPingWithoutPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendPingWithSmallTextPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendPingWithSmallTextPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendPingWithSmallBinaryPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendPingWithSmallBinaryPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendPingWithBinaryPayloadOf125Octets")
-    @Test(timeout = 1500)
+    @Test
     public void sendPingWithBinaryPayloadOf125Octets() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendPingWithBinaryPayloadOf125OctetsInOctetWiseChops")
-    @Test(timeout = 1500)
+    @Test
     public void sendPingWithBinaryPayloadOf125OctetsInOctetWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendUnsolicitedPongWithoutPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendUnsolicitedPongWithoutPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendUnsolicitedPongWithPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendUnsolicitedPongWithPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendUnsolicitedPongWithPayloadThenPingWithPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendUnsolicitedPongWithPayloadThenPingWithPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTenPingsWithPayload")
-    @Test(timeout = 1500)
+    @Test
     public void sendTenPingsWithPayload() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTenPingsWithPayloadInOctetWiseChops")
-    @Test(timeout = 1500)
+    @Test
     public void sendTenPingsWithPayloadInOctetWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12367")
     @Specification("sendPingWithBinaryPayloadOf126Octets")
-    @Test(timeout = 1500)
+    @Test
     public void sendPingWithBinaryPayloadOf126Octets() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/reservedbits/ReservedBitsIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/reservedbits/ReservedBitsIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.autobahn.reservedbits;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -52,49 +52,49 @@ public class ReservedBitsIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
-    
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("sendCloseWithRSVEquals7")
-    @Test(timeout = 1500)
+    @Test
     public void sendCloseWithRSVEquals() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallTextMessageWithRSVEquals1")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageWithRSVEquals1() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallTextMessageThenSmallTextMessageWithRSVEquals2ThenSendPing")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageThenSmallTextMessageWithRSVEquals2ThenSendPing() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallTextMessageThenSmallTextMessageWithRSVEquals3ThenSendPingInFrameWiseChops")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageThenSmallTextMessageWithRSVEquals3ThenSendPingInFrameWiseChops() throws Exception {
         robot.finish();
     }
 
     @Ignore("KG-12368")
     @Specification("sendSmallTextMessageThenSmallTextMessageWithRSVEquals4ThenSendPingInOctetWiseChops")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallTextMessageThenSmallTextMessageWithRSVEquals3ThenSendPingInOctetWiseChops() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendSmallBinaryMessageWithRSVEquals5")
-    @Test(timeout = 1500)
+    @Test
     public void sendSmallBinaryMessageWithRSVEquals5() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendPingWithRSVEquals6")
-    @Test(timeout = 1500)
+    @Test
     public void sendPingWithRSVEquals6() throws Exception {
         robot.finish();
     }
-    
+
 }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/utf8handling/UTF8HandlingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/autobahn/utf8handling/UTF8HandlingIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.autobahn.utf8handling;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -52,955 +52,955 @@ public class UTF8HandlingIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
- 
+    public TestRule chain = createRuleChain(gateway, robot);
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment2")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment2() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment3")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment3() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment4")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment4() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment5")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment5() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment6")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment6() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment7")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment7() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment8")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment8() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment9")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment9() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment10")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment10() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment11")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment11() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment12")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment12() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment13")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment13() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment14")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment14() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment15")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment15() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment16")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment16() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment17")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment17() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment18")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment18() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment19")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment19() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment20")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment20() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment21")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment21() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment22")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment22() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment23")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment23() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment24")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment24() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment25")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment25() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment26")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment26() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment27")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment27() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment28")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment28() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment29")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment29() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment30")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment30() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment31")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment31() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment32")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment32() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment33")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment33() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment34")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment34() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment35")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment35() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment36")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment36() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment37")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment37() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment38")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment38() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment39")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment39() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment40")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment40() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment41")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment41() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment42")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment42() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment43")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment43() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment44")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment44() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment45")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment45() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment46")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment46() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment47")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment47() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment48")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment48() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment49")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment49() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment50")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment50() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment51")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment51() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment52")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment52() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment53")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment53() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment54")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment54() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment55")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment55() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment56")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment56() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment57")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment57() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment58")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment58() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment59")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment59() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment60")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment60() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment61")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment61() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment62")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment62() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment63")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment63() throws Exception {
         robot.finish();
     }
-    
+
     @Specification("sendTextMessageWithValidUTF8PayloadInOneFragment64")
-    @Test(timeout = 1500)
+    @Test
     public void sendTextMessageWithValidUTF8PayloadInOneFragment64() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithValidUTF8PayloadInTwoFragmentsFragmentedOnCodePointBoundary")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithValidUTF8PayloadInTwoFragmentsFragmentedOnCodePointBoundary() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12366")
     @Specification("sendTextMessageOfLengthZero")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageOfLengthZero() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12366")
     @Specification("sendThreeFragmentedTextMessagesOfLengthZero")
-    @Test(timeout = 1500)
+    @Test
     public void	sendThreeFragmentedTextMessagesOfLengthZero() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12366")
     @Specification("sendThreeFragmentedTextMessagesFirstAndLastLengthZeroMiddleNonEmpty")
-    @Test(timeout = 1500)
+    @Test
     public void	sendThreeFragmentedTextMessagesFirstAndLastLengthZeroMiddleNonEmpty() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment2")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment2() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment3")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment3() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment4")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment4() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment5")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment5() throws Exception {
         robot.finish();
     }
 
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment6")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment6() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment7")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment7() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment8")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment8() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment9")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment9() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment10")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment10() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment11")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment11() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment12")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment12() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment13")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment13() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment14")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment14() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment15")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment15() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment16")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment16() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment17")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment17() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment18")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment18() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment19")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment19() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment20")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment20() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment21")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment21() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment22")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment22() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment23")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment23() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment24")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment24() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment25")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment25() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment26")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment26() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment27")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment27() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment28")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment28() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment29")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment29() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment30")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment30() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment31")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment31() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment32")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment32() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment33")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment33() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment34")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment34() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment35")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment35() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment36")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment36() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment37")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment37() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment38")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment38() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment39")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment39() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment40")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment40() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment41")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment41() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment42")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment42() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment43")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment43() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment44")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment44() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment45")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment45() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment46")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment46() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment47")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment47() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment48")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment48() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment49")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment49() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment50")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment50() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment51")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment51() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment52")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment52() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment53")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment53() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment54")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment54() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment55")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment55() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment56")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment56() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment57")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment57() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment58")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment58() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment59")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment59() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment60")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment60() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment61")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment61() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment62")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment62() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment63")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment63() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment64")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment64() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment65")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment65() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment66")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment66() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment67")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment67() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment68")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment68() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment69")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment69() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneFragment70")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneFragment70() throws Exception {
         robot.finish();
     }
 
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadInOneOctetFragments")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadInOneOctetFragments() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadIn3Fragments")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadIn3Fragments() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadIn3Fragments2")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadIn3Fragments2() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessagewithInvalidUTF8PayloadIn3Chops")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessagewithInvalidUTF8PayloadIn3Chops() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithInvalidUTF8PayloadIn3Chops2")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithInvalidUTF8PayloadIn3Chops2() throws Exception {
         robot.finish();
     }
 
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithValidUTF8PayloadInOneOctetFragments")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithValidUTF8PayloadInOneOctetFragments() throws Exception {
         robot.finish();
     }
-    
+
     @Ignore("Requires updates from branch KG-10406-continuation-frame and fix for KG-12373")
     @Specification("sendTextMessageWithValidUTF8PayloadInOneOctetFragments2")
-    @Test(timeout = 1500)
+    @Test
     public void	sendTextMessageWithValidUTF8PayloadInOneOctetFragments2() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/idletimeout/IdleTimeoutExtensionIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/idletimeout/IdleTimeoutExtensionIT.java
@@ -21,40 +21,23 @@
 
 package org.kaazing.gateway.transport.wsn.extensions.idletimeout;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 // Note: further testing of this extension is done in WsnInactivityTimeoutIT
 public class IdleTimeoutExtensionIT {
 
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-    @BeforeClass
-    public static void init()
-            throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
 
     public GatewayRule gateway = new GatewayRule() {
         {
@@ -84,7 +67,7 @@ public class IdleTimeoutExtensionIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("shouldGetValueFromIdleTimeoutExtension")
     @Test

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/idletimeout/IdleTimeoutExtensionPongsIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/idletimeout/IdleTimeoutExtensionPongsIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,15 +21,13 @@
 
 package org.kaazing.gateway.transport.wsn.extensions.idletimeout;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
 
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -42,15 +40,6 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class IdleTimeoutExtensionPongsIT {
 
     private K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-    @BeforeClass
-    public static void init()
-            throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
 
     public GatewayRule gateway = new GatewayRule() {
         {
@@ -72,10 +61,10 @@ public class IdleTimeoutExtensionPongsIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("shouldGetPongsFromidleTimeoutExtension")
-    @Test(timeout = 8 * 1000) 
+    @Test
     public void shouldGetPongsFromidleTimeoutExtensionWhenWriterIdle() throws Exception {
         System.out.println("### Creating server socket and listening");
         ServerSocket listen = new ServerSocket();

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/pingpong/PingPongExtensionIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/pingpong/PingPongExtensionIT.java
@@ -21,40 +21,23 @@
 
 package org.kaazing.gateway.transport.wsn.extensions.pingpong;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
-import org.apache.log4j.PropertyConfigurator;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 //Note: further testing of this extension is done in WsnInactivityTimeoutIT
 public class PingPongExtensionIT {
 
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
-
-    private static final boolean ENABLE_DIAGNOSTICS = false;
-    @BeforeClass
-    public static void init()
-            throws Exception {
-        if (ENABLE_DIAGNOSTICS) {
-            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
-        }
-    }
 
     public GatewayRule gateway = new GatewayRule() {
         {
@@ -74,7 +57,7 @@ public class PingPongExtensionIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("pingPongExtensionShouldNotEscapeBinary")
     @Test

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/test/ExtensionWithFilterIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/extensions/test/ExtensionWithFilterIT.java
@@ -21,9 +21,8 @@
 
 package org.kaazing.gateway.transport.wsn.extensions.test;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
 import static org.kaazing.gateway.util.Utils.asByteArray;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.ProtocolException;
 import java.net.URI;
@@ -34,9 +33,7 @@ import org.apache.mina.core.session.IoSession;
 import org.apache.mina.core.write.WriteRequest;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.resource.address.ws.WsResourceAddress;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
@@ -49,12 +46,9 @@ import org.kaazing.gateway.transport.ws.extension.WebSocketExtensionFactorySpi;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.kaazing.mina.core.session.IoSessionEx;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class ExtensionWithFilterIT {
 
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
 
     private GatewayRule gateway = new GatewayRule() {
@@ -76,7 +70,7 @@ public class ExtensionWithFilterIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("should.transform.messages")
     @Test

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/Draft76SafariExtendedHandshakeTestIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/Draft76SafariExtendedHandshakeTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.handshake;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -89,7 +89,7 @@ public class Draft76SafariExtendedHandshakeTestIT {
 	                        .allowOrigin("*")
 	                    .done()
 	                .done()
-				    .security()		
+				    .security()
 					// TODO: keyStoreFile and keyStorePasswordFile are
 					// deprecated method which will be removed eventually(4.0.1
 					// time frame) and keyStore + keyStorePassword should be
@@ -102,33 +102,33 @@ public class Draft76SafariExtendedHandshakeTestIT {
 				        .realm()
 				          	.name("demo")
 				          	.description("Kaazing WebSocket Gateway Demo")
-				          	.httpChallengeScheme("Application Basic")	
+				          	.httpChallengeScheme("Application Basic")
 				          	.loginModule()
 				          	.type("class:org.kaazing.gateway.security.auth.YesLoginModule")
 				          		.success("requisite")
 				          		.option("roles", "AUTHORIZED, ADMINISTRATOR")
 				          	.done()
 				      	.done()
-				    .done()			            
-				   .done(); 
+				    .done()
+				   .done();
 			init(configuration);
 
 		}
 	};
 
 	@Rule
-	public TestRule chain = outerRule(robot).around(gateway);
+	public TestRule chain = createRuleChain(gateway, robot);
 
 	@Specification("replayDraft76HandshakeCapturedFromDesktopSafariExpectingA101Response")
-	@Test(timeout = 1500)
+	@Test
 	//KG-8523 NullPointerException
 	public void replayDraft76HandshakeCapturedFromDesktopSafariExpectingA101Response()
 			throws Exception {
 		robot.finish();
 	}
-	
+
 	@Specification("doDraft76HandshakeExpectingASynthetic101Response")
-	@Test(timeout = 1500)
+	@Test
 	//KG-8523 NullPointerException
 	//Original method name:replayInitialRequestResponseCycleForDraft76HandshakeExpectingASynthetic101ResponseWithExtendedHandshakeProtocolConfirmed
 	public void doDraft76HandshakeExpectingASynthetic101Response()

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/EchoServiceIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/EchoServiceIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.handshake;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -57,16 +57,16 @@ public class EchoServiceIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("echo.service.cross.origin.allow")
-    @Test(timeout = 1500)
+    @Test
     public void echoServiceCrossOriginAllow() throws Exception {
         robot.finish();
     }
 
     @Specification("echo.service.cross.origin.deny")
-    @Test(timeout = 1500)
+    @Test
     public void echoServiceCrossOriginDeny() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/RFC6455ChromeExtendedHandshakeTestIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/RFC6455ChromeExtendedHandshakeTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.handshake;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -54,7 +54,7 @@ public class RFC6455ChromeExtendedHandshakeTestIT {
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}
-			
+
 			GatewayConfiguration configuration = new GatewayConfigurationBuilder()
 					.service()
 	                    .accept(URI.create("ws://localhost:8001/echo"))
@@ -89,21 +89,21 @@ public class RFC6455ChromeExtendedHandshakeTestIT {
 	                        .allowOrigin("*")
 	                    .done()
 	                .done()
-				    .security()		
+				    .security()
 					// TODO: keyStoreFile and keyStorePasswordFile are
 					// deprecated method which will be removed eventually(4.0.1
 					// time frame) and keyStore + keyStorePassword should be
 					// sufficient.
-					// KG-8840		           
+					// KG-8840
 				        .keyStore(keyStore)
 				        .keyStorePassword(password)
 				        .keyStorePasswordFile(keyStorePwFile)
 				        .realm()
 				          	.name("demo")
 				          	.description("Kaazing WebSocket Gateway Demo")
-				          	.httpChallengeScheme("Basic")	
+				          	.httpChallengeScheme("Basic")
 				        .done()
-				    .done()			            
+				    .done()
                    .done();
 			init(configuration);
 
@@ -111,10 +111,10 @@ public class RFC6455ChromeExtendedHandshakeTestIT {
 	};
 
 	@Rule
-	public TestRule chain = outerRule(robot).around(gateway);
+	public TestRule chain = createRuleChain(gateway, robot);
 
 	@Specification("canCompleteAnExtendedHandshakeAndNegotiateAnApplicationExtension")
-	@Test(timeout = 1500)
+	@Test
 	public void canCompleteAnExtendedHandshakeAndNegotiateAnApplicationExtension()
 			throws Exception {
 		robot.finish();

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/RFC6455Firefox11BetaExtendedHandshakeTestIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/RFC6455Firefox11BetaExtendedHandshakeTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.handshake;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -54,7 +54,7 @@ public class RFC6455Firefox11BetaExtendedHandshakeTestIT {
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}
-			
+
 			GatewayConfiguration configuration = new GatewayConfigurationBuilder()
 					.service()
 	                    .accept(URI.create("ws://localhost:8001/echo"))
@@ -89,12 +89,12 @@ public class RFC6455Firefox11BetaExtendedHandshakeTestIT {
 	                            .allowOrigin("*")
 	                    .done()
 	                .done()
-				    .security()	
+				    .security()
 					// TODO: keyStoreFile and keyStorePasswordFile are
 					// deprecated method which will be removed eventually(4.0.1
 					// time frame) and keyStore + keyStorePassword should be
 					// sufficient.
-					// KG-8840					           
+					// KG-8840
 				        .keyStoreFile("target/truststore/keystore.db")
 				        .keyStore(keyStore)
 				        .keyStorePassword(password)
@@ -102,20 +102,20 @@ public class RFC6455Firefox11BetaExtendedHandshakeTestIT {
 				        .realm()
 				          	.name("demo")
 				          	.description("Kaazing WebSocket Gateway Demo")
-				          	.httpChallengeScheme("Basic")	
+				          	.httpChallengeScheme("Basic")
 				        .done()
-				    .done()			            
-				   .done(); 
+				    .done()
+				   .done();
 			init(configuration);
 
 		}
 	};
 
 	@Rule
-	public TestRule chain = outerRule(robot).around(gateway);
+	public TestRule chain = createRuleChain(gateway, robot);
 
 	@Specification("canCompleteAnExtendedHandshakeFirstRequestAndNegotiateTheXKaazinghandshakeProtocol")
-	@Test(timeout = 1500)
+	@Test
 	public void canCompleteAnExtendedHandshakeFirstRequestAndNegotiateTheXKaazinghandshakeProtocol()
 			throws Exception {
 		robot.finish();

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/WsHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/WsHandshakeIT.java
@@ -21,16 +21,13 @@
 
 package org.kaazing.gateway.transport.wsn.handshake;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -40,8 +37,6 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class WsHandshakeIT {
 
     private K3poRule robot = new K3poRule();
-
-    private TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
 
     private GatewayRule gateway = new GatewayRule() {
         {
@@ -73,7 +68,7 @@ public class WsHandshakeIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("websocket.handshake")
     @Test

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/WsHttpKeepaliveTimeoutIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/WsHttpKeepaliveTimeoutIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.handshake;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -58,10 +58,10 @@ public class WsHttpKeepaliveTimeoutIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("keepalive.timeout.cross.origin.deny")
-    @Test(timeout = 5*1000)
+    @Test
     public void echoServiceCrossOriginDeny() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/WsxExtensionsNegotiationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/handshake/WsxExtensionsNegotiationIT.java
@@ -21,27 +21,21 @@
 
 package org.kaazing.gateway.transport.wsn.handshake;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class WsxExtensionsNegotiationIT {
 
-    private TestRule trace = new MethodExecutionTrace();
-    private TestRule timeout = new DisableOnDebug(new Timeout(4, SECONDS));
     private final K3poRule robot = new K3poRule();
 
     private GatewayRule gateway = new GatewayRule() {
@@ -77,7 +71,7 @@ public class WsxExtensionsNegotiationIT {
     };
 
     @Rule
-    public TestRule chain = outerRule(trace).around(robot).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("should.negotiate.extensions.in.wrapped.request")
     @Test

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/proxy/ProxyOrphanedConnectionIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/proxy/ProxyOrphanedConnectionIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 
 package org.kaazing.gateway.transport.wsn.proxy;
 
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -37,7 +37,7 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class ProxyOrphanedConnectionIT {
 
     private K3poRule robot = new K3poRule();
-    
+
     public GatewayRule gateway = new GatewayRule() {
         {
             // @formatter:off
@@ -54,12 +54,12 @@ public class ProxyOrphanedConnectionIT {
             init(configuration);
         }
     };
-    
+
     @Rule
-    public TestRule chain = outerRule(robot).around(gateway);
+    public TestRule chain = createRuleChain(gateway, robot);
 
     @Specification("connectToFrontEndProxyAndKillFrontBeforeBackendIsEstablished")
-    @Test(timeout = 5000)
+    @Test
     public void closeOnFrontBeforeConnectedFullyOnBackShouldKillBack() throws Exception {
         robot.finish();
     }

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/BaseFramingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/BaseFramingIT.java
@@ -16,17 +16,14 @@
 
 package org.kaazing.gateway.transport.wsn.specification.ws;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -39,7 +36,7 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class BaseFramingIT {
 
     private final K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/ws/framing");
-    
+
     private GatewayRule gateway = new GatewayRule() {
         {
             // @formatter:off
@@ -57,11 +54,9 @@ public class BaseFramingIT {
             init(configuration);
         }
     };
-    
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
 
     @Rule
-    public final TestRule chain = outerRule(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Test
     @Ignore("Error: expected 'read [0x82 0x00]', actual 'Disconnected', Not echoing 0 length payload, "

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/ClosingHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/ClosingHandshakeIT.java
@@ -16,17 +16,14 @@
 
 package org.kaazing.gateway.transport.wsn.specification.ws;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -39,7 +36,7 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 public class ClosingHandshakeIT {
 
     private final K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/ws/closing");
-    
+
     private final GatewayRule gateway = new GatewayRule() {
         {
             // @formatter:off
@@ -58,10 +55,8 @@ public class ClosingHandshakeIT {
         }
     };
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(8, SECONDS));
-
     @Rule
-    public final TestRule chain = outerRule(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Test
     @Specification({

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/ControlIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/ControlIT.java
@@ -16,17 +16,14 @@
 
 package org.kaazing.gateway.transport.wsn.specification.ws;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -57,11 +54,9 @@ public class ControlIT {
             init(configuration);
         }
     };
-    
-    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
 
     @Rule
-    public final TestRule chain = outerRule(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Test
     @Specification({

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/DataFramingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/DataFramingIT.java
@@ -16,16 +16,13 @@
 
 package org.kaazing.gateway.transport.wsn.specification.ws;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -57,10 +54,8 @@ public class DataFramingIT {
         }
     };
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
-
     @Rule
-    public final TestRule chain = outerRule(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     // TODO: invalid UTF-8 in text frame (opcode 0x01) RFC-6455, section 8.1
 

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/ExtensibilityIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/ExtensibilityIT.java
@@ -16,16 +16,13 @@
 
 package org.kaazing.gateway.transport.wsn.specification.ws;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -57,10 +54,8 @@ public class ExtensibilityIT {
         }
     };
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
-
     @Rule
-    public final TestRule chain = outerRule(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     @Test
     @Specification({

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/MaskingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/MaskingIT.java
@@ -16,17 +16,14 @@
 
 package org.kaazing.gateway.transport.wsn.specification.ws;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -60,14 +57,12 @@ public class MaskingIT {
         }
     };
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
-
     @Rule
-    public final TestRule chain = outerRule(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
-/*    
+/*
  *  Client-only Tests
- *  
+ *
     @Test
     @Specification({
         "server.send.masked.text/handshake.request.and.frame",
@@ -84,7 +79,7 @@ public class MaskingIT {
         k3po.finish();
     }
 */
-    
+
     @Test
     @Ignore("Read value for client differs from expected.")
     @Specification({

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/OpeningHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/OpeningHandshakeIT.java
@@ -16,17 +16,14 @@
 
 package org.kaazing.gateway.transport.wsn.specification.ws;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -66,10 +63,8 @@ public class OpeningHandshakeIT {
         }
     };
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
-
     @Rule
-    public final TestRule chain = outerRule(k3po).around(gateway).around(timeout);
+    public TestRule chain = createRuleChain(gateway, k3po);
 
     // TODO:
     // proxy => HTTP CONNECT w/ optional authorization, auto-configuration via ws://, wss://
@@ -151,7 +146,7 @@ public class OpeningHandshakeIT {
     public void shouldEstablishConnectionWhenOrderOfExtensionsNegotiatedChanged() throws Exception {
         k3po.finish();
     }
-    
+
     // Gateway sending payload
     @Test
     @Ignore("Gateway sending payload with 405 Not Allowed, <html><head></head><body><h1>405 Method Not Allowed</h1></body></html>")
@@ -242,9 +237,9 @@ public class OpeningHandshakeIT {
         k3po.finish();
     }
 
-/*   
+/*
  *  Client-only Tests
- *   
+ *
     @Test
     @Specification({
         "response.header.connection.not.upgrade/handshake.request",


### PR DESCRIPTION
…a way to get k3po to generate a good certificate response accepted by Oracle JDK 1.8.0_51.

Also added ITUtil, containing a utility methods for creating rule chains for robot tests, and changed a bunch of robot tests to use it, so all test methods have a timeout and trace log if they fail.

@jitsni This is **not yet ready for merging**, I just want to get your feedback before I go modify all the other robot tests,