### PR TITLE
Fixed org.kaazing.gateway.server.test.Gateway testware class not to swallow exceptions

### DIFF
--- a/server/src/main/java/org/kaazing/gateway/server/test/Gateway.java
+++ b/server/src/main/java/org/kaazing/gateway/server/test/Gateway.java
@@ -277,8 +277,7 @@ public class Gateway {
                 }
             }
         } catch (Exception e) {
-            // TODO
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -387,23 +386,24 @@ public class Gateway {
 
     private void appendAcceptOptions(ServiceType newService, ServiceConfiguration service) throws Exception {
         // accept-options
-        try {
-            Map<String, String> acceptOptions = service.getAcceptOptions();
-            if (!acceptOptions.isEmpty()) {
-                ServiceAcceptOptionsType newAcceptOptions = newService.addNewAcceptOptions();
-                Node domNode = newAcceptOptions.getDomNode();
-                Document ownerDocument = domNode.getOwnerDocument();
-                for (Entry<String, String> acceptOption : acceptOptions.entrySet()) {
+        Map<String, String> acceptOptions = service.getAcceptOptions();
+        if (!acceptOptions.isEmpty()) {
+            ServiceAcceptOptionsType newAcceptOptions = newService.addNewAcceptOptions();
+            Node domNode = newAcceptOptions.getDomNode();
+            Document ownerDocument = domNode.getOwnerDocument();
+            for (Entry<String, String> acceptOption : acceptOptions.entrySet()) {
+                try {
                     Element newElement = ownerDocument
                             .createElementNS(domNode.getNamespaceURI(), acceptOption.getKey());
                     Text newTextNode = ownerDocument.createTextNode(acceptOption.getValue());
                     newElement.appendChild(newTextNode);
                     domNode.appendChild(newElement);
+                } catch (Exception e) {
+                    String message = String.format("Processing of accept option %s %s failed with exception %s",
+                            acceptOption.getKey(), acceptOption.getValue(), e);
+                    throw new Exception(message, e);
                 }
             }
-        } catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
         }
     }
 
@@ -421,23 +421,25 @@ public class Gateway {
     }
 
     public void appendConnectOptions(ServiceType newService, ServiceConfiguration service) throws Exception {
-        try {
-            Map<String, String> connectOptions = service.getConnectOptions();
-            if (!connectOptions.isEmpty()) {
-                ServiceConnectOptionsType newConnectOptions = newService.addNewConnectOptions();
-                Node domNode = newConnectOptions.getDomNode();
-                Document ownerDocument = domNode.getOwnerDocument();
-                for (Entry<String, String> connectOption : connectOptions.entrySet()) {
-                    Element newElement = ownerDocument.createElementNS(domNode.getNamespaceURI(),
-                            connectOption.getKey());
-                    Text newTextNode = ownerDocument.createTextNode(connectOption.getValue());
-                    newElement.appendChild(newTextNode);
-                    domNode.appendChild(newElement);
+        Map<String, String> connectOptions = service.getConnectOptions();
+        if (!connectOptions.isEmpty()) {
+            ServiceConnectOptionsType newConnectOptions = newService.addNewConnectOptions();
+            Node domNode = newConnectOptions.getDomNode();
+            Document ownerDocument = domNode.getOwnerDocument();
+            for (Entry<String, String> connectOption : connectOptions.entrySet()) {
+                try {
+                Element newElement = ownerDocument.createElementNS(domNode.getNamespaceURI(),
+                        connectOption.getKey());
+                Text newTextNode = ownerDocument.createTextNode(connectOption.getValue());
+                newElement.appendChild(newTextNode);
+                domNode.appendChild(newElement);
+                }
+                catch (Exception e) {
+                    String message = String.format("Processing of connect option %s %s failed with exception %s",
+                            connectOption.getKey(), connectOption.getValue(), e);
+                    throw new Exception(message, e);
                 }
             }
-        } catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
caused by configuration issues, such as connect and accept options with names which are invalid XML element names (like "http[http/1.1].transport"). This was causing some tests to appear to succeed because they were not testing the functionality they thought they were.