### PR TITLE
Forward port: report "Early termination of IO session" and "Network collectivity has been lost

### DIFF
--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
@@ -347,7 +347,7 @@ public class HttpAcceptor extends AbstractBridgeAcceptor<DefaultHttpSession, Htt
 
             DefaultHttpSession httpSession = SESSION_KEY.remove(session);
             if (httpSession != null && !httpSession.isClosing()) {
-                httpSession.reset(new Exception("Early termination of IO session").fillInStackTrace());
+                httpSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
             }
         }
 

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
@@ -35,6 +35,7 @@ import static org.kaazing.gateway.transport.http.HttpHeaders.HEADER_CONTENT_LENG
 import static org.kaazing.gateway.transport.http.bridge.filter.HttpNextProtocolHeaderFilter.PROTOCOL_HTTPXE_1_1;
 import static org.kaazing.gateway.transport.http.bridge.filter.HttpProtocolFilter.PROTOCOL_HTTP_1_1;
 
+import java.io.IOException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -453,7 +454,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
         protected void doSessionClosed(IoSessionEx session) throws Exception {
             DefaultHttpSession httpSession = HTTP_SESSION_KEY.remove(session);
             if (httpSession != null && !httpSession.isClosing()) {
-                httpSession.reset(new Exception("Early termination of IO session").fillInStackTrace());
+                httpSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
                 return;
             }
 

--- a/transport/sse/src/main/java/org/kaazing/gateway/transport/sse/SseAcceptor.java
+++ b/transport/sse/src/main/java/org/kaazing/gateway/transport/sse/SseAcceptor.java
@@ -26,6 +26,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.mina.core.session.IdleStatus.WRITER_IDLE;
 import static org.kaazing.gateway.resource.address.ResourceAddress.TRANSPORT;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
@@ -289,7 +290,7 @@ public class SseAcceptor extends AbstractBridgeAcceptor<SseSession, Binding> {
         protected void doSessionClosed(HttpAcceptSession session) throws Exception {
             SseSession sseSession = SSE_SESSION_KEY.remove(session);
             if (sseSession != null && !sseSession.isClosing()) {
-                sseSession.reset(new Exception("Early termination of IO session").fillInStackTrace());
+                sseSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
             }
 
             IoFilterChain filterChain = session.getFilterChain();
@@ -670,7 +671,7 @@ public class SseAcceptor extends AbstractBridgeAcceptor<SseSession, Binding> {
                 IoSession parent = sseSession.getParent();
                 if (parent == null || parent.isClosing()) {
                     // behave similarly to connection reset by peer at NIO layer
-                    sseSession.reset(new Exception("Early termination of IO session").fillInStackTrace());
+                    sseSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
                 }
             }
         }

--- a/transport/sse/src/main/java/org/kaazing/gateway/transport/sse/SseConnector.java
+++ b/transport/sse/src/main/java/org/kaazing/gateway/transport/sse/SseConnector.java
@@ -23,6 +23,7 @@ package org.kaazing.gateway.transport.sse;
 
 import static java.lang.String.format;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
@@ -256,7 +257,7 @@ public class SseConnector extends AbstractBridgeConnector<SseSession> {
             }
         }
         else {
-            sseSession.reset(new Exception("Early termination of IO session").fillInStackTrace());
+            sseSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
         }
     }
 

--- a/transport/ssl/src/main/java/org/kaazing/gateway/transport/ssl/SslAcceptor.java
+++ b/transport/ssl/src/main/java/org/kaazing/gateway/transport/ssl/SslAcceptor.java
@@ -73,6 +73,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Resource;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import java.io.IOException;
 import java.net.URI;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -572,7 +573,7 @@ public class SslAcceptor extends AbstractBridgeAcceptor<SslSession, NextProtocol
                     sslSession.getProcessor().remove(sslSession);
                 } else {
                     // behave similarly to connection reset by peer at NIO layer
-                    sslSession.reset(new Exception("Early termination of IO session").fillInStackTrace());
+                    sslSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
                 }
             }
         }

--- a/transport/ssl/src/main/java/org/kaazing/gateway/transport/ssl/SslConnector.java
+++ b/transport/ssl/src/main/java/org/kaazing/gateway/transport/ssl/SslConnector.java
@@ -30,6 +30,7 @@ import static org.kaazing.gateway.resource.address.ssl.SslResourceAddress.WANT_C
 import static org.kaazing.gateway.transport.BridgeSession.LOCAL_ADDRESS;
 import static java.lang.String.format;
 
+import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -390,7 +391,7 @@ public class SslConnector extends AbstractBridgeConnector<SslSession> {
         	if (sslSession != null) {
         	    if (!sslSession.isClosing()) {
         	        // behave similarly to connection reset by peer at NIO layer
-        	        sslSession.reset(new Exception("Early termination of IO session").fillInStackTrace());
+        	        sslSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
         	    }
         	}
         	else {

--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
@@ -43,6 +43,7 @@ import static org.kaazing.gateway.transport.ws.util.WsUtils.negotiateWebSocketPr
 import static org.kaazing.gateway.transport.wsn.WsnSession.SESSION_KEY;
 import static org.kaazing.mina.core.buffer.IoBufferEx.FLAG_NONE;
 
+import java.io.IOException;
 import java.net.ProtocolException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -715,7 +716,7 @@ public class WsnAcceptor extends AbstractBridgeAcceptor<WsnSession, WsnBindings.
         protected void doSessionClosed(IoSessionEx session) throws Exception {
             WsnSession wsnSession = SESSION_KEY.remove(session);
             if (wsnSession != null && !wsnSession.isClosing()) {
-                wsnSession.reset(new Exception("Network connectivity has been lost or transport was closed at other end").fillInStackTrace());
+                wsnSession.reset(new IOException("Network connectivity has been lost or transport was closed at other end").fillInStackTrace());
             }
 
             IoFilterChain filterChain = session.getFilterChain();

--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnConnector.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnConnector.java
@@ -27,6 +27,7 @@ import static org.kaazing.gateway.resource.address.ResourceAddress.ALTERNATE;
 import static org.kaazing.gateway.resource.address.ResourceAddress.NEXT_PROTOCOL;
 import static org.kaazing.gateway.transport.wsn.WsnSession.SESSION_KEY;
 
+import java.io.IOException;
 import java.net.ConnectException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -477,7 +478,7 @@ public class WsnConnector extends AbstractBridgeConnector<WsnSession> {
             WsnSession wsnSession = SESSION_KEY.remove(session);
             if (wsnSession != null && !wsnSession.isClosing()) {
                 // TODO: require WebSocket controlled close handshake
-                wsnSession.reset(new Exception("Early termination of IO session").fillInStackTrace());
+                wsnSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
             }
         }
 


### PR DESCRIPTION
…or transport was closed at other end" exception as IOException not just vanilla Exception so exceptionCaught on higher transport levels or services can handle them specifically.

(John reviewed the [original 4.0 changes](https://github.com/kaazing-private/gateway.server/pull/58))