### PR TITLE
wsn session may be null when there is an exception

### DIFF
--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
@@ -694,7 +694,9 @@ public class WsnAcceptor extends AbstractBridgeAcceptor<WsnSession, WsnBindings.
             }
 
             WsnSession wsnSession = SESSION_KEY.get(session);
-            wsnSession.setCloseException(cause);
+            if (wsnSession != null) {
+                wsnSession.setCloseException(cause);
+            }
 
             session.close(true);
         }


### PR DESCRIPTION
wsn session may be null when there is an exception (for e.g. wsn session is not even created, and i/o error happened on http layer). Guarding against it.