### PR TITLE
Adding round trip latency for websocket sessions(it gives meaningful values on…

### DIFF
--- a/management/src/main/java/org/kaazing/gateway/management/jmx/SessionMXBean.java
+++ b/management/src/main/java/org/kaazing/gateway/management/jmx/SessionMXBean.java
@@ -47,4 +47,8 @@ public interface SessionMXBean /*extends SessionManagementListener*/ {
     String getSessionTypeName();
 
     String getSessionDirection();
+
+    long getLastRoundTripLatency();
+
+    long getLastRoundTripLatencyTimestamp();
 }

--- a/management/src/main/java/org/kaazing/gateway/management/jmx/SessionMXBeanImpl.java
+++ b/management/src/main/java/org/kaazing/gateway/management/jmx/SessionMXBeanImpl.java
@@ -104,4 +104,14 @@ public class SessionMXBeanImpl implements SessionMXBean {
     public String getSessionDirection() {
         return sessionManagementBean.getSessionDirection();
     }
+
+    @Override
+    public long getLastRoundTripLatency() {
+        return sessionManagementBean.getLastRoundTripLatency();
+    }
+
+    @Override
+    public long getLastRoundTripLatencyTimestamp() {
+        return sessionManagementBean.getLastRoundTripLatencyTimestamp();
+    }
 }

--- a/management/src/main/java/org/kaazing/gateway/management/session/SessionManagementBean.java
+++ b/management/src/main/java/org/kaazing/gateway/management/session/SessionManagementBean.java
@@ -96,4 +96,9 @@ public interface SessionManagementBean extends ManagementBean {
     void doExceptionCaught(final Throwable cause) throws Exception;
 
     void doExceptionCaughtListeners(final Throwable cause);
+
+    long getLastRoundTripLatency();
+
+    long getLastRoundTripLatencyTimestamp();
+
 }

--- a/management/src/main/java/org/kaazing/gateway/management/session/SessionManagementBeanImpl.java
+++ b/management/src/main/java/org/kaazing/gateway/management/session/SessionManagementBeanImpl.java
@@ -34,6 +34,9 @@ import org.kaazing.mina.core.session.IoSessionEx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.kaazing.gateway.transport.ws.AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY;
+import static org.kaazing.gateway.transport.ws.AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY_TIMESTAMP;
+
 /**
  * Implementation of the management 'data' bean for a session. This just contains the data. Wrappers for different management
  * protocols define the use of those data.
@@ -391,4 +394,39 @@ public class SessionManagementBeanImpl extends AbstractManagementBean implements
             }
         });
     }
+
+    @Override
+    public long getLastRoundTripLatency() {
+        IoSessionEx session = getSession();
+        while (session != null) {
+            Long latency = LAST_ROUND_TRIP_LATENCY.get(session);
+            if (latency != null) {
+                return latency;
+            }
+            if (session instanceof BridgeSession) {
+                session = ((BridgeSession) session).getParent();
+            } else {
+                break;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public long getLastRoundTripLatencyTimestamp() {
+        IoSessionEx session = getSession();
+        while (session != null) {
+            Long latency = LAST_ROUND_TRIP_LATENCY_TIMESTAMP.get(session);
+            if (latency != null) {
+                return latency;
+            }
+            if (session instanceof BridgeSession) {
+                session = ((BridgeSession) session).getParent();
+            } else {
+                break;
+            }
+        }
+        return -1;
+    }
+
 }

--- a/management/src/test/java/org/kaazing/gateway/management/jmx/JmxRoundTripLatencyIT.java
+++ b/management/src/test/java/org/kaazing/gateway/management/jmx/JmxRoundTripLatencyIT.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.management.jmx;
+
+import static org.kaazing.gateway.management.test.util.TlsTestUtil.getKeystoreFileLocation;
+import static org.kaazing.gateway.management.test.util.TlsTestUtil.keyStore;
+import static org.kaazing.gateway.management.test.util.TlsTestUtil.password;
+import static org.kaazing.gateway.management.test.util.TlsTestUtil.trustStore;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+import static java.lang.System.currentTimeMillis;
+import static java.net.URI.create;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.security.KeyStore;
+import java.util.Set;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+
+import org.kaazing.gateway.management.test.util.JmxRule;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+
+public class JmxRoundTripLatencyIT {
+
+    private static final String JMX_URI = "service:jmx:rmi:///jndi/rmi://localhost:2020/jmxrmi";
+    private static final String WS_URI = "ws://localhost:8001/echo";
+    private static final String WSE_URI = "wse://localhost:8123/echo";
+
+    protected static final String ADMIN = "AUTHORIZED";
+
+    private final KeyStore keyStore = keyStore();
+    private final char[] password = password();
+    private final KeyStore trustStore = trustStore();
+
+    private K3poRule k3po = new K3poRule();
+
+    private GatewayRule gateway = new GatewayRule() {
+        {
+            // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                        .service()
+                            .accept(create(WSE_URI))
+                            .acceptOption("ws.inactivityTimeout", "2sec")
+                            .type("echo")
+                        .done()
+                        .service()
+                            .accept(create(WS_URI))
+                            .type("echo")
+                            .crossOrigin()
+                                .allowOrigin("*")
+                            .done()
+                            .acceptOption("ws.inactivityTimeout", "2sec")
+                        .done()
+                        .service()
+                            .property("connector.server.address", "jmx://localhost:2020/")
+                            .type("management.jmx")
+                            .authorization()
+                                .requireRole(ADMIN)
+                            .done()
+                            .realmName("jmxrealm")
+                        .done()
+                        .security()
+                            .trustStore(trustStore)
+                            .keyStore(keyStore)
+                            .keyStorePassword(password)
+                            .keyStoreFile(getKeystoreFileLocation())
+                            .realm()
+                                .name("jmxrealm")
+                                .description("realm for jmx")
+                                .httpChallengeScheme("Application Basic")
+                                .loginModule()
+                                    .type("class:com.kaazing.gateway.management.test.util.TestLoginModule")
+                                    .success("requisite")
+                                .done()
+                            .done()
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration);
+        }
+    };
+
+    private JmxRule jmxConnection = new JmxRule(JMX_URI);
+
+    @Rule
+    public TestRule chain = createRuleChain(gateway, k3po).around(jmxConnection);
+
+    @Specification("echoServiceToGetRoundTripLatencyAttributesFromJMX")
+    @Test
+    public void getRoundTripLatencyAttributesFromJmx() throws Exception {
+        Long latency = null;
+        Long latencyTimestamp = null;
+        Long currentTimestamp = currentTimeMillis();
+
+        k3po.start();
+
+        k3po.awaitBarrier("SESSION_ESTABLISHED");
+
+        MBeanServerConnection mbeanServerConn = jmxConnection.getConnection();
+        Set<ObjectName> mbeanNames = mbeanServerConn.queryNames(null, null);
+        String MBeanPrefix = "subtype=services,serviceType=echo,serviceId=\"" + WS_URI + "\",name=sessions";
+        for (ObjectName name : mbeanNames) {
+            if (name.toString().indexOf(MBeanPrefix) > 0) {
+                latency = (Long) mbeanServerConn.getAttribute(name, "LastRoundTripLatency");
+                latencyTimestamp = (Long) mbeanServerConn.getAttribute(name, "LastRoundTripLatencyTimestamp");
+            }
+        }
+
+        k3po.notifyBarrier("READ_LATENCY_ATTRIBUTES");
+
+        assertTrue("Could not retrieve Round Trip Latency from Jmx", latency > -1);
+        assertTrue("Could not retrieve Round Trip Latency Timestamp from Jmx", latencyTimestamp > currentTimestamp);
+
+        k3po.finish();
+    }
+
+    @Specification("echoServiceToGetWsebRoundTripLatencyAttributesFromJMX")
+    @Test
+    public void getWsebRoundTripLatencyAttributesFromJmx() throws Exception {
+        Long latency = null;
+        Long latencyTimestamp = null;
+        Long currentTimestamp = currentTimeMillis();
+
+        k3po.start();
+
+        k3po.awaitBarrier("SESSION_ESTABLISHED");
+
+        MBeanServerConnection mbeanServerConn = jmxConnection.getConnection();
+        Set<ObjectName> mbeanNames = mbeanServerConn.queryNames(null, null);
+        String MBeanPrefix = "subtype=services,serviceType=echo,serviceId=\"" + WSE_URI + "\",name=sessions";
+        for (ObjectName name : mbeanNames) {
+            if (name.toString().indexOf(MBeanPrefix) > 0) {
+                latency = (Long) mbeanServerConn.getAttribute(name, "LastRoundTripLatency");
+                latencyTimestamp = (Long) mbeanServerConn.getAttribute(name, "LastRoundTripLatencyTimestamp");
+            }
+        }
+
+        k3po.notifyBarrier("READ_LATENCY_ATTRIBUTES");
+
+        assertTrue("Could not retrieve Round Trip Latency from Jmx", latency > -1);
+        assertTrue("Could not retrieve Round Trip Latency Timestamp from Jmx", latencyTimestamp > currentTimestamp);
+
+        k3po.finish();
+    }
+
+}

--- a/management/src/test/java/org/kaazing/gateway/management/test/util/JmxRule.java
+++ b/management/src/test/java/org/kaazing/gateway/management/test/util/JmxRule.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.management.test.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import javax.management.remote.rmi.RMIConnectorServer;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+import javax.rmi.ssl.SslRMIServerSocketFactory;
+
+import org.junit.Assert;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class JmxRule implements TestRule {
+
+    private final String jmxURI;
+    private MBeanServerConnection connection;
+
+    public JmxRule(String jmxURI) {
+        this.jmxURI = jmxURI;
+    }
+
+    public MBeanServerConnection getConnection() {
+        return connection;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new JmxStatement(base);
+    }
+
+    public class JmxStatement extends Statement {
+
+        private final Statement base;
+
+        public JmxStatement(Statement base) {
+            this.base = base;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            /*
+             * Confirm system properties are properly set to use JMX
+             * 
+             * -Dcom.sun.management.jmxremote.authenticate=false
+             * -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false
+             * -Djava.rmi.server.hostname=localhost -Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts
+             */
+            Properties properties = System.getProperties();
+            Assert.assertEquals("false", properties.get("com.sun.management.jmxremote.authenticate"));
+            Assert.assertEquals("false", properties.get("com.sun.management.jmxremote.ssl"));
+            Assert.assertEquals("false", properties.get("com.sun.management.jmxremote.local.only"));
+            Assert.assertEquals("localhost", properties.get("java.rmi.server.hostname"));
+
+            Map<String, Object> env = new HashMap<String, Object>();
+            SslRMIClientSocketFactory csf = new SslRMIClientSocketFactory();
+            SslRMIServerSocketFactory ssf = new SslRMIServerSocketFactory();
+            env.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, csf);
+            env.put(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE, ssf);
+            env.put(JMXConnector.CREDENTIALS, new String[]{"admin", "admin"});
+            JMXConnector jmxConnector = JMXConnectorFactory.connect(new JMXServiceURL(jmxURI), env);
+            connection = jmxConnector.getMBeanServerConnection();
+            base.evaluate();
+        }
+
+    }
+
+}

