### PR TITLE
Http.proxy identical <accept> and <connect> with no additional accept/connect options provokes Gateway timeout

### DIFF
--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultAcceptOptionsContext.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultAcceptOptionsContext.java
@@ -169,6 +169,7 @@ public class DefaultAcceptOptionsContext implements AcceptOptionsContext {
         }
     }
 
+    @Override
     public Map<String, Object> asOptionsMap() {
         Map<String, Object> result = new LinkedHashMap<>();
 

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
@@ -634,6 +634,13 @@ public class GatewayContextResolver {
             ConnectOptionsContext connectOptionsContext =
                     new DefaultConnectOptionsContext(connectOptions, defaultConnectOptions);
 
+            if (serviceType.equals("http.proxy") && acceptOptions == null && connectOptions == null) {
+                if (acceptURIs.contains(connectURIs.iterator().next())) {
+                    throw new RuntimeException(String.format("Different <accept> and <connect> URIs should"
+                            + " be provided for service of type %s", serviceType));
+                }
+            }
+
             Key encryptionKey = null;
 
             if (serviceRealmContext == null &&

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
@@ -634,13 +634,6 @@ public class GatewayContextResolver {
             ConnectOptionsContext connectOptionsContext =
                     new DefaultConnectOptionsContext(connectOptions, defaultConnectOptions);
 
-            if (serviceType.equals("http.proxy") && acceptOptions == null && connectOptions == null) {
-                if (acceptURIs.contains(connectURIs.iterator().next())) {
-                    throw new RuntimeException(String.format("Different <accept> and <connect> URIs should"
-                            + " be provided for service %s of type %s", serviceName, serviceType));
-                }
-            }
-
             Key encryptionKey = null;
 
             if (serviceRealmContext == null &&

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
@@ -637,7 +637,7 @@ public class GatewayContextResolver {
             if (serviceType.equals("http.proxy") && acceptOptions == null && connectOptions == null) {
                 if (acceptURIs.contains(connectURIs.iterator().next())) {
                     throw new RuntimeException(String.format("Different <accept> and <connect> URIs should"
-                            + " be provided for service of type %s", serviceType));
+                            + " be provided for service %s of type %s", serviceName, serviceType));
                 }
             }
 

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyIdenticalAcceptConnectIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyIdenticalAcceptConnectIT.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.service.http.proxy;
+
+import java.net.URI;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.kaazing.gateway.server.test.Gateway;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+
+public class HttpProxyIdenticalAcceptConnectIT {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldFailWhenIdenticalAcceptAndConnect() throws Exception {
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Different <accept> and <connect> URIs should be provided for service of type http.proxy");
+        Gateway gateway = new Gateway();
+        // @formatter:off
+        gateway.start(new GatewayConfigurationBuilder()
+                .service()
+                .accept(URI.create("http://localhost:8080/"))
+                .connect(URI.create("http://localhost:8080/"))
+                .type("http.proxy")
+            .done()
+        .done());
+        // @formatter:on
+    }
+}

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyIdenticalAcceptConnectIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyIdenticalAcceptConnectIT.java
@@ -17,6 +17,7 @@ package org.kaazing.gateway.service.http.proxy;
 
 import java.net.URI;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -24,21 +25,42 @@ import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 
 public class HttpProxyIdenticalAcceptConnectIT {
+    private Gateway gateway = new Gateway();
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @After
+    public void clear() throws Exception {
+        gateway.stop();
+    }
 
     @Test
     public void shouldFailWhenIdenticalAcceptAndConnect() throws Exception {
         thrown.expect(RuntimeException.class);
         thrown.expectMessage("Different <accept> and <connect> URIs should be provided for service of type http.proxy");
-        Gateway gateway = new Gateway();
         // @formatter:off
         gateway.start(new GatewayConfigurationBuilder()
                 .service()
                 .accept(URI.create("http://localhost:8080/"))
+                .accept(URI.create("http://localhost:8081/"))
                 .connect(URI.create("http://localhost:8080/"))
                 .type("http.proxy")
+            .done()
+        .done());
+        // @formatter:on
+    }
+
+    @Test
+    public void shouldNotFailWhenIdenticalAcceptAndConnectOptions() throws Exception {
+        // @formatter:off
+        gateway.start(new GatewayConfigurationBuilder()
+                .service()
+                .accept(URI.create("http://localhost:8080/"))
+                .accept(URI.create("http://localhost:8081/"))
+                .connect(URI.create("http://localhost:8080/"))
+                .type("http.proxy")
+                .connectOption("http.transport", "tcp://localhost:8081")
             .done()
         .done());
         // @formatter:on

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyIdenticalAcceptConnectIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyIdenticalAcceptConnectIT.java
@@ -38,7 +38,7 @@ public class HttpProxyIdenticalAcceptConnectIT {
     @Test
     public void shouldFailWhenIdenticalAcceptAndConnect() throws Exception {
         thrown.expect(RuntimeException.class);
-        thrown.expectMessage("Different <accept> and <connect> URIs should be provided for service of type http.proxy");
+        thrown.expectMessage("Different <accept> and <connect> URIs should be provided for service proxy serv of type http.proxy");
         // @formatter:off
         gateway.start(new GatewayConfigurationBuilder()
                 .service()
@@ -46,6 +46,7 @@ public class HttpProxyIdenticalAcceptConnectIT {
                 .accept(URI.create("http://localhost:8081/"))
                 .connect(URI.create("http://localhost:8080/"))
                 .type("http.proxy")
+                .name("proxy serv")
             .done()
         .done());
         // @formatter:on
@@ -60,6 +61,7 @@ public class HttpProxyIdenticalAcceptConnectIT {
                 .accept(URI.create("http://localhost:8081/"))
                 .connect(URI.create("http://localhost:8080/"))
                 .type("http.proxy")
+                .name("proxy serv")
                 .connectOption("http.transport", "tcp://localhost:8081")
             .done()
         .done());


### PR DESCRIPTION
Added a first version of a fix - TBD: discuss as to whether the proposed approach in GatewayContextResolver is sufficient.