### PR TITLE
Not firing session idle after the session is closed

### DIFF
--- a/mina.netty/src/main/java/org/kaazing/mina/netty/DefaultIoSessionIdleTracker.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/netty/DefaultIoSessionIdleTracker.java
@@ -163,7 +163,7 @@ public final class DefaultIoSessionIdleTracker implements IoSessionIdleTracker {
             // after t0 + configured idleTime. Even if an I/O event occurred after t0, we may still need to fire sessionIdle.
             long timeUntilSessionIdle = startPoint + idleTimeMillis - currentTimeMillis();
             if (timeUntilSessionIdle <= 0 && idleTimeMillis != 0) {
-                if (session.getIoThread() != IoSessionEx.NO_THREAD) {
+                if (session.getIoThread() != IoSessionEx.NO_THREAD && !session.isClosing()) {
                     fireSessionIdle(session);
                 }
                 reschedule(idleTimeMillis);


### PR DESCRIPTION
I see that session idle may fire after the session is closed. This is causing failures in tests:
https://s3.amazonaws.com/archive.travis-ci.org/jobs/103181082/log.txt

Now, not firing the idle event after the session is closed.