--- a/management/src/test/java/org/kaazing/gateway/management/test/util/TestLoginModule.java
+++ b/management/src/test/java/org/kaazing/gateway/management/test/util/TestLoginModule.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.management.test.util;
+
+import java.security.Principal;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+/**
+ * Login module that always logs in
+ *
+ */
+public class TestLoginModule implements LoginModule {
+    private static final Principal ROLE_PRINCIPAL = new RolePrincipal();
+
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        subject.getPrincipals().add(ROLE_PRINCIPAL);
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+
+    static class RolePrincipal implements Principal {
+        @Override
+        public String getName() {
+            return "AUTHORIZED";
+        }
+    }
+
+}

--- a/management/src/test/java/org/kaazing/gateway/management/test/util/TlsTestUtil.java
+++ b/management/src/test/java/org/kaazing/gateway/management/test/util/TlsTestUtil.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.management.test.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.KeyStore;
+
+public class TlsTestUtil {
+    static final String keyStoreFileLocation = "target/truststore/keystore.db";
+
+    public static char[] password() {
+        return "ab987c".toCharArray();
+    }
+
+    public static KeyStore keyStore() {
+        try {
+            // Initialize KeyStore of gateway
+            KeyStore keyStore = KeyStore.getInstance("JCEKS");
+            FileInputStream kis = new FileInputStream(keyStoreFileLocation);
+            keyStore.load(kis, password());
+            kis.close();
+            return keyStore;
+        } catch (Exception e) {
+            File file = new File(keyStoreFileLocation);
+            throw new RuntimeException("Cannot create keystore" + file.getAbsolutePath(), e);
+        }
+    }
+
+    public static KeyStore trustStore() {
+        try {
+            // Initialize TrustStore of gateway
+            KeyStore trustStore = KeyStore.getInstance("JKS");
+            FileInputStream tis = new FileInputStream("target/truststore/truststore.db");
+            trustStore.load(tis, null);
+            tis.close();
+            return trustStore;
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot create truststore", e);
+        }
+    }
+
+    public static String getKeystoreFileLocation() {
+        return keyStoreFileLocation;
+    }
+}

