### PR TITLE
Adding timeout to WsnAcceptorTest

### DIFF
--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnAcceptorTest.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/WsnAcceptorTest.java
@@ -26,7 +26,9 @@ import org.apache.mina.core.future.IoFuture;
 import org.apache.mina.core.service.IoHandler;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.kaazing.gateway.resource.address.ResourceAddress;
 import org.kaazing.gateway.resource.address.ResourceAddressFactory;
 import org.kaazing.gateway.transport.BridgeServiceFactory;
@@ -40,9 +42,14 @@ import org.kaazing.gateway.transport.ws.WsAcceptor;
 import org.kaazing.gateway.util.scheduler.SchedulerProvider;
 import org.kaazing.mina.core.future.UnbindFuture;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
+import static org.kaazing.test.util.ITUtil.timeoutRule;
 
 public class WsnAcceptorTest {
+
+    @Rule
+    public final TestRule timeoutRule = timeoutRule(10, SECONDS);
 
     private SchedulerProvider schedulerProvider;
     


### PR DESCRIPTION
Travis hangs in this test. Adding timeout to see if it helps.