### PR TITLE
Fixed issue regarding IndexOutOfBounds when no addresses available

### DIFF
--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResourceAddressFactorySpi.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResourceAddressFactorySpi.java
@@ -148,6 +148,10 @@ public abstract class ResourceAddressFactorySpi<T extends ResourceAddress> {
             alternate = address;
         }
 
+        if (addresses.size() == 0) {
+            throw new IllegalArgumentException(format("No addresses available for binding for URI: %s", location));
+        }
+
         return addresses.get(0);
     }
 
@@ -229,6 +233,10 @@ public abstract class ResourceAddressFactorySpi<T extends ResourceAddress> {
             }
 
             alternate = address;
+        }
+
+        if (addresses.size() == 0) {
+            throw new IllegalArgumentException(format("No addresses available for binding for URI: %s", location));
         }
 
         return addresses.get(0);

--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResourceAddressFactorySpi.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResourceAddressFactorySpi.java
@@ -148,7 +148,7 @@ public abstract class ResourceAddressFactorySpi<T extends ResourceAddress> {
             alternate = address;
         }
 
-        if (addresses.size() == 0) {
+        if (addresses.isEmpty()) {
             throw new IllegalArgumentException(format("No addresses available for binding for URI: %s", location));
         }
 
@@ -235,7 +235,7 @@ public abstract class ResourceAddressFactorySpi<T extends ResourceAddress> {
             alternate = address;
         }
 
-        if (addresses.size() == 0) {
+        if (addresses.isEmpty()) {
             throw new IllegalArgumentException(format("No addresses available for binding for URI: %s", location));
         }
 

--- a/server/src/test/java/org/kaazing/gateway/server/preferedipv4/ResourceAddressFactorySpiPreferIPV4Test.java
+++ b/server/src/test/java/org/kaazing/gateway/server/preferedipv4/ResourceAddressFactorySpiPreferIPV4Test.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.server.preferedipv4;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kaazing.gateway.server.test.Gateway;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+
+public class ResourceAddressFactorySpiPreferIPV4Test {
+	@Before
+    public void setUp() {
+		System.setProperty("java.net.preferIPv4Stack" , "true");
+    }
+
+    @After
+    public void tearDown() {
+    	System.setProperty("java.net.preferIPv4Stack" , "false");
+    }
+
+    @Test
+    public void testEmptyCollection() {
+    	GatewayConfiguration gc = new GatewayConfigurationBuilder().
+    			service().
+    				name("echo").
+    				type("echo")
+    				.accept(URI.create("ws://[::1]:8000/echo/")).
+    			done().
+    		done();
+
+    	Gateway gateway = new Gateway();
+    	
+    	try {
+    		gateway.start(gc);
+    		assertTrue("This should not be reached", false);
+    	} 
+    	catch (AssertionError e) {
+    		assertTrue(false); 
+    	}
+    	catch (Exception e) {
+    		assertTrue(
+    				"Exception message on binding",
+    				e.getMessage()
+    						.startsWith(
+    								"Error binding to ws://[::1]:8000/: Tried to bind address"));
+    	}
+
+    	try {
+    		gateway.stop();
+    	} catch (Exception e) {
+    		assertFalse(e instanceof java.lang.NullPointerException);
+    	}
+    }
+}

--- a/server/src/test/java/org/kaazing/gateway/transport/TestTransport.java
+++ b/server/src/test/java/org/kaazing/gateway/transport/TestTransport.java
@@ -15,7 +15,6 @@
  */
 package org.kaazing.gateway.transport;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,12 +55,12 @@ final class TestTransport extends Transport {
 
     @Override
     public BridgeAcceptor getAcceptor(ResourceAddress address) {
-        return null;
+        return acceptor;
     }
 
     @Override
     public BridgeConnector getConnector(ResourceAddress address) {
-        return null;
+        return connector;
     }
 
     @Override


### PR DESCRIPTION
Added fix by throwing an IllegalArgumentException when no addresses are available for binding: 
```
GATEWAY_OPTS=-Djava.net.preferIPv4Stack=true
```
and service accept host set to an IPv6 address.

In progress: adding a test case to validate the behavior.