--- a/management/src/test/scripts/org/kaazing/gateway/management/jmx/echoServiceToGetRoundTripLatencyAttributesFromJMX.rpt
+++ b/management/src/test/scripts/org/kaazing/gateway/management/jmx/echoServiceToGetRoundTripLatencyAttributesFromJMX.rpt
@@ -1,0 +1,61 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect tcp://127.0.0.1:8001
+connected
+
+# Connection request
+write "GET /echo?.kl=Y HTTP/1.1\r\n"
+write "Upgrade: websocket\r\n"
+write "Connection: Upgrade\r\n"
+write "Host: localhost:8001\r\n"
+write "Origin: http://localhost:8001\r\n"
+write "Sec-WebSocket-Key: nDaimG37f4nUqogPypithw==\r\n"
+write "Sec-WebSocket-Version: 13\r\n"
+write "\r\n"
+
+# 101 Response
+
+read "HTTP/1.1 101 Web Socket Protocol Handshake\r\n"
+read "Connection: Upgrade\r\n"
+read /Date: .*/ "\r\n"
+read /Sec-WebSocket-Accept: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "Upgrade: websocket\r\n"
+read "\r\n"
+
+# binary-encoded balancer directive - NO balance needed      
+read [0x82 0x04 0xEF 0x83 0xBF 0x4E]
+
+# Read PING
+read [0x89 0x00]
+
+# Send PONG response
+write [0x8a 0x00]
+
+# Read PING
+read [0x89 0x00]
+
+# Send PONG response
+write [0x8a 0x00]
+
+read notify SESSION_ESTABLISHED
+
+write await READ_LATENCY_ATTRIBUTES
+
+# Close connection
+close
+closed

