### PR TITLE
Forward Port to 5.x: Transport logging fixes (ipv6, wseb, remove /) #87

### DIFF
--- a/transport/nio/src/test/java/org/kaazing/gateway/transport/nio/internal/NioSocketAcceptorTest.java
+++ b/transport/nio/src/test/java/org/kaazing/gateway/transport/nio/internal/NioSocketAcceptorTest.java
@@ -630,10 +630,12 @@ public class NioSocketAcceptorTest {
                 allowing(mockSession).getLocalAddress(); will(returnValue(bindAddress));
                 oneOf(mockSession).close(with(any(boolean.class)));
                 allowing(mockSession).getFilterChain(); will(returnValue(mockFilterChain));
+                allowing(mockSession).getRemoteAddress(); will(returnValue(bindAddress));
+                allowing(mockSession).getService(); will(returnValue(mockAcceptor));
 
                 allowing(mockSession).getTransportMetadata();
                 will(returnValue(transportMetadata));
-                allowing(transportMetadata).getAddressType();
+                allowing(transportMetadata).getAddressType(); will(returnValue(SocketAddress.class));
 
                 allowing(mockFilterChain).addFirst(with(any(String.class)), with(any(IoFilter.class)));
                 allowing(mockFilterChain).addLast(with(any(String.class)), with(any(IoFilter.class)));

--- a/transport/spi/pom.xml
+++ b/transport/spi/pom.xml
@@ -60,6 +60,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.resource.address.http</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.resource.address.ws</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock-junit4</artifactId>
             <scope>test</scope>

--- a/transport/spi/pom.xml
+++ b/transport/spi/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>gateway.util</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+ 
         <!-- for shared test utility classes used by transports -->
         <dependency>
             <groupId>org.jmock</groupId>
@@ -64,7 +64,11 @@
             <artifactId>jmock-junit4</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jmock</groupId>
+            <artifactId>jmock-legacy</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/transport/spi/src/test/java/org/kaazing/gateway/transport/LoggingFilterTest.java
+++ b/transport/spi/src/test/java/org/kaazing/gateway/transport/LoggingFilterTest.java
@@ -17,27 +17,33 @@
 package org.kaazing.gateway.transport;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 
 import org.apache.mina.core.filterchain.IoFilter.NextFilter;
+import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.service.IoAcceptor;
+import org.apache.mina.core.service.IoConnector;
 import org.apache.mina.core.service.TransportMetadata;
 import org.apache.mina.core.session.IoSession;
 import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import org.kaazing.gateway.resource.address.ResourceAddress;
+import org.kaazing.gateway.resource.address.ResourceAddressFactories;
+import org.kaazing.gateway.resource.address.ResourceAddressFactory;
+import org.kaazing.gateway.resource.address.ws.WsResourceAddress;
 import org.kaazing.gateway.transport.test.Expectations;
+import org.kaazing.gateway.transport.AbstractBridgeAcceptor;
 import org.kaazing.gateway.transport.LoggingFilter;
-import org.kaazing.gateway.transport.BridgeSession;
 import org.kaazing.gateway.transport.ExceptionLoggingFilter;
-import org.kaazing.mina.core.service.IoServiceEx;
-import org.kaazing.mina.core.session.IoSessionEx;
 
 public class LoggingFilterTest {
     
@@ -85,59 +91,173 @@ public class LoggingFilterTest {
     }
     
     @Test
-    public void getUserIdentifierShouldReturnNull() throws Exception {
+    public void getUserIdentifierShouldReturnLocalAddress() throws Exception {
         final TransportMetadata transportMetadata = context.mock(TransportMetadata.class);
-        final BridgeSession bridgeSession = context.mock(BridgeSession.class, "bridgeSession");
+        final IoConnector connector = context.mock(IoConnector.class, "connector");
+        
+        final InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("localhost"), 2121);
         
         context.checking(new Expectations() {
             {
-                oneOf(bridgeSession).getTransportMetadata(); will(returnValue(transportMetadata));
+                oneOf(session).getService(); will(returnValue(connector));
+                oneOf(session).getLocalAddress(); will(returnValue(address));
+                oneOf(session).getTransportMetadata(); will(returnValue(transportMetadata));
                 oneOf(transportMetadata).getAddressType(); will(returnValue(Object.class));
-                oneOf(bridgeSession).getParent();
+                
             }
         });
-        assertNull(LoggingFilter.getUserIdentifier(bridgeSession));
+        assertEquals(address.toString(), LoggingFilter.getUserIdentifier(session));
     }
     
     @Test
-    public void getUserIdentifierShouldReturnTcpEndpoint() throws Exception {
+    public void getUserIdentifierShouldReturnRemoteIpv4AddressForIoAcceptor() throws Exception {
         final TransportMetadata transportMetadata = context.mock(TransportMetadata.class);
         final IoAcceptor service = context.mock(IoAcceptor.class, "service");
 
-        final InetSocketAddress remoteAddress = new InetSocketAddress(InetAddress.getByName("localhost"), 2121);
+        final InetSocketAddress address = new InetSocketAddress(InetAddress.getByAddress(new byte[]{127,0,0,1}), 2121);
         
         context.checking(new Expectations() {
             {
                 oneOf(session).getService(); will(returnValue(service));
+                oneOf(session).getRemoteAddress(); will(returnValue(address));
                 oneOf(session).getTransportMetadata(); will(returnValue(transportMetadata));
                 oneOf(transportMetadata).getAddressType(); will(returnValue(InetSocketAddress.class));
-                oneOf(session).getRemoteAddress(); will(returnValue(remoteAddress));
             }
         });
-        assertEquals(remoteAddress.toString(), LoggingFilter.getUserIdentifier(session));
+        assertEquals("127.0.0.1:2121", LoggingFilter.getUserIdentifier(session));
     }
     
     @Test
-    public void getUserIdentifierShouldReturnTcpEndpointFromParent() throws Exception {
+    public void getUserIdentifierShouldReturnIpv6AddressForIoAcceptor() throws Exception {
         final TransportMetadata transportMetadata = context.mock(TransportMetadata.class);
-        final BridgeSession bridgeSession = context.mock(BridgeSession.class, "bridgeSession");
-        final IoSessionEx parent = context.mock(IoSessionEx.class, "parent");
-        final IoServiceEx service = context.mock(IoServiceEx.class, "service");
+        final IoAcceptor service = context.mock(IoAcceptor.class, "service");
 
-        final InetSocketAddress localAddress = new InetSocketAddress(InetAddress.getByName("localhost"), 2121);
+        final InetSocketAddress address = new InetSocketAddress(InetAddress.getByAddress(
+                new byte[]{(byte) 0xfe, (byte) 0x80, 0, 0, 0, 0, 0, 0, (byte) 0x90,
+                        (byte) 0xea, 0x3e, (byte) 0xe4, 0x77, (byte) 0xad, 0x77, (byte) 0xec}), 2121);
+
+        context.checking(new Expectations() {
+            {
+
+                oneOf(session).getService(); will(returnValue(service));
+                oneOf(session).getRemoteAddress(); will(returnValue(address));
+                oneOf(session).getTransportMetadata(); will(returnValue(transportMetadata));
+                oneOf(transportMetadata).getAddressType(); will(returnValue(InetSocketAddress.class));
+            }
+        });
+        assertEquals("fe80:0:0:0:90ea:3ee4:77ad:77ec:2121", LoggingFilter.getUserIdentifier(session));
+    }
+    
+    @Test
+    public void getUserIdentifierShouldReturnScopedIpv6AddressForIoAcceptor() throws Exception {
+        final TransportMetadata transportMetadata = context.mock(TransportMetadata.class);
+        final IoAcceptor service = context.mock(IoAcceptor.class, "service");
+
+        final InetSocketAddress address = new InetSocketAddress(Inet6Address.getByAddress(
+                null,
+                new byte[]{(byte) 0xfe, (byte) 0x80, 0, 0, 0, 0, 0, 0, (byte) 0x90, (byte) 0xea, 0x3e,
+                           (byte) 0xe4, 0x77, (byte) 0xad, 0x77, (byte) 0xec},
+                15),
+                2121);
         
         context.checking(new Expectations() {
             {
-                oneOf(bridgeSession).getTransportMetadata(); will(returnValue(transportMetadata));
-                oneOf(transportMetadata).getAddressType(); will(returnValue(Object.class));
-                oneOf(bridgeSession).getParent(); will(returnValue(parent));
-                oneOf(parent).getService(); will(returnValue(service));
-                oneOf(parent).getTransportMetadata(); will(returnValue(transportMetadata));
+                oneOf(session).getService(); will(returnValue(service));
+                oneOf(session).getRemoteAddress(); will(returnValue(address));
+                oneOf(session).getTransportMetadata(); will(returnValue(transportMetadata));
                 oneOf(transportMetadata).getAddressType(); will(returnValue(InetSocketAddress.class));
-                oneOf(parent).getLocalAddress(); will(returnValue(localAddress));
             }
         });
-        assertEquals(localAddress.toString(), LoggingFilter.getUserIdentifier(bridgeSession));
+        assertEquals("fe80:0:0:0:90ea:3ee4:77ad:77ec%15:2121", LoggingFilter.getUserIdentifier(session));
+    }
+    
+    @Test
+    public void getUserIdentifierShouldReturnRemoteAddressForBridgeAcceptor() throws Exception {
+        context.setImposteriser(ClassImposteriser.INSTANCE);
+        final TransportMetadata transportMetadata = context.mock(TransportMetadata.class);
+        final AbstractBridgeAcceptor<?, ?> service = context.mock(AbstractBridgeAcceptor.class, "service");
+
+        final InetSocketAddress address = new InetSocketAddress(InetAddress.getByAddress(new byte[]{127,0,0,1}), 2121);
+        
+        context.checking(new Expectations() {
+            {
+                oneOf(session).getService(); will(returnValue(service));
+                oneOf(session).getRemoteAddress(); will(returnValue(address));
+                oneOf(session).getTransportMetadata(); will(returnValue(transportMetadata));
+                oneOf(transportMetadata).getAddressType(); will(returnValue(InetSocketAddress.class));
+            }
+        });
+        assertEquals("127.0.0.1:2121", LoggingFilter.getUserIdentifier(session));
+    }
+    
+    @Test
+    public void getUserIdentifierShouldReturnTcpEndpointFromTransport() throws Exception {
+        context.setImposteriser(ClassImposteriser.INSTANCE);
+        final ResourceAddress address = context.mock(ResourceAddress.class, "address");
+
+        ResourceAddressFactory addressFactory = ResourceAddressFactories.newResourceAddressFactory();
+        URI transportURI = URI.create("tcp://localhost:2121");
+        final ResourceAddress transport = addressFactory.newResourceAddress(transportURI);
+
+        final TransportMetadata transportMetadata = context.mock(TransportMetadata.class);
+        final IoAcceptor service = context.mock(IoAcceptor.class, "service");
+
+        context.checking(new Expectations() {
+            {
+                oneOf(session).getService(); will(returnValue(service));
+                oneOf(session).getRemoteAddress(); will(returnValue(address));
+                oneOf(address).getTransport(); will(returnValue(transport));
+                oneOf(session).getTransportMetadata(); will(returnValue(transportMetadata));
+                oneOf(transportMetadata).getAddressType(); will(returnValue(WsResourceAddress.class));
+            }
+        });
+        assertEquals("localhost:2121", LoggingFilter.getUserIdentifier(session));
+    }
+
+    @Test
+    public void getUserIdentifierShouldReturnTcpEndpointFromHttpAddress() throws Exception {
+        ResourceAddressFactory addressFactory = ResourceAddressFactories.newResourceAddressFactory();
+        URI addressURI = URI.create("http://localhost:2121/jms");
+        final ResourceAddress address = addressFactory.newResourceAddress(addressURI);
+
+        assertEquals("localhost:2121", LoggingFilter.getUserIdentifier(address));
+    }
+
+    @Test
+    public void getUserIdentifierShouldReturnTcpEndpointFromWsAddress() throws Exception {
+        ResourceAddressFactory addressFactory = ResourceAddressFactories.newResourceAddressFactory();
+        URI addressURI = URI.create("ws://localhost:2121/jms");
+        final ResourceAddress address = addressFactory.newResourceAddress(addressURI);
+
+        assertEquals("localhost:2121", LoggingFilter.getUserIdentifier(address));
+    }
+
+    @Test
+    public void shouldAddLoggingFilterWhenUserIdIsScopedIpv6Address() throws Exception {
+        final TransportMetadata transportMetadata = context.mock(TransportMetadata.class);
+        final IoConnector connector = context.mock(IoConnector.class, "connector");
+        final IoFilterChain filterChain = context.mock(IoFilterChain.class, "filterChain");
+        
+        final InetSocketAddress address = new InetSocketAddress(Inet6Address.getByAddress(
+                null,
+                new byte[]{(byte) 0xfe, (byte) 0x80, 0, 0, 0, 0, 0, 0, (byte) 0x90, (byte) 0xea, 0x3e,
+                           (byte) 0xe4, 0x77, (byte) 0xad, 0x77, (byte) 0xec},
+                15),
+                2121);
+
+        context.checking(new Expectations() {
+            {
+                oneOf(logger).isInfoEnabled(); will(returnValue(true));
+                oneOf(logger).isTraceEnabled(); will(returnValue(false));
+                oneOf(session).getService(); will(returnValue(connector));
+                oneOf(session).getLocalAddress(); will(returnValue(address));
+                oneOf(session).getTransportMetadata(); will(returnValue(transportMetadata));
+                oneOf(transportMetadata).getAddressType(); will(returnValue(Object.class));
+                oneOf(session).getFilterChain(); will(returnValue(filterChain));
+                oneOf(filterChain).addLast(with("tcp#logging"), with(any(ExceptionLoggingFilter.class)));
+            }
+        });
+        LoggingFilter.addIfNeeded(logger, session, "tcp");
     }
     
 }

--- a/transport/spi/src/test/java/org/kaazing/gateway/transport/LoggingFilterTest.java
+++ b/transport/spi/src/test/java/org/kaazing/gateway/transport/LoggingFilterTest.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.kaazing.gateway.resource.address.ResourceAddress;
 import org.kaazing.gateway.resource.address.ResourceAddressFactories;
 import org.kaazing.gateway.resource.address.ResourceAddressFactory;
-import org.kaazing.gateway.resource.address.ws.WsResourceAddress;
 import org.kaazing.gateway.transport.test.Expectations;
 import org.kaazing.gateway.transport.AbstractBridgeAcceptor;
 import org.kaazing.gateway.transport.LoggingFilter;
@@ -208,7 +207,6 @@ public class LoggingFilterTest {
                 oneOf(session).getRemoteAddress(); will(returnValue(address));
                 oneOf(address).getTransport(); will(returnValue(transport));
                 oneOf(session).getTransportMetadata(); will(returnValue(transportMetadata));
-                oneOf(transportMetadata).getAddressType(); will(returnValue(WsResourceAddress.class));
             }
         });
         assertEquals("localhost:2121", LoggingFilter.getUserIdentifier(session));

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/logging/WsebAcceptorLoggingIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/logging/WsebAcceptorLoggingIT.java
@@ -71,20 +71,20 @@ public class WsebAcceptorLoggingIT {
         k3po.finish();
 
         List<String> expectedPatterns = new ArrayList<String>(Arrays.asList(new String[] {
-            "tcp#.*OPENED",
-            "tcp#.*WRITE",
-            "tcp#.*RECEIVED",
-            "tcp#.*CLOSED",
-            "http#.*OPENED",
-            "http#.*WRITE",
-            "http#.*RECEIVED",
-            "http#.*EXCEPTION",
-            "http#.*CLOSED",
-            "wseb#.*OPENED",
-            "wseb#.*WRITE",
-            "wseb#.*RECEIVED",
-            "wseb#.*EXCEPTION",
-            "wseb#.*CLOSED"
+             "tcp#.* [^/]*:\\d*] OPENED",
+             "tcp#.* [^/]*:\\d*] WRITE",
+             "tcp#.* [^/]*:\\d*] RECEIVED",
+             "tcp#.* [^/]*:\\d*] CLOSED",
+             "http#.* [^/]*:\\d*] OPENED",
+             "http#.* [^/]*:\\d*] WRITE",
+             "http#.* [^/]*:\\d*] RECEIVED",
+             "http#.* [^/]*:\\d*] EXCEPTION",
+             "http#.* [^/]*:\\d*] CLOSED",
+             "wseb#.* [^/]*:\\d*] OPENED",
+             "wseb#.* [^/]*:\\d*] WRITE",
+             "wseb#.* [^/]*:\\d*] RECEIVED",
+             "wseb#.* [^/]*:\\d*] EXCEPTION",
+             "wseb#.* [^/]*:\\d*] CLOSED"
         }));
         
         List<String> forbiddenPatterns = Collections.emptyList();
@@ -100,16 +100,16 @@ public class WsebAcceptorLoggingIT {
         k3po.finish();
 
         List<String> expectedPatterns = new ArrayList<String>(Arrays.asList(new String[] {
-            "tcp#.*OPENED",
-            "tcp#.*WRITE",
-            "tcp#.*RECEIVED",
-            "tcp#.*CLOSED",
-            "http#.*OPENED",
-            "http#.*WRITE",
-            "http#.*RECEIVED",
-            "http#.*CLOSED",
-            "wseb#.*OPENED",
-            "wseb#.*CLOSED"
+             "\\[tcp#.* [^/]*:\\d*] OPENED",
+             "\\[tcp#.* [^/]*:\\d*] WRITE",
+             "\\[tcp#.* [^/]*:\\d*] RECEIVED",
+             "\\[tcp#.* [^/]*:\\d*] CLOSED",
+             "\\[http#.* [^/]*:\\d*] OPENED",
+             "\\[http#.* [^/]*:\\d*] WRITE",
+             "\\[http#.* [^/]*:\\d*] RECEIVED",
+             "\\[http#.* [^/]*:\\d*] CLOSED",
+             "\\[wseb#.* [^/]*:\\d*] OPENED",
+             "\\[wseb#.* [^/]*:\\d*] CLOSED"
         }));
         
         List<String> forbiddenPatterns = Arrays.asList("#.*EXCEPTION");

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/logging/WsebConnectorLoggingIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/logging/WsebConnectorLoggingIT.java
@@ -100,19 +100,19 @@ public class WsebConnectorLoggingIT {
         k3po.finish();
 
         List<String> expectedPatterns = new ArrayList<String>(Arrays.asList(new String[] {
-            "tcp#.*OPENED",
-            "tcp#.*WRITE",
-            "tcp#.*RECEIVED",
-            "tcp#.*CLOSED",
-            "http#.*OPENED",
-            "http#.*WRITE",
-            "http#.*RECEIVED",
-            "http#.*CLOSED",
-            "http#.*EXCEPTION.*IOException",
-            "wseb#.*OPENED",
-            "wseb#.*WRITE",
-            "wseb#.*RECEIVED",
-            "wseb#.*CLOSED"
+            "tcp#.* [^/]*:\\d*] OPENED",
+            "tcp#.* [^/]*:\\d*] WRITE",
+            "tcp#.* [^/]*:\\d*] RECEIVED",
+            "tcp#.* [^/]*:\\d*] CLOSED",
+            "http#.* [^/]*:\\d*] OPENED",
+            "http#.* [^/]*:\\d*] WRITE",
+            "http#.* [^/]*:\\d*] RECEIVED",
+            "http#.* [^/]*:\\d*] CLOSED",
+            "http#.* [^/]*:\\d*] EXCEPTION.*IOException",
+            "wseb#.* [^/]*:\\d*] OPENED",
+            "wseb#.* [^/]*:\\d*] WRITE",
+            "wseb#.* [^/]*:\\d*] RECEIVED",
+            "wseb#.* [^/]*:\\d*] CLOSED"
         }));
         
         List<String> forbiddenPatterns = null;
@@ -144,16 +144,16 @@ public class WsebConnectorLoggingIT {
         k3po.finish();
 
         List<String> expectedPatterns = new ArrayList<String>(Arrays.asList(new String[] {
-            "tcp#.*OPENED",
-            "tcp#.*WRITE",
-            "tcp#.*RECEIVED",
-            "tcp#.*CLOSED",
-            "http#.*OPENED",
-            "http#.*WRITE",
-            "http#.*RECEIVED",
-            "http#.*CLOSED",
-            "wseb#.*OPENED",
-            "wseb#.*CLOSED"
+            "tcp#.* [^/]*:\\d*] OPENED",
+            "tcp#.* [^/]*:\\d*] WRITE",
+            "tcp#.* [^/]*:\\d*] RECEIVED",
+            "tcp#.* [^/]*:\\d*] CLOSED",
+            "http#.* [^/]*:\\d*] OPENED",
+            "http#.* [^/]*:\\d*] WRITE",
+            "http#.* [^/]*:\\d*] RECEIVED",
+            "http#.* [^/]*:\\d*] CLOSED",
+            "wseb#.* [^/]*:\\d*] OPENED",
+            "wseb#.* [^/]*:\\d*] CLOSED"
         }));
         
         List<String> forbiddenPatterns = Arrays.asList("#.*EXCEPTION");

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/logging/WsnAcceptorLoggingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/logging/WsnAcceptorLoggingIT.java
@@ -84,17 +84,17 @@ public class WsnAcceptorLoggingIT {
     public void shouldLogOpenWriteReceivedAndAbruptClose() throws Exception {
         k3po.finish();
         List<String> expectedPatterns = new ArrayList<String>(Arrays.asList(new String[] {
-            "tcp#.*OPENED",
-            "tcp#.*WRITE",
-            "tcp#.*RECEIVED",
-            "tcp#.*CLOSED",
-            "http#.*OPENED",
-            "http#.*CLOSED",
-            "wsn#.*OPENED",
-            "wsn#.*WRITE",
-            "wsn#.*RECEIVED",
-            "wsn#.*EXCEPTION.*IOException",
-            "wsn#.*CLOSED"
+            "tcp#.* [^/]*:\\d*] OPENED", // example: [tcp#34 192.168.4.126:49966] OPENED: (...
+            "tcp#.* [^/]*:\\d*] WRITE",
+            "tcp#.* [^/]*:\\d*] RECEIVED",
+            "tcp#.* [^/]*:\\d*] CLOSED",
+            "http#.* [^/]*:\\d*] OPENED",
+            "http#.* [^/]*:\\d*] CLOSED",
+            "wsn#.* [^/]*:\\d*] OPENED",
+            "wsn#.* [^/]*:\\d*] WRITE",
+            "wsn#.* [^/]*:\\d*] RECEIVED",
+            "wsn#.* [^/]*:\\d*] EXCEPTION.*IOException",
+            "wsn#.* [^/]*:\\d*] CLOSED"
         }));
         List<String> forbiddenPatterns = null;
     
@@ -108,14 +108,14 @@ public class WsnAcceptorLoggingIT {
     public void shouldLogOpenAndCleanClose() throws Exception {
         k3po.finish();
         List<String> expectedPatterns = new ArrayList<String>(Arrays.asList(new String[] {
-            "tcp#.*OPENED",
-            "tcp#.*WRITE",
-            "tcp#.*RECEIVED",
-            "tcp#.*CLOSED",
-            "http#.*OPENED",
-            "http#.*CLOSED",
-            "wsn#.*OPENED",
-            "wsn#.*CLOSED"
+            "tcp#.* [^/]*:\\d*] OPENED",
+            "tcp#.* [^/]*:\\d*] WRITE",
+            "tcp#.* [^/]*:\\d*] RECEIVED",
+            "tcp#.* [^/]*:\\d*] CLOSED",
+            "http#.* [^/]*:\\d*] OPENED",
+            "http#.* [^/]*:\\d*] CLOSED",
+            "wsn#.* [^/]*:\\d*] OPENED",
+            "wsn#.* [^/]*:\\d*] CLOSED"
         }));
         List<String> forbiddenPatterns = Arrays.asList("#.*EXCEPTION");
     

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/logging/WsnConnectorLoggingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/logging/WsnConnectorLoggingIT.java
@@ -166,14 +166,14 @@ public class WsnConnectorLoggingIT {
         assertTrue(close.await(10, SECONDS));
 
         List<String> expectedPatterns = new ArrayList<String>(Arrays.asList(new String[] {
-            "tcp#.*OPENED",
-            "tcp#.*WRITE",
-            "tcp#.*RECEIVED",
-            "tcp#.*CLOSED",
-            "http#.*OPENED",
-            "http#.*CLOSED",
-            "wsn#.*OPENED",
-            "wsn#.*CLOSED"
+            "tcp#.* [^/]*:\\d*] OPENED",
+            "tcp#.* [^/]*:\\d*] WRITE",
+            "tcp#.* [^/]*:\\d*] RECEIVED",
+            "tcp#.* [^/]*:\\d*] CLOSED",
+            "http#.* [^/]*:\\d*] OPENED",
+            "http#.* [^/]*:\\d*] CLOSED",
+            "wsn#.* [^/]*:\\d*] OPENED",
+            "wsn#.* [^/]*:\\d*] CLOSED"
         }));
 
         List<String> forbiddenPatterns = Arrays.asList("#.*EXCEPTION");


### PR DESCRIPTION
Forward port from gateway.server 4.x of [Transport logging fixes (ipv6, wseb, remove /) ](https://github.com/kaazing-private/gateway.server/pull/87)