### PR TITLE
HttpBindings comparator didn't check transport's origin

### DIFF
--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/Comparators.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/Comparators.java
@@ -81,7 +81,7 @@ public final class Comparators {
     }
 
     public static <T> Comparator<T> compareNonNull(Comparator<T> comparator) {
-        return new NonNullComparator<>(comparator);
+        return new NonNullComparator<T>(comparator);
     }
 
     public static <T extends Comparable<T>> Comparator<T> compareComparable(Class<T> clazz) {
@@ -192,22 +192,34 @@ public final class Comparators {
         
     }
 
+    private static ResourceAddress getFloorTransport(ResourceAddress address) {
+        assert address != null;
+
+        ResourceAddress transport;
+        while((transport = address.getTransport()) != null) {
+            address = transport;
+        }
+        return address;
+    }
+
     private static final class ResourceOriginAndProtocolStackComparator implements Comparator<ResourceAddress> {
 
         @Override
         public int compare(ResourceAddress addr1, ResourceAddress addr2) {
-            
+
             int compareOrigin = ORIGIN_COMPARATOR.compare(addr1, addr2);
             if (compareOrigin != 0) {
                 return compareOrigin;
             }
-            
+
             int compareNextProtocol = PROTOCOL_STACK_COMPARATOR.compare(addr1, addr2);
             if (compareNextProtocol != 0) {
                 return compareNextProtocol;
             }
-            
-            return 0;
+
+            ResourceAddress floor1 = getFloorTransport(addr1);
+            ResourceAddress floor2 = getFloorTransport(addr2);
+            return ORIGIN_PATH_ALTERNATES_AND_PROTOCOL_STACK_COMPARATOR.compare(floor1, floor2);
         }
     }
 

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpBindings.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpBindings.java
@@ -90,32 +90,10 @@ public class HttpBindings extends Bindings<HttpBinding> {
         if (httpBinding != null) {
             URI location = address.getResource();
             String path = location.getPath();
-
-            Binding httpBinding2 = httpBinding.get(path);
-            if (httpBinding2 != null) {
-                ResourceAddress boundAddress = httpBinding2.bindAddress();
-                ResourceAddress boundAddressFloor = getFloorTransport(boundAddress);
-                ResourceAddress sourceAddressFloor = getFloorTransport(address);
-
-                URI sourceAddressURI = sourceAddressFloor.getResource();
-                while (boundAddressFloor != null) {
-                    if (sourceAddressURI.equals(boundAddressFloor.getResource())) {
-                        return httpBinding2;
-                    }
-                    boundAddressFloor = boundAddressFloor.getOption(ALTERNATE);
-                }
-            }
+            return httpBinding.get(path);
         }
         
         return null;
-    }
-
-    private ResourceAddress getFloorTransport(ResourceAddress boundAddress) {
-        if(boundAddress.getTransport() == null){
-            return boundAddress;
-        }
-        return getFloorTransport(boundAddress.getTransport());
-        
     }
 
     @Override

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpBindingsTest.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpBindingsTest.java
@@ -166,6 +166,50 @@ public class HttpBindingsTest {
     }
 
     @Test
+    public void shouldCorrectlyBindTwoAddressesWithTcpBind() throws Exception {
+        URI uri1 = URI.create("http://localhost:8001/");
+        HashMap<String, Object> options1 = new HashMap<String, Object>();
+        options1.put("tcp.bind", "7777");
+
+        URI uri2 = URI.create("http://localhost:8001/");
+        HashMap<String, Object> options2 = new HashMap<String, Object>();
+
+
+        ResourceAddress address1 = addressFactory.newResourceAddress(uri1, options1);
+        ResourceAddress address2 = addressFactory.newResourceAddress(uri2, options2);
+
+        Bindings.Binding binding1 = new Bindings.Binding(address1, handler, initializer);
+        Bindings.Binding binding2 = new Bindings.Binding(address2, handler, initializer);
+
+        Bindings.Binding oldBinding = httpBindings.addBinding(binding1);
+        assertNull(oldBinding);
+        oldBinding = httpBindings.addBinding(binding2);
+        assertNull(oldBinding);
+    }
+
+    @Test
+    public void shouldCorrectlyBindTwoSecureAddressesWithTcpBind() throws Exception {
+        URI uri1 = URI.create("https://localhost:8001/");
+        HashMap<String, Object> options1 = new HashMap<String, Object>();
+        options1.put("tcp.bind", "7777");
+
+        URI uri2 = URI.create("https://localhost:8001/");
+        HashMap<String, Object> options2 = new HashMap<String, Object>();
+
+
+        ResourceAddress address1 = addressFactory.newResourceAddress(uri1, options1);
+        ResourceAddress address2 = addressFactory.newResourceAddress(uri2, options2);
+
+        Bindings.Binding binding1 = new Bindings.Binding(address1, handler, initializer);
+        Bindings.Binding binding2 = new Bindings.Binding(address2, handler, initializer);
+
+        Bindings.Binding oldBinding = httpBindings.addBinding(binding1);
+        assertNull(oldBinding);
+        oldBinding = httpBindings.addBinding(binding2);
+        assertNull(oldBinding);
+    }
+
+    @Test
     public void testAddHttpBindingTwiceShouldIncrementHttpBindingBindingReferenceCount() throws Exception {
         URI fooURI = URI.create("http://example.com/foo");
         ResourceAddress address = addressFactory.newResourceAddress(fooURI, makeOpts());

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnAcceptorTest.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnAcceptorTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.mina.core.future.IoFuture;
 import org.apache.mina.core.service.IoHandler;
 import org.junit.After;
 import org.junit.Before;
@@ -44,6 +45,8 @@ import org.kaazing.gateway.transport.nio.internal.NioSocketConnector;
 import org.kaazing.gateway.transport.ws.WsAcceptor;
 import org.kaazing.gateway.util.scheduler.SchedulerProvider;
 import org.kaazing.mina.core.future.UnbindFuture;
+
+import static org.junit.Assert.assertTrue;
 
 public class WsnAcceptorTest {
 
@@ -176,4 +179,29 @@ public class WsnAcceptorTest {
         System.out.println(wsnAcceptor.bindings());
     }
 
+    @Test
+    public void shouldBindWsxAddressesWithTcpBind() throws Exception {
+        URI uri1 = URI.create("wsx://localhost:8001/");
+        HashMap<String, Object> options1 = new HashMap<String, Object>();
+        options1.put("tcp.bind", "7777");
+
+        URI uri2 = URI.create("wsx://localhost:8001/");
+        HashMap<String, Object> options2 = new HashMap<String, Object>();
+
+        ResourceAddress address1 = addressFactory.newResourceAddress(uri1, options1);
+        ResourceAddress address2 = addressFactory.newResourceAddress(uri2, options2);
+
+        final IoHandler ioHandler = new IoHandlerAdapter();
+        wsnAcceptor.bind(address1, ioHandler, null);
+        wsnAcceptor.bind(address2, ioHandler, null);
+
+        IoFuture future1 = wsnAcceptor.unbind(address1);
+        IoFuture future2 = wsnAcceptor.unbind(address2);
+        future1.await(5, TimeUnit.SECONDS);
+        future2.await(5, TimeUnit.SECONDS);
+
+        assertTrue(wsnAcceptor.emptyBindings());
+        assertTrue(httpAcceptor.emptyBindings());
+        assertTrue(tcpAcceptor.emptyBindings());
+    }
 }


### PR DESCRIPTION
The following address were conflicting since the origin was not
matched for tcp addresses.
http://localhost:8001/
  tcp://localhost:8001

http://localhost:8001/
  tcp://localhost:7777

Now the floor transport is compared to fix this. That means
the special floor check on HttpBindings is removed.