--- a/management/src/test/scripts/org/kaazing/gateway/management/jmx/echoServiceToGetWsebRoundTripLatencyAttributesFromJMX.rpt
+++ b/management/src/test/scripts/org/kaazing/gateway/management/jmx/echoServiceToGetWsebRoundTripLatencyAttributesFromJMX.rpt
@@ -1,0 +1,154 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# create request (as done by .Net 3.5 client)
+
+connect tcp://localhost:8123
+connected
+
+# Send create request
+
+write "POST /;post/echo/;e/cb HTTP/1.1\r\n"
+write "X-WebSocket-Extensions: x-kaazing-http-revalidate\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Accept-Commands: ping\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8123\r\n"
+write "Content-Length: 3\r\n"
+write "Expect: 100-continue\r\n"
+write "Connection: Keep-Alive\r\n"
+write "\r\n"
+write ">|<"
+
+write notify CREATE_REQUESTED
+
+read await CREATE_REQUESTED
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Content-Length: 257\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read "X-WebSocket-Extensions: x-kaazing-http-revalidate; 56414C49\r\n"
+# read "Content-Length: 132\r\n"
+read "\r\n"
+# Example: http://localhost:8123/echo/;e/ub/fUOutUjjl9sgFumZWv1XySfdooieOf7e
+read "http://localhost:8123" /(?<up>.*)/ "\n"
+read "http://localhost:8123" /(?<down>.*)/ "\n"
+
+read notify CREATED
+
+# upstream request (PONG response) on same TCP connection
+write await PING_RECEIVED
+# write "POST /;post/echo/;e/ub/fUOutUjjl9sgFumZWv1XySfdooieOf7e HTTP/1.1\r\n"
+write "POST /;post"
+write ${up}
+write " HTTP/1.1\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "X-WebSocket-Extensions: x-kaazing-http-revalidate\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8123\r\n"
+write "Content-Length: 6\r\n"
+write "Expect: 100-continue\r\n"
+write "Connection: Close\r\n"
+write "\r\n"
+write [0x8a 0x00] # pong
+write [0x01 0x30 0x31 0xff] # reconnect
+write notify PONG_REPLY_SENT
+
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Length: 19\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+closed
+
+# downstream on separate TCP connection
+connect tcp://localhost:8123
+connected
+write await CREATED
+# write "POST /;post/echo/;e/db/fUOutUjjl9sgFumZWv1XySfdooieOf7e?.kf=0&.kp=2048&.kcc=private HTTP/1.1\r\n"
+write "POST /;post"
+write ${down}
+write "?.kf=0&.kp=2048&.kcc=private HTTP/1.1\r\n"
+write "Content-Type: text/plain\r\n"
+write "X-WebSocket-Extensions: x-kaazing-http-revalidate\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8123\r\n"
+write "Content-Length: 3\r\n"
+write "Expect: 100-continue\r\n"
+write "\r\n"
+write ">|<"
+write notify DOWNSTREAM_REQUESTED
+
+read await DOWNSTREAM_REQUESTED
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: private\r\n"
+read "Connection: close\r\n"
+read "Content-Type: application/octet-stream\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Type: application/octet-stream\r\n"
+read "X-Idle-Timeout: 5\r\n"
+read "\r\n"
+read [0x01 0x30 0x30 0xff] # NO-OP
+read [0x01]
+# Padding to 2048 bytes (0 is 0x30). The following line does not work unfortunately:
+# read /0*/ "0"
+read [0..2044]
+read [0xff]
+read [0x89 0x00]  # ping
+read notify PING_RECEIVED
+read await PONG_REPLY_SENT
+read [0x89 0x00]  # ping
+
+read notify SESSION_ESTABLISHED
+
+write await READ_LATENCY_ATTRIBUTES
+
+write "POST /;post"
+write ${up}
+write " HTTP/1.1\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "X-WebSocket-Extensions: x-kaazing-http-revalidate\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8123\r\n"
+write "Content-Length: 6\r\n"
+write "Expect: 100-continue\r\n"
+write "Connection: Close\r\n"
+write "\r\n"
+write [0x8a 0x00] # pong
+write [0x01 0x30 0x31 0xff] # reconnect
+
+closed

--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/AbstractWsBridgeSession.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/AbstractWsBridgeSession.java
@@ -33,6 +33,7 @@ import org.kaazing.gateway.server.spi.security.LoginResult;
 import org.kaazing.gateway.transport.AbstractBridgeSession;
 import org.kaazing.gateway.transport.BridgeServiceFactory;
 import org.kaazing.gateway.transport.Direction;
+import org.kaazing.gateway.transport.TypedAttributeKey;
 import org.kaazing.gateway.transport.ws.extension.WebSocketExtension;
 import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
 import org.kaazing.mina.core.buffer.IoBufferEx;
@@ -54,6 +55,11 @@ public abstract class AbstractWsBridgeSession<S extends IoSessionEx, B extends I
 
     // This logger logs websocket logout events, and must be mentioned explicitly to show up to customers.
     protected static final Logger logoutLogger = LoggerFactory.getLogger("session.logout");
