### PR TITLE
If the parent session is already closed, ssl filter would be null.

### DIFF
--- a/transport/ssl/src/main/java/org/kaazing/gateway/transport/ssl/SslConnectProcessor.java
+++ b/transport/ssl/src/main/java/org/kaazing/gateway/transport/ssl/SslConnectProcessor.java
@@ -43,12 +43,14 @@ public class SslConnectProcessor extends BridgeConnectProcessor<SslSession> {
                 IoSession parent = session.getParent();
                 IoFilterChain filterChain = parent.getFilterChain();
                 Entry entry = filterChain.getEntry(SslFilter.class);
-                SslFilter sslFilter = (SslFilter)entry.getFilter();
-                if (sslFilter.isSslStarted(parent)) {
-                    // unsecuring the session will trigger
-                    //  parent close from SslConnector
-                    sslFilter.stopSsl(parent);
-                    return;
+                if (entry != null) {
+                    SslFilter sslFilter = (SslFilter) entry.getFilter();
+                    if (sslFilter.isSslStarted(parent)) {
+                        // unsecuring the session will trigger
+                        //  parent close from SslConnector
+                        sslFilter.stopSsl(parent);
+                        return;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Guarding against it (forward porting from 4.x)