### PR TITLE
HTTP HEAD method resources may have Content-Length without content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <hazelcast.version>1.9.4.8</hazelcast.version>
-        <k3po.version>2.1.0</k3po.version>
+        <k3po.version>develop-SNAPSHOT</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
         <slf4j.log4j.version>1.7.5</slf4j.log4j.version>
@@ -197,6 +197,12 @@
                 <artifactId>gateway.truststore</artifactId>
                 <version>[1.0.0.0,1.1.0.0)</version>
                 <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>specification.http</artifactId>
+                <version>${k3po.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <hazelcast.version>1.9.4.8</hazelcast.version>
-        <k3po.version>develop-SNAPSHOT</k3po.version>
+        <k3po.version>2.1.0</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
         <slf4j.log4j.version>1.7.5</slf4j.log4j.version>

--- a/service/http.proxy/pom.xml
+++ b/service/http.proxy/pom.xml
@@ -67,6 +67,11 @@
             <classifier>keystore</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>specification.http</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.head.method.rpt
@@ -33,9 +33,6 @@ read "Server: Apache-Coyote/1.1\r\n"
 read "Set-Cookie: JSESSIONID=A2DA686DD40F58A3344B63CE81146785; Path=/examples/; HttpOnly\r\n"
 read "\r\n"
 
-close
-closed
-
 #
 # tomcat server
 #
@@ -60,6 +57,3 @@ write "Content-Type: text/html;charset=ISO-8859-1\r\n"
 write "Content-Length: 357\r\n"
 write "Date: Tue, 10 Feb 2015 02:17:15 GMT\r\n"
 write "\r\n"
-
-close
-closed

--- a/transport/http/pom.xml
+++ b/transport/http/pom.xml
@@ -159,6 +159,11 @@
             <artifactId>jmock-script</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>specification.http</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
@@ -88,7 +88,7 @@ import org.slf4j.LoggerFactory;
 public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
 
     private static final TypedAttributeKey<Callable<DefaultHttpSession>> HTTP_SESSION_FACTORY_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpSessionFactory");
-    public static final TypedAttributeKey<HttpSession> HTTP_SESSION_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpSession");
+    public static final TypedAttributeKey<DefaultHttpSession> HTTP_SESSION_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpSession");
     private static final TypedAttributeKey<ConnectFuture> HTTP_CONNECT_FUTURE_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpConnectFuture");
 
     
@@ -446,7 +446,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
 
         @Override
         protected void doSessionClosed(IoSessionEx session) throws Exception {
-            DefaultHttpSession httpSession = (DefaultHttpSession) HTTP_SESSION_KEY.remove(session);
+            DefaultHttpSession httpSession = HTTP_SESSION_KEY.remove(session);
             if (httpSession != null && !httpSession.isClosing()) {
                 httpSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
                 return;
@@ -492,7 +492,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
             // TODO: if content is complete then suspendRead on iosession
             // TODO: in processor when complete resume iosession read (parent)
 
-            DefaultHttpSession httpSession = (DefaultHttpSession) HTTP_SESSION_KEY.get(session);
+            DefaultHttpSession httpSession = HTTP_SESSION_KEY.get(session);
             HttpMessage httpMessage = (HttpMessage) message;
             switch (httpMessage.getKind()) {
             case RESPONSE:

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
@@ -88,7 +88,7 @@ import org.slf4j.LoggerFactory;
 public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
 
     private static final TypedAttributeKey<Callable<DefaultHttpSession>> HTTP_SESSION_FACTORY_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpSessionFactory");
-    private static final TypedAttributeKey<DefaultHttpSession> HTTP_SESSION_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpSession");
+    public static final TypedAttributeKey<HttpSession> HTTP_SESSION_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpSession");
     private static final TypedAttributeKey<ConnectFuture> HTTP_CONNECT_FUTURE_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpConnectFuture");
 
     
@@ -446,7 +446,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
 
         @Override
         protected void doSessionClosed(IoSessionEx session) throws Exception {
-            DefaultHttpSession httpSession = HTTP_SESSION_KEY.remove(session);
+            DefaultHttpSession httpSession = (DefaultHttpSession) HTTP_SESSION_KEY.remove(session);
             if (httpSession != null && !httpSession.isClosing()) {
                 httpSession.reset(new IOException("Early termination of IO session").fillInStackTrace());
                 return;
@@ -492,7 +492,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
             // TODO: if content is complete then suspendRead on iosession
             // TODO: in processor when complete resume iosession read (parent)
 
-            DefaultHttpSession httpSession = HTTP_SESSION_KEY.get(session);
+            DefaultHttpSession httpSession = (DefaultHttpSession) HTTP_SESSION_KEY.get(session);
             HttpMessage httpMessage = (HttpMessage) message;
             switch (httpMessage.getKind()) {
             case RESPONSE:

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpResponseDecoder.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpResponseDecoder.java
@@ -17,6 +17,9 @@ package org.kaazing.gateway.transport.http.bridge.filter;
 
 import org.apache.mina.core.session.IoSession;
 import org.apache.mina.filter.codec.statemachine.DecodingState;
+import org.kaazing.gateway.transport.http.HttpConnector;
+import org.kaazing.gateway.transport.http.HttpMethod;
+import org.kaazing.gateway.transport.http.HttpSession;
 import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
 import org.kaazing.mina.core.session.IoSessionEx;
 
@@ -26,7 +29,8 @@ public class HttpResponseDecoder extends HttpMessageDecoder {
 	protected DecodingState initDecodingState(IoSession session) {
         IoSessionEx sessionEx = (IoSessionEx) session;
         IoBufferAllocatorEx<?> allocator = sessionEx.getBufferAllocator();
-		return new HttpResponseDecodingState(allocator);
+		HttpSession httpSession = HttpConnector.HTTP_SESSION_KEY.get(session);
+		return new HttpResponseDecodingState(allocator, httpSession);
 	}
 
 }

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpConnectorRule.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpConnectorRule.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.http;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.mina.core.future.ConnectFuture;
+import org.apache.mina.core.service.IoHandler;
+import org.apache.mina.core.session.IoSessionInitializer;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.kaazing.gateway.resource.address.ResourceAddress;
+import org.kaazing.gateway.resource.address.ResourceAddressFactory;
+import org.kaazing.gateway.transport.BridgeServiceFactory;
+import org.kaazing.gateway.transport.TransportFactory;
+import org.kaazing.gateway.transport.nio.internal.NioSocketAcceptor;
+import org.kaazing.gateway.transport.nio.internal.NioSocketConnector;
+import org.kaazing.gateway.util.scheduler.SchedulerProvider;
+
+
+/**
+ * Declaring an instance of this class as a @Rule causes the gateway to be
+ * started in process before each test method and stopped after it. The rule
+ * can be chained with a K3poRule for use with robot (this causes Robot to be
+ * started before the gateway and stopped after it).
+ */
+public class HttpConnectorRule implements TestRule {
+
+    private ResourceAddressFactory addressFactory;
+    private HttpConnector httpConnector;
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new ConnectorStatement(base);
+    }
+
+    public ConnectFuture connect(String connect, IoHandler connectHandler, IoSessionInitializer<? extends ConnectFuture> initializer) {
+        Map<String, Object> connectOptions = new HashMap<>();
+        ResourceAddress connectAddress =
+                addressFactory.newResourceAddress(URI.create(connect), connectOptions);
+
+        return httpConnector.connect(connectAddress, connectHandler, initializer);
+    }
+
+    private final class ConnectorStatement extends Statement {
+
+        private final Statement base;
+
+        private NioSocketConnector tcpConnector;
+        private NioSocketAcceptor tcpAcceptor;
+        private SchedulerProvider schedulerProvider;
+
+        public ConnectorStatement(Statement base) {
+            this.base = base;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            try {
+                // Connector setup
+                schedulerProvider = new SchedulerProvider();
+
+                addressFactory = ResourceAddressFactory.newResourceAddressFactory();
+                TransportFactory transportFactory = TransportFactory.newTransportFactory(Collections.<String, Object> emptyMap());
+                BridgeServiceFactory serviceFactory = new BridgeServiceFactory(transportFactory);
+
+                tcpAcceptor = (NioSocketAcceptor)transportFactory.getTransport("tcp").getAcceptor();
+                tcpAcceptor.setResourceAddressFactory(addressFactory);
+                tcpAcceptor.setBridgeServiceFactory(serviceFactory);
+                tcpAcceptor.setSchedulerProvider(schedulerProvider);
+
+                tcpConnector = (NioSocketConnector)transportFactory.getTransport("tcp").getConnector();
+                tcpConnector.setResourceAddressFactory(addressFactory);
+                tcpConnector.setBridgeServiceFactory(serviceFactory);
+                tcpConnector.setTcpAcceptor(tcpAcceptor);
+
+                httpConnector = (HttpConnector)transportFactory.getTransport("http").getConnector();
+                httpConnector.setBridgeServiceFactory(serviceFactory);
+                httpConnector.setResourceAddressFactory(addressFactory);
+
+                base.evaluate();
+            } finally {
+                tcpConnector.dispose();
+                tcpAcceptor.dispose();
+                httpConnector.dispose();
+                schedulerProvider.shutdownNow();
+            }
+        }
+
+    }
+}

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/connector/specification/rfc7230/MessageFormatIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/connector/specification/rfc7230/MessageFormatIT.java
@@ -50,6 +50,7 @@ import org.kaazing.mina.core.session.IoSessionEx;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 
+@org.junit.Ignore
 public class MessageFormatIT {
 
     private final HttpConnectorRule connector = new HttpConnectorRule();

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/connector/specification/rfc7230/MessageFormatIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/connector/specification/rfc7230/MessageFormatIT.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.http.connector.specification.rfc7230;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+import static org.junit.rules.RuleChain.outerRule;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+import org.apache.mina.core.filterchain.IoFilterChain;
+import org.apache.mina.core.future.ConnectFuture;
+import org.apache.mina.core.service.IoHandler;
+import org.apache.mina.core.session.IoSession;
+import org.apache.mina.core.session.IoSessionInitializer;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.api.Invocation;
+import org.jmock.lib.action.CustomAction;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.gateway.transport.http.DefaultHttpSession;
+import org.kaazing.gateway.transport.http.HttpConnectSession;
+import org.kaazing.gateway.transport.http.HttpConnectorRule;
+import org.kaazing.gateway.transport.http.HttpMethod;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
+import org.kaazing.mina.core.buffer.IoBufferEx;
+import org.kaazing.mina.core.session.IoSessionEx;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+
+public class MessageFormatIT {
+
+    private final HttpConnectorRule connector = new HttpConnectorRule();
+    private final K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/http/rfc7230/message.format");
+
+    @Rule
+    public TestRule chain = createRuleChain(connector, k3po);
+
+    private Mockery context;
+
+    @Before
+    public void initialize() {
+        context = new Mockery();
+        context.setThreadingPolicy(new Synchroniser());
+    }
+
+    @Test
+    @Specification({
+            "head.response.must.not.have.content.though.may.have.content.length/response" })
+    public void headResponseMustNotHaveContentThoughMayHaveContentLength() throws Exception {
+        final IoHandler handler = context.mock(IoHandler.class);
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        context.checking(new Expectations() {
+            {
+                oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
+                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                allowing(handler).messageReceived(with(any(IoSessionEx.class)), with(any(Object.class)));
+                allowing(handler).exceptionCaught(with(any(IoSessionEx.class)), with(any(Throwable.class)));
+                oneOf(handler).sessionClosed(with(any(IoSessionEx.class)));
+                will(new CustomAction("Latch countdown") {
+                    @Override
+                    public Object invoke(Invocation invocation) throws Throwable {
+                        latch.countDown();
+                        return null;
+                    }
+                });
+            }
+        });
+
+        ConnectFuture connectFuture = connector.connect("http://localhost:8080/", handler, new ConnectSessionInitializer());
+        connectFuture.awaitUninterruptibly();
+        assertTrue(connectFuture.isConnected());
+
+        assertTrue(latch.await(10, SECONDS));
+        context.assertIsSatisfied();
+
+        k3po.finish();
+    }
+
+    private static class ConnectSessionInitializer implements IoSessionInitializer<ConnectFuture> {
+        @Override
+        public void initializeSession(IoSession session, ConnectFuture future) {
+            HttpConnectSession connectSession = (HttpConnectSession) session;
+            connectSession.setMethod(HttpMethod.HEAD);
+        }
+    }
+
+}

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/connector/specification/rfc7230/MessageFormatIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/connector/specification/rfc7230/MessageFormatIT.java
@@ -50,7 +50,7 @@ import org.kaazing.mina.core.session.IoSessionEx;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 
-@org.junit.Ignore
+@org.junit.Ignore("The head response test passes even without fix")
 public class MessageFormatIT {
 
     private final HttpConnectorRule connector = new HttpConnectorRule();


### PR DESCRIPTION
Fixing HttpResponseDecodingState by keeping tracking of HttpSession (so HttpMethod)
and not wait for content