### PR TITLE
If a session is migrated, need to fire idle event on the migrated session

### DIFF
--- a/mina.netty/src/main/java/org/kaazing/mina/core/session/AbstractIoSessionEx.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/core/session/AbstractIoSessionEx.java
@@ -31,12 +31,16 @@ import org.kaazing.mina.core.filterchain.DefaultIoFilterChain;
 import org.kaazing.mina.core.filterchain.DefaultIoFilterChainEx;
 import org.kaazing.mina.core.service.IoProcessorEx;
 import org.kaazing.mina.core.write.WriteRequestEx;
+import org.kaazing.mina.netty.util.threadlocal.VicariousThreadLocal;
 
 /**
  * This class extends the functionality of AbstractIoSession to add support for thread alignment: the guarantee
  * that all operations on the session's filter chain take place in the same IO worker thread.
 */
 public abstract class AbstractIoSessionEx extends AbstractIoSession implements IoSessionEx {
+
+    // TODO: move to non-static on NioSocketChannelIoAcceptor / NioSocketChannelIoConnector
+    public static final ThreadLocal<Executor> CURRENT_WORKER = new VicariousThreadLocal<Executor>();
 
     private final boolean ioAligned;
     private final int ioLayer;

--- a/mina.netty/src/main/java/org/kaazing/mina/netty/socket/nio/NioSocketChannelIoSession.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/netty/socket/nio/NioSocketChannelIoSession.java
@@ -28,7 +28,6 @@ import org.jboss.netty.channel.socket.nio.NioWorker;
 import org.kaazing.mina.core.service.IoProcessorEx;
 import org.kaazing.mina.netty.ChannelIoService;
 import org.kaazing.mina.netty.ChannelIoSession;
-import org.kaazing.mina.netty.util.threadlocal.VicariousThreadLocal;
 
 /**
  * This session is always used in conjunction with an NioSocketChannel, which necessarily has an associated worker.
@@ -36,9 +35,6 @@ import org.kaazing.mina.netty.util.threadlocal.VicariousThreadLocal;
  * is made in another thread).
  */
 public class NioSocketChannelIoSession extends ChannelIoSession<NioSocketChannelConfig> {
-
-    // TODO: move to non-static on NioSocketChannelIoAcceptor / NioSocketChannelIoConnector
-    private static final ThreadLocal<WorkerExecutor> WORKER_EXECUTOR = new VicariousThreadLocal<WorkerExecutor>();
 
     public NioSocketChannelIoSession(ChannelIoService service, IoProcessorEx<ChannelIoSession<? extends ChannelConfig>>
         processor, NioSocketChannel channel) {
@@ -59,11 +55,11 @@ public class NioSocketChannelIoSession extends ChannelIoSession<NioSocketChannel
     }
 
     private static Executor asExecutor(NioWorker worker) {
-        WorkerExecutor executor = WORKER_EXECUTOR.get();
+        WorkerExecutor executor = (WorkerExecutor) CURRENT_WORKER.get();
         if (executor == null) {
             assert isInIoThread(worker) : "Session created from non-I/O thread";
             executor = new WorkerExecutor(worker);
-            WORKER_EXECUTOR.set(executor);
+            CURRENT_WORKER.set(executor);
         }
         assert executor.worker == worker : "Worker does not match I/O thread";
         return executor;


### PR DESCRIPTION
Forward Porting:
---------------------- 
If a session is migrated, need to fire idle event on the migrated session
* Moving WORKER_EXECUTOR to AbstractIoSessionEx and will be accessed by
  other layers.
* s/WORKER_EXECUTOR/CURRENT_WORKER