### PR TITLE
Trying to address travis gateway build failures.

### DIFF
--- a/management/src/test/java/org/kaazing/gateway/management/impl/ServiceDefaultsConfigurationBeanImplTest.java
+++ b/management/src/test/java/org/kaazing/gateway/management/impl/ServiceDefaultsConfigurationBeanImplTest.java
@@ -21,8 +21,14 @@
 
 package org.kaazing.gateway.management.impl;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
 import java.net.URI;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
@@ -32,6 +38,9 @@ public class ServiceDefaultsConfigurationBeanImplTest {
     private final URI SNMP_SERVICE_ACCEPT_URL = URI.create("ws://localhost:8000/snmp");
     private final String SNMP_SERVICE_NAME = "SNMP Management Service";
     private final String SNMP_SERVICE_TYPE = "management.snmp";
+
+    @Rule
+    public TestRule chain = createRuleChain(20, SECONDS);
 
     @Test
     public void testServiceDefaultsWithoutSslCiphers() throws Exception {

--- a/management/src/test/java/org/kaazing/gateway/management/jmx/JmxManagementServiceHandlerTest.java
+++ b/management/src/test/java/org/kaazing/gateway/management/jmx/JmxManagementServiceHandlerTest.java
@@ -22,7 +22,7 @@
 package org.kaazing.gateway.management.jmx;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.kaazing.test.util.ITUtil.createTimeout;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 
@@ -43,7 +43,7 @@ public class JmxManagementServiceHandlerTest {
     private final String PROXY = "proxy";
 
     @Rule
-    public TestRule timeoutRule = createTimeout(20, SECONDS);
+    public TestRule timeoutRule = createRuleChain(20, SECONDS);
 
     @Test
     public void testNoJMXBindingNameConflictsOnMultiServicesUsingSameConnect() throws Exception {

--- a/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
+++ b/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
@@ -72,7 +72,8 @@ public final class ITUtil {
      * @return
      */
     public static RuleChain createRuleChain(long timeout, TimeUnit timeUnit) {
-        TestRule timeoutRule = new DisableOnDebug(Timeout.builder().withTimeout(timeout, timeUnit).withLookingForStuckThread(true).build());
+        TestRule timeoutRule = new DisableOnDebug(Timeout.builder().withTimeout(timeout, timeUnit)
+                .withLookingForStuckThread(true).build());
         TestRule trace = new MethodExecutionTrace();
         return RuleChain.outerRule(trace).around(timeoutRule);
     }

--- a/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
+++ b/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
@@ -47,20 +47,20 @@ public final class ITUtil {
     }
 
     /**
-     * Creates a rule (chain) out of a k3po rule, adding extra rules as follows:<ol>
+     * Creates a rule (chain) out of a k3po or other rule, adding extra rules as follows:<ol>
      * <li> a timeout rule
      * <li> a rule to print console messages at the start and end of each test method and print trace level
      * log messages on test failure.
      * </ol>
-     * @param robot    Rule to startup and stop k3po
+     * @param rule    Rule to startup and stop k3po
      * @param timeout  The maximum allowed time duration of each test (including Gateway and robot startup and shutdown)
      * @param timeUnit The unit for the timeout
      * @return         A TestRule which should be the only public @Rule in our robot tests
      */
-    public static RuleChain createRuleChain(K3poRule robot, long timeout, TimeUnit timeUnit) {
+    public static RuleChain createRuleChain(TestRule rule, long timeout, TimeUnit timeUnit) {
         TestRule timeoutRule = createTimeout(timeout, timeUnit);
         TestRule trace = new MethodExecutionTrace();
-        return RuleChain.outerRule(trace).around(timeoutRule).around(robot);
+        return RuleChain.outerRule(trace).around(timeoutRule).around(rule);
     }
 
     /**

--- a/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
+++ b/test.util/src/main/java/org/kaazing/test/util/ITUtil.java
@@ -58,19 +58,23 @@ public final class ITUtil {
      * @return         A TestRule which should be the only public @Rule in our robot tests
      */
     public static RuleChain createRuleChain(TestRule rule, long timeout, TimeUnit timeUnit) {
-        TestRule timeoutRule = createTimeout(timeout, timeUnit);
-        TestRule trace = new MethodExecutionTrace();
-        return RuleChain.outerRule(trace).around(timeoutRule).around(rule);
+        return createRuleChain(timeout, timeUnit).around(rule);
     }
 
     /**
-     * Creates a Timeout will which is disabled when debugging and has the option to look for a stuck thread
+     * Creates a rule chain containing the following rules:<ol>
+     * <li> a timeout rule
+     * <li> a rule to print console messages at the start and end of each test method and print trace level
+     * log messages on test failure.
+     * </ol>
      * @param timeout  The maximum allowed time duration of the test
      * @param timeUnit The unit for the timeout
      * @return
      */
-    public static TestRule createTimeout(long timeout, TimeUnit timeUnit) {
-        return new DisableOnDebug(Timeout.builder().withTimeout(timeout, timeUnit).withLookingForStuckThread(true).build());
+    public static RuleChain createRuleChain(long timeout, TimeUnit timeUnit) {
+        TestRule timeoutRule = new DisableOnDebug(Timeout.builder().withTimeout(timeout, timeUnit).withLookingForStuckThread(true).build());
+        TestRule trace = new MethodExecutionTrace();
+        return RuleChain.outerRule(trace).around(timeoutRule);
     }
 
 

--- a/transport/nio/src/test/java/org/kaazing/gateway/transport/nio/internal/NioSocketAcceptorTest.java
+++ b/transport/nio/src/test/java/org/kaazing/gateway/transport/nio/internal/NioSocketAcceptorTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -142,6 +142,7 @@ public class NioSocketAcceptorTest {
         int[] rounds = new int[]{1,2,10};
         for ( int iterationCount: rounds ) {
             for ( int i = 0; i < iterationCount; i++) {
+                System.out.println("accept.bind, i=" + i);
                 acceptor.bind(bindAddress, ioHandler, null);
             }
             for (int j = 0; j < iterationCount; j++) {
@@ -249,7 +250,7 @@ public class NioSocketAcceptorTest {
                 return null;
             }
         });
-        
+
         context.assertIsSatisfied();
 
         Sequence order = context.sequence("order");
@@ -275,7 +276,7 @@ public class NioSocketAcceptorTest {
         }
         finally {
             socket.close();
-    
+
             acceptor.dispose();
         }
 
@@ -331,7 +332,7 @@ public class NioSocketAcceptorTest {
                 return null;
             }
         });
-        
+
         context.assertIsSatisfied();
 
         Sequence order = context.sequence("order");
@@ -355,7 +356,7 @@ public class NioSocketAcceptorTest {
         }
         finally {
             socket.close();
-    
+
             acceptor.dispose();
         }
 

--- a/transport/ssl/src/test/java/org/kaazing/gateway/transport/ssl/Sslv3Test.java
+++ b/transport/ssl/src/test/java/org/kaazing/gateway/transport/ssl/Sslv3Test.java
@@ -21,22 +21,11 @@
 
 package org.kaazing.gateway.transport.ssl;
 
-import org.junit.BeforeClass;
-import org.kaazing.gateway.server.test.Gateway;
-import org.kaazing.gateway.server.test.config.GatewayConfiguration;
-import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
-import org.kaazing.test.util.ITUtil;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-
-import javax.net.SocketFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -49,10 +38,21 @@ import java.net.URI;
 import java.security.KeyStore;
 import java.security.Security;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.kaazing.gateway.server.test.Gateway;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 
 public class Sslv3Test {
 
@@ -63,7 +63,7 @@ public class Sslv3Test {
     private SSLSocketFactory clientSocketFactory;
 
     @Rule
-    public TestRule chain = ITUtil.createTimeout(10, SECONDS);
+    public TestRule chain = createRuleChain(10, SECONDS);
 
     @BeforeClass
     public static void initClass() throws Exception {

--- a/transport/ssl/src/test/java/org/kaazing/gateway/transport/ssl/Sslv3Test.java
+++ b/transport/ssl/src/test/java/org/kaazing/gateway/transport/ssl/Sslv3Test.java
@@ -21,13 +21,15 @@
 
 package org.kaazing.gateway.transport.ssl;
 
-import org.apache.log4j.BasicConfigurator;
 import org.junit.BeforeClass;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.test.util.ITUtil;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
@@ -47,6 +49,7 @@ import java.net.URI;
 import java.security.KeyStore;
 import java.security.Security;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -59,9 +62,11 @@ public class Sslv3Test {
 
     private SSLSocketFactory clientSocketFactory;
 
+    @Rule
+    public TestRule chain = ITUtil.createTimeout(10, SECONDS);
+
     @BeforeClass
     public static void initClass() throws Exception {
-        BasicConfigurator.configure();
         // SSLv3 is part of disabled algorithms, reset for SSLv3 to work
         // But before JSSE initialized (so run the tests in separate jvm)
         Security.setProperty("jdk.tls.disabledAlgorithms", "true");
@@ -91,7 +96,7 @@ public class Sslv3Test {
     // Gateway doesn't enable SSLv3 by default, but configured explicitly to use *only* SSLv3
     // using ssl.protocols option. Client is also configured to use *only* SSLv3, so we expect
     // SSL handshake go through
-    @Test(timeout = 5000)
+    @Test
     public void acceptSucceedsWithSslv3() throws Exception {
         Gateway gateway = new Gateway();
         SSLSocket socket = null;
@@ -139,7 +144,7 @@ public class Sslv3Test {
 
     // Gateway doesn't enable SSLv3 by default. But client is configured to use *only* SSLv3,
     // so we expect SSL handshake to *not* go through
-    @Test(timeout = 5000)
+    @Test
     public void acceptFailsWithoutSslv3() throws Exception {
         Gateway gateway = new Gateway();
         SSLSocket socket = null;
@@ -179,7 +184,7 @@ public class Sslv3Test {
 
 
     // 8567 (only SSLv3 by config) -> 8658 (only SSLv3 by config), so we expect SSL handshake to go through
-    @Test(timeout = 5000)
+    @Test
     public void connectSucceedsWithSslv3() throws Exception {
         Gateway gateway = new Gateway();
         Socket socket = null;
@@ -232,7 +237,7 @@ public class Sslv3Test {
 
     // 9557 (no SSLv3 by default) -> 9588 (no SSLv3 by default), so we expect SSL handshake to go through
     // using some protocol other than SSLv3
-    @Test(timeout = 5000)
+    @Test
     public void connectSucceedsWithoutSslv3() throws Exception {
         Gateway gateway = new Gateway();
         Socket socket = null;
@@ -282,7 +287,7 @@ public class Sslv3Test {
     }
 
     // 8567 (only SSLv3) -> 8658 (no SSLv3 by default), so we expect SSL handshake to *not* go through
-    @Test(timeout = 5000)
+    @Test
     public void connectFailsWithSslv3() throws Exception {
         Gateway gateway = new Gateway();
         Socket socket = null;
@@ -333,7 +338,7 @@ public class Sslv3Test {
     }
 
     // 9567 (no SSLv3 by default) -> 9658 (only SSLv3 by config), so we expect SSL handshake to *not* go through
-    @Test(timeout = 5000)
+    @Test
     public void connectFailsWithoutSslv3() throws Exception {
         Gateway gateway = new Gateway();
         Socket socket = null;

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnConnectorTest.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnConnectorTest.java
@@ -22,9 +22,11 @@
 package org.kaazing.gateway.transport.wsn;
 
 import static java.nio.ByteBuffer.wrap;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.kaazing.gateway.util.Utils.asByteBuffer;
+import static org.kaazing.test.util.ITUtil.createTimeout;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -34,7 +36,6 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.PropertyConfigurator;
 import org.apache.mina.core.buffer.IoBuffer;
 import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.future.CloseFuture;
@@ -47,7 +48,6 @@ import org.apache.mina.core.session.IoSession;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,11 +72,10 @@ import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
 import org.kaazing.mina.core.buffer.IoBufferEx;
 import org.kaazing.mina.core.buffer.SimpleBufferAllocator;
 import org.kaazing.mina.core.session.IoSessionEx;
-import org.kaazing.test.util.MethodExecutionTrace;
 
 public class WsnConnectorTest {
     @Rule
-    public TestRule testExecutionTrace = new MethodExecutionTrace();
+    public TestRule cain = createTimeout(30, SECONDS);
 
     private SchedulerProvider schedulerProvider;
 
@@ -94,15 +93,6 @@ public class WsnConnectorTest {
     private HttpAcceptor httpAcceptor;
     private WsnAcceptor wsnAcceptor;
 
-    private static final boolean DEBUG = false;
-    @BeforeClass
-    public static void initLogging()
-            throws Exception {
-
-        if (DEBUG) {
-            PropertyConfigurator.configure("src/test/resources/log4j-trace.properties");
-        }
-    }
     @Before
     public void init() {
         schedulerProvider = new SchedulerProvider();
@@ -168,7 +158,7 @@ public class WsnConnectorTest {
         }
     }
 
-    @Test (timeout = 10000)
+    @Test
     public void shouldCloseWsnSessionWhenTransportClosesCleanlyButUnexpectedly() throws Exception {
 
         URI location = URI.create("wsn://localhost:8000/echo");
@@ -311,7 +301,7 @@ public class WsnConnectorTest {
 
     }
 
-    @Test (timeout = 30000)
+    @Test
     @Ignore("Failing on travis CI https://github.com/kaazing/gateway/issues/162")
     public void shouldNotHangOnToHttpConnectSessionsWhenEstablishingAndTearingDownWsnConnectorSessions() throws Exception {
 

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnConnectorTest.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnConnectorTest.java
@@ -26,7 +26,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.kaazing.gateway.util.Utils.asByteBuffer;
-import static org.kaazing.test.util.ITUtil.createTimeout;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -75,7 +75,7 @@ import org.kaazing.mina.core.session.IoSessionEx;
 
 public class WsnConnectorTest {
     @Rule
-    public TestRule cain = createTimeout(30, SECONDS);
+    public TestRule cain = createRuleChain(30, SECONDS);
 
     private SchedulerProvider schedulerProvider;
 

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
  */
 
-package org.kaazing.gateway.transport.wsn;
+package org.kaazing.gateway.transport.wsn.specification.ws.connector;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/WsnConnectorRule.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/WsnConnectorRule.java
@@ -2,17 +2,19 @@
  * Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
  */
 
-package org.kaazing.gateway.transport.wsn;
+package org.kaazing.gateway.transport.wsn.specification.ws.connector;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
+import org.apache.mina.core.future.ConnectFuture;
+import org.apache.mina.core.service.IoHandler;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 import org.kaazing.gateway.resource.address.ResourceAddress;
 import org.kaazing.gateway.resource.address.ResourceAddressFactory;
 import org.kaazing.gateway.transport.BridgeServiceFactory;
@@ -20,12 +22,7 @@ import org.kaazing.gateway.transport.TransportFactory;
 import org.kaazing.gateway.transport.http.HttpConnector;
 import org.kaazing.gateway.transport.nio.internal.NioSocketAcceptor;
 import org.kaazing.gateway.transport.nio.internal.NioSocketConnector;
-import org.apache.log4j.PropertyConfigurator;
-import org.apache.mina.core.future.ConnectFuture;
-import org.apache.mina.core.service.IoHandler;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.kaazing.gateway.transport.wsn.WsnConnector;
 import org.kaazing.gateway.util.scheduler.SchedulerProvider;
 
 
@@ -37,7 +34,6 @@ import org.kaazing.gateway.util.scheduler.SchedulerProvider;
  */
 public class WsnConnectorRule implements TestRule {
 
-    private final String log4jPropertiesResourceName;
     private ResourceAddressFactory addressFactory;
     private WsnConnector wsnConnector;
 
@@ -48,11 +44,7 @@ public class WsnConnectorRule implements TestRule {
     }
 
     public WsnConnectorRule() {
-        this(null);
-    }
 
-    public WsnConnectorRule(String log4jPropertiesResourceName) {
-        this.log4jPropertiesResourceName = log4jPropertiesResourceName;
     }
 
     public ConnectFuture connect(String connect, Long wsInactivityTimeout, IoHandler connectHandler)
@@ -82,17 +74,6 @@ public class WsnConnectorRule implements TestRule {
 
         @Override
         public void evaluate() throws Throwable {
-            if (log4jPropertiesResourceName != null) {
-                // Initialize log4j using a properties file available on the class path
-                Properties log4j = new Properties();
-                InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(log4jPropertiesResourceName);
-                if (in == null) {
-                    throw new IOException(String.format("Could not load resource %s", log4jPropertiesResourceName));
-                }
-                log4j.load(in);
-                in.close();
-                PropertyConfigurator.configure(log4j);
-            }
             try {
                 // Connector setup
                 schedulerProvider = new SchedulerProvider();


### PR DESCRIPTION
 Add timeout rule to WsnConnectorTest. Move OpeningHandshakeIT.java and WsnConnectorRule to a more logical package location (under specification/ws since this is a spec test).