+
+    public static final TypedAttributeKey<Long> LAST_ROUND_TRIP_LATENCY =
+            new TypedAttributeKey<>(AbstractWsBridgeSession.class, "lastRoundTripLatency");
+    public static final TypedAttributeKey<Long> LAST_ROUND_TRIP_LATENCY_TIMESTAMP =
+            new TypedAttributeKey<>(AbstractWsBridgeSession.class, "lastRoundTripLatencyTimestamp");
 
     protected BridgeServiceFactory bridgeServiceFactory;
     protected ResourceAddressFactory resourceAddressFactory;

--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/bridge/filter/WsCheckAliveFilter.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/bridge/filter/WsCheckAliveFilter.java
@@ -43,9 +43,11 @@ import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.future.IoFutureListener;
 import org.apache.mina.core.future.WriteFuture;
 import org.apache.mina.core.session.IdleStatus;
+import org.apache.mina.core.session.IoSession;
 import org.kaazing.gateway.resource.address.ws.WsResourceAddress;
 import org.kaazing.gateway.transport.AbstractBridgeSession;
 import org.kaazing.gateway.transport.IoFilterAdapter;
+import org.kaazing.gateway.transport.ws.AbstractWsBridgeSession;
 import org.kaazing.gateway.transport.ws.WsAcceptor;
 import org.kaazing.gateway.transport.ws.WsMessage;
 import org.kaazing.gateway.transport.ws.WsPingMessage;
@@ -73,6 +75,7 @@ public class WsCheckAliveFilter extends IoFilterAdapter<IoSessionEx> {
     // The following values are in milliseconds
     private final long maxExpectedRtt; // how long to wait for pong reply
     private final long pingDelay; // how long to wait before sending ping
+    private final IoSession wsSession;
 
     private enum NextAction {
         PONG, // ping has been written, awaiting pong
@@ -102,9 +105,14 @@ public class WsCheckAliveFilter extends IoFilterAdapter<IoSessionEx> {
     }
 
     public static void addIfFeatureEnabled(IoFilterChain filterChain, String filterName, long inactivityTimeoutIn, Logger logger) {
+        addIfFeatureEnabled(filterChain, filterName, inactivityTimeoutIn, null, logger);
+    }
+
+    public static void addIfFeatureEnabled(IoFilterChain filterChain, String filterName, long inactivityTimeoutIn,
+                                           IoSessionEx wsSession, Logger logger) {
         long inactivityTimeout = getInactivityTimeoutMillis(inactivityTimeoutIn, logger);
         if (inactivityTimeout > 0) {
-            filterChain.addLast(filterName, new WsCheckAliveFilter(inactivityTimeout, logger));
+            filterChain.addLast(filterName, new WsCheckAliveFilter(inactivityTimeout, wsSession, logger));
             if (logger.isDebugEnabled()) {
                 logger.debug(String.format("Configured WebSocket inactivity timeout (ws.inactivity.timeout) is %d milliseconds", inactivityTimeout));
             }
@@ -130,11 +138,16 @@ public class WsCheckAliveFilter extends IoFilterAdapter<IoSessionEx> {
     }
 
     WsCheckAliveFilter(long inactivityTimeout, Logger logger) {
+        this(inactivityTimeout, null, logger);
+    }
+
+    WsCheckAliveFilter(long inactivityTimeout, IoSession wsSession, Logger logger) {
         assert inactivityTimeout > 0;
         // KG-7057: Assume maximum possible round-trip time is half the configured inactivity timeout, but don't let it be 0
         this.maxExpectedRtt = Math.max(inactivityTimeout / 2, 1);
         this.pingDelay = maxExpectedRtt;
         this.logger = logger;
+        this.wsSession = wsSession;
     }
 
     @Override
@@ -154,15 +167,28 @@ public class WsCheckAliveFilter extends IoFilterAdapter<IoSessionEx> {
         WsMessage wsMessage = (WsMessage) message;
         switch (wsMessage.getKind()) {
         case PONG:
-            // Print out observed rtt to satisfy the curious
-            if (logger.isTraceEnabled()) {
-                long rtt = System.currentTimeMillis() - pingSentTime;
-                logger.trace(String.format("WsCheckAliveFilter: PONG received (%s), round-trip time = %d msec, nextAction = %s",
-                        wsMessage, rtt, nextAction));
-            }
             if (nextAction != NextAction.PONG) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace(String.format("WsCheckAliveFilter: Unsolicited PONG received (%s), nextAction = %s",
+                            wsMessage, nextAction));
+                }
                 // Unsolicited PONG from (rogue) client, ignore
                 return;
+            }
+
+            long roundTripTime = System.currentTimeMillis() - pingSentTime;
+            // Print out observed rtt to satisfy the curious
+            if (logger.isTraceEnabled()) {
+                logger.trace(String.format("WsCheckAliveFilter: PONG received (%s), round-trip time = %d msec, nextAction = %s",
+                        wsMessage, roundTripTime, nextAction));
+            }
+            if (wsSession != null) {
+                // wse case where session is not accessible for management
+                AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY.set(wsSession, roundTripTime);
+                AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY_TIMESTAMP.set(wsSession, pingSentTime);
+            } else {
+                AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY.set(session, roundTripTime);
+                AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY_TIMESTAMP.set(session, pingSentTime);
             }
             schedulePing(session);
             return;
@@ -253,8 +279,8 @@ public class WsCheckAliveFilter extends IoFilterAdapter<IoSessionEx> {
         if (logger.isTraceEnabled()) {
             logger.trace(String.format("Writing %s at time %d", emptyPing, System.currentTimeMillis()));
         }
-        WriteFuture written = session.write(emptyPing);
-        written.addListener(setPingTimeOnWrite);
+        pingSentTime = System.currentTimeMillis();
+        session.write(emptyPing);
     }
 
     // For unit test only

--- a/transport/ws/src/test/java/org/kaazing/gateway/transport/ws/bridge/filter/WsCheckAliveFilterTest.java
+++ b/transport/ws/src/test/java/org/kaazing/gateway/transport/ws/bridge/filter/WsCheckAliveFilterTest.java
@@ -225,6 +225,7 @@ public class WsCheckAliveFilterTest {
                 allowing(session).getBufferAllocator(); will(returnValue(SimpleBufferAllocator.BUFFER_ALLOCATOR));
                 oneOf(session).getConfig(); will(returnValue(config));
                 oneOf(config).setIdleTimeInMillis(IdleStatus.READER_IDLE, inactivityTimeout / 2);
+                allowing(session).setAttribute(with(any(Object.class)), with(any(Long.class)));
             }
         });
 
@@ -249,6 +250,7 @@ public class WsCheckAliveFilterTest {
                 allowing(logger).isTraceEnabled();
                 oneOf(session).getConfig(); will(returnValue(config));
                 oneOf(config).setIdleTimeInMillis(IdleStatus.READER_IDLE, 1L);
+                allowing(session).setAttribute(with(any(Object.class)), with(any(Long.class)));
             }
         });
 
@@ -277,6 +279,7 @@ public class WsCheckAliveFilterTest {
                 allowing(logger).isTraceEnabled();
                 allowing(session).getConfig(); will(returnValue(config));
                 oneOf(config).setIdleTimeInMillis(IdleStatus.READER_IDLE, inactivityTimeout / 2);
+                allowing(session).setAttribute(with(any(Object.class)), with(any(Long.class)));
             }
         });
 

--- a/transport/wseb/src/main/java/org/kaazing/gateway/transport/wseb/WsebInactivityTracker.java
+++ b/transport/wseb/src/main/java/org/kaazing/gateway/transport/wseb/WsebInactivityTracker.java
@@ -76,7 +76,7 @@ class WsebInactivityTracker implements IoSessionIdleTracker {
         ALREADY_TRACKED.set(wsebSession, true);
         idleTracker.addSession(transportSession);
         WsCheckAliveFilter.addIfFeatureEnabled(transportSession.getFilterChain(), CHECK_ALIVE_FILTER, 
-                ((WsebSession)wsebSession).getLocalAddress().getOption(INACTIVITY_TIMEOUT), logger);
+                ((WsebSession) wsebSession).getLocalAddress().getOption(INACTIVITY_TIMEOUT), wsebSession, logger);
     }
 
     @Override

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebRoundTripLatencyIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/WsebRoundTripLatencyIT.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.wseb;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.kaazing.gateway.server.Launcher;
+import org.kaazing.gateway.server.context.GatewayContext;
+import org.kaazing.gateway.server.test.Gateway;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.service.ServiceContext;
+import org.kaazing.gateway.transport.BridgeSession;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.mina.core.session.IoSessionEx;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.System.currentTimeMillis;
+import static java.net.URI.create;
+import static org.junit.Assert.assertTrue;
+import static org.kaazing.gateway.transport.ws.AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY;
+import static org.kaazing.gateway.transport.ws.AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY_TIMESTAMP;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+public class WsebRoundTripLatencyIT {
+
+    private K3poRule k3po = new K3poRule();
+    private GatewayContext context;
+    private final Launcher launcher = new Launcher();
+
+    @Before
+    public void StartGateway() throws Throwable {
+        // @formatter:off
+        GatewayConfiguration configuration =
+                new GatewayConfigurationBuilder()
+                    .service()
+                        .accept(create("wse://localhost:8123/echo"))
+                        .acceptOption("ws.inactivity.timeout", "2sec")
+                        .type("echo")
+                    .done()
+                .done();
+        // @formatter:on
+
+        context = new Gateway().createGatewayContext(configuration);
+        launcher.init(context);
+    }
+
+    @After
+    public void StopGateway() throws Throwable {
+        context = null;
+        launcher.destroy();
+    }
+
+    @Rule
+    public TestRule chain = createRuleChain(k3po, 15, TimeUnit.SECONDS);
+
+    @Specification("shouldPropagateWseRoundTripLatencyAttributesToSession")
+    @Test
+    public void shouldPropagateRoundTripLatencyAttributesToSession() throws Exception {
+        Long latency = null;
+        Long latencyTimestamp = null;
+        Long currentTimestamp = currentTimeMillis();
+
+        k3po.start();
+
+        k3po.awaitBarrier("SESSION_ESTABLISHED");
+
+        for (ServiceContext serviceContext : context.getServices()) {
+            for (IoSessionEx session : serviceContext.getActiveSessions()) {
+                while (session != null) {
+                    latency = LAST_ROUND_TRIP_LATENCY.get(session);
+                    latencyTimestamp = LAST_ROUND_TRIP_LATENCY_TIMESTAMP.get(session);
+                    if (latency == null && session instanceof BridgeSession) {
+                        session = ((BridgeSession) session).getParent();
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        k3po.notifyBarrier("READ_LATENCY_ATTRIBUTES");
+
+        assertTrue("Could not retrieve Round Trip Latency from Jmx", latency != null && latency > -1);
+        assertTrue("Could not retrieve Round Trip Latency Timestamp from Jmx", latencyTimestamp > currentTimestamp);
+
+        k3po.finish();
+    }
+
+}

--- a/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/shouldPropagateWseRoundTripLatencyAttributesToSession.rpt
+++ b/transport/wseb/src/test/scripts/org/kaazing/gateway/transport/wseb/shouldPropagateWseRoundTripLatencyAttributesToSession.rpt
@@ -1,0 +1,152 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# create request (as done by .Net 3.5 client)
+
+connect tcp://localhost:8123
+connected
+
+# Send create request
+
+write "POST /;post/echo/;e/cb HTTP/1.1\r\n"
+write "X-WebSocket-Extensions: x-kaazing-http-revalidate\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Accept-Commands: ping\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8123\r\n"
+write "Content-Length: 3\r\n"
+write "Expect: 100-continue\r\n"
+write "Connection: Keep-Alive\r\n"
+write "\r\n"
+write ">|<"
+
+write notify CREATE_REQUESTED
+
+read await CREATE_REQUESTED
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read "Content-Length: 196\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read "\r\n"
+# Example: http://localhost:8123/echo/;e/ub/fUOutUjjl9sgFumZWv1XySfdooieOf7e
+read "http://localhost:8123" /(?<up>.*)/ "\n"
+read "http://localhost:8123" /(?<down>.*)/ "\n"
+
+read notify CREATED
+
+# upstream request (PONG response) on same TCP connection
+write await PING_RECEIVED
+# write "POST /;post/echo/;e/ub/fUOutUjjl9sgFumZWv1XySfdooieOf7e HTTP/1.1\r\n"
+write "POST /;post"
+write ${up}
+write " HTTP/1.1\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "X-WebSocket-Extensions: x-kaazing-http-revalidate\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8123\r\n"
+write "Content-Length: 6\r\n"
+write "Expect: 100-continue\r\n"
+write "Connection: Close\r\n"
+write "\r\n"
+write [0x8a 0x00] # pong
+write [0x01 0x30 0x31 0xff] # reconnect
+write notify PONG_REPLY_SENT
+
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Length: 19\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+closed
+
+# downstream on separate TCP connection
+connect tcp://localhost:8123
+connected
+write await CREATED
+# write "POST /;post/echo/;e/db/fUOutUjjl9sgFumZWv1XySfdooieOf7e?.kf=0&.kp=2048&.kcc=private HTTP/1.1\r\n"
+write "POST /;post"
+write ${down}
+write "?.kf=0&.kp=2048&.kcc=private HTTP/1.1\r\n"
+write "Content-Type: text/plain\r\n"
+write "X-WebSocket-Extensions: x-kaazing-http-revalidate\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8123\r\n"
+write "Content-Length: 3\r\n"
+write "Expect: 100-continue\r\n"
+write "\r\n"
+write ">|<"
+write notify DOWNSTREAM_REQUESTED
+
+read await DOWNSTREAM_REQUESTED
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: private\r\n"
+read "Connection: close\r\n"
+read "Content-Type: application/octet-stream\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Type: application/octet-stream\r\n"
+read "X-Idle-Timeout: 5\r\n"
+read "\r\n"
+read [0x01 0x30 0x30 0xff] # NO-OP
+read [0x01]
+# Padding to 2048 bytes (0 is 0x30). The following line does not work unfortunately:
+# read /0*/ "0"
+read [0..2044]
+read [0xff]
+read [0x89 0x00]  # ping
+read notify PING_RECEIVED
+read await PONG_REPLY_SENT
+read [0x89 0x00]  # ping
+
+read notify SESSION_ESTABLISHED
+
+write await READ_LATENCY_ATTRIBUTES
+
+write "POST /;post"
+write ${up}
+write " HTTP/1.1\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "X-WebSocket-Extensions: x-kaazing-http-revalidate\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "X-Origin: privileged://localhost:8123\r\n"
+write "X-Origin-privileged%3A%2F%2Flocalhost%3A8123: privileged://localhost:8123\r\n"
+write "Host: localhost:8123\r\n"
+write "Content-Length: 6\r\n"
+write "Expect: 100-continue\r\n"
+write "Connection: Close\r\n"
+write "\r\n"
+write [0x8a 0x00] # pong
+write [0x01 0x30 0x31 0xff] # reconnect
+
+closed

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnRoundTripLatencyIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnRoundTripLatencyIT.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.wsn;
+
+import org.apache.log4j.PropertyConfigurator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.kaazing.gateway.server.Launcher;
+import org.kaazing.gateway.server.context.GatewayContext;
+import org.kaazing.gateway.server.test.Gateway;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.service.ServiceContext;
+import org.kaazing.gateway.transport.BridgeSession;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.mina.core.session.IoSessionEx;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.System.currentTimeMillis;
+import static java.net.URI.create;
+import static org.junit.Assert.assertTrue;
+import static org.kaazing.gateway.transport.ws.AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY;
+import static org.kaazing.gateway.transport.ws.AbstractWsBridgeSession.LAST_ROUND_TRIP_LATENCY_TIMESTAMP;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+public class WsnRoundTripLatencyIT {
+
+    private K3poRule k3po = new K3poRule();
+    private GatewayContext context;
+    private final Launcher launcher = new Launcher();
+
+    private static final boolean ENABLE_DIAGNOSTICS = false;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        if (ENABLE_DIAGNOSTICS) {
+            PropertyConfigurator.configure("src/test/resources/log4j-diagnostic.properties");
+        }
+    }
+
+    @Before
+    public void StartGateway() throws Throwable {
+        // @formatter:off
+        GatewayConfiguration configuration = new GatewayConfigurationBuilder()
+                .service()
+                    .accept(create("ws://localhost:8001/echo"))
+                    .type("echo")
+                    .crossOrigin()
+                        .allowOrigin("*")
+                    .done()
+                    .acceptOption("ws.inactivity.timeout", "2sec")
+                .done()
+            .done();
+        // @formatter:on
+
+        context = new Gateway().createGatewayContext(configuration);
+        launcher.init(context);
+    }
+
+    @After
+    public void StopGateway() throws Throwable {
+        context = null;
+        launcher.destroy();
+    }
+
+    @Rule
+    public TestRule chain = createRuleChain(k3po, 10, TimeUnit.SECONDS);
+
+    @Specification("shouldPropagateRoundTripLatencyToSession")
+    @Test
+    public void shouldPropagateRoundTripLatencyAttributesToSession() throws Exception {
+        Long latency = null;
+        Long latencyTimestamp = null;
+        Long currentTimestamp = currentTimeMillis();
+
+        k3po.start();
+
+        k3po.awaitBarrier("SESSION_ESTABLISHED");
+
+        for (ServiceContext serviceContext : context.getServices()) {
+            for (IoSessionEx session : serviceContext.getActiveSessions()) {
+                while (session != null) {
+                    latency = LAST_ROUND_TRIP_LATENCY.get(session);
+                    latencyTimestamp = LAST_ROUND_TRIP_LATENCY_TIMESTAMP.get(session);
+                    if (latency == null && session instanceof BridgeSession) {
+                        session = ((BridgeSession) session).getParent();
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        k3po.notifyBarrier("READ_LATENCY_ATTRIBUTES");
+
+        assertTrue("Could not retrieve Round Trip Latency from Jmx", latency > -1);
+        assertTrue("Could not retrieve Round Trip Latency Timestamp from Jmx", latencyTimestamp > currentTimestamp);
+
+        k3po.finish();
+    }
+
+}

--- a/transport/wsn/src/test/scripts/org/kaazing/gateway/transport/wsn/shouldPropagateRoundTripLatencyToSession.rpt
+++ b/transport/wsn/src/test/scripts/org/kaazing/gateway/transport/wsn/shouldPropagateRoundTripLatencyToSession.rpt
@@ -1,0 +1,61 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect tcp://127.0.0.1:8001
+connected
+
+# Connection request
+write "GET /echo?.kl=Y HTTP/1.1\r\n"
+write "Upgrade: websocket\r\n"
+write "Connection: Upgrade\r\n"
+write "Host: localhost:8001\r\n"
+write "Origin: http://localhost:8001\r\n"
+write "Sec-WebSocket-Key: nDaimG37f4nUqogPypithw==\r\n"
+write "Sec-WebSocket-Version: 13\r\n"
+write "\r\n"
+
+# 101 Response
+
+read "HTTP/1.1 101 Web Socket Protocol Handshake\r\n"
+read "Connection: Upgrade\r\n"
+read /Date: .*/ "\r\n"
+read /Sec-WebSocket-Accept: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "Upgrade: websocket\r\n"
+read "\r\n"
+
+# binary-encoded balancer directive - NO balance needed      
+read [0x82 0x04 0xEF 0x83 0xBF 0x4E]
+
+# Read PING
+read [0x89 0x00]
+
+# Send PONG response
+write [0x8a 0x00]
+
+# Read PING
+read [0x89 0x00]
+
+# Send PONG response
+write [0x8a 0x00]
+
+read notify SESSION_ESTABLISHED
+
+write await READ_LATENCY_ATTRIBUTES
+
+# Close connection
+close
+closed


### PR DESCRIPTION
Adding round trip latency for session (it gives meaningful values only for
websocket sessions) beans and is exposed via JMX. It piggybacks on
inactivity timeout functionality for websocket sessions. 

This is being forward-ported from 4.x