### PR TITLE
Issue 427: thread alignment violation in wse due to race with client close

### DIFF
--- a/mina.netty/pom.xml
+++ b/mina.netty/pom.xml
@@ -132,10 +132,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.11</version>
+                <version>${checkstyle.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>validate</id>
                         <phase>validate</phase>
                         <configuration>
                             <encoding>UTF-8</encoding>
@@ -155,7 +154,7 @@
                     <dependency>
                         <groupId>org.kaazing</groupId>
                         <artifactId>code.quality</artifactId>
-                        <version>1.1</version>
+                        <version>${code.quality.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/mina.netty/src/main/java/org/kaazing/mina/netty/ChannelIoSession.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/netty/ChannelIoSession.java
@@ -38,6 +38,7 @@ public class ChannelIoSession<C extends ChannelConfig> extends AbstractIoSession
     private final IoHandler handler;
     private final IoProcessorEx<ChannelIoSession<? extends ChannelConfig>> processor;
     private final TransportMetadata transportMetadata;
+    private volatile boolean closedReceived;
 
     public ChannelIoSession(ChannelIoService service, IoProcessorEx<ChannelIoSession<? extends ChannelConfig>> processor,
             Channel channel, ChannelIoSessionConfig<C> config, Thread ioThread, Executor ioExecutor) {
@@ -107,6 +108,14 @@ public class ChannelIoSession<C extends ChannelConfig> extends AbstractIoSession
     @Override
     public void suspendRead() {
         channel.setReadable(false);
+    }
+
+    protected boolean isClosedReceived() {
+        return closedReceived;
+    }
+
+    void setClosedReceived() {
+        closedReceived = true;
     }
 
 }

--- a/mina.netty/src/main/java/org/kaazing/mina/netty/IoSessionChannelHandler.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/netty/IoSessionChannelHandler.java
@@ -29,7 +29,6 @@ import org.jboss.netty.channel.ExceptionEvent;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelHandler;
 import org.jboss.netty.channel.WriteCompletionEvent;
-
 import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
 
 import java.io.IOException;
@@ -65,9 +64,15 @@ public class IoSessionChannelHandler extends SimpleChannelHandler {
     @Override
     public void channelClosed(ChannelHandlerContext ctx, ChannelStateEvent e)
             throws Exception {
-        // Processor remove takes care of firing sessionClosed on the filter chain.
-        session.getProcessor().remove(session);
         idleTracker.removeSession(session);
+        // Processor remove takes care of firing sessionClosed on the filter chain.
+        if (session.isIoRegistered()) {
+            session.getProcessor().remove(session);
+        }
+        else {
+            // session is being realigned (by calls to setIoAlignment), defer closed processing
+            session.setClosedReceived();
+        }
     }
 
     @Override

--- a/mina.netty/src/main/java/org/kaazing/mina/netty/socket/nio/NioSocketChannelIoSession.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/netty/socket/nio/NioSocketChannelIoSession.java
@@ -48,6 +48,11 @@ public class NioSocketChannelIoSession extends ChannelIoSession<NioSocketChannel
         if (ioExecutor == NO_EXECUTOR) {
             channel.setWorker(null);
         }
+        else if (isClosedReceived()) {
+            // Process the closed event now that realignment is complete
+            // We must not register the channel with the worker since it is closed
+            getProcessor().remove(this);
+        }
         else {
             NioWorker newWorker = ((WorkerExecutor) ioExecutor).worker;
             channel.setWorker(newWorker);

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <hazelcast.version>1.9.4.8</hazelcast.version>
-        <k3po.version>3.0.0-alpha-19</k3po.version>
+        <k3po.version>3.0.0-alpha-20</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
         <slf4j.log4j.version>1.7.5</slf4j.log4j.version>

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/wse/acceptor/ClosingIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/wse/acceptor/ClosingIT.java
@@ -21,7 +21,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 import static org.kaazing.test.util.ITUtil.timeoutRule;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -31,7 +35,6 @@ import org.apache.mina.core.service.IoHandler;
 import org.apache.mina.core.session.IoSession;
 import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -44,6 +47,7 @@ import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.kaazing.mina.core.session.IoSessionEx;
 import org.kaazing.test.util.ITUtil;
+import org.kaazing.test.util.MemoryAppender;
 import org.kaazing.test.util.MethodExecutionTrace;
 
 public class ClosingIT {
@@ -129,30 +133,27 @@ public class ClosingIT {
     @Test
     @Specification("client.abruptly.closes.upstream/request")
     public void clientAbruptlyClosesUpstream() throws Exception {
-        final AtomicLong timeToClose = new AtomicLong(0);
-        CountDownLatch closed = new CountDownLatch(1);
-        acceptor.bind("wse://localhost:8080/path", new IoHandlerAdapter<IoSession>() {
-            @Override
-            protected void doSessionOpened(IoSession session) throws Exception {
-                final long start = currentTimeMillis();
-                session.getCloseFuture().addListener(new IoFutureListener<IoFuture>() {
+        final IoHandler handler = context.mock(IoHandler.class);
+        final CountDownLatch closed = new CountDownLatch(1);
 
-                    @Override
-                    public void operationComplete(IoFuture future) {
-                        timeToClose.set(currentTimeMillis() - start);
-                        closed.countDown();
-                    }
-                });
+        context.checking(new Expectations() {
+            {
+                oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
+                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                oneOf(handler).exceptionCaught(with(any(IoSessionEx.class)), with(any(IOException.class)));
+                oneOf(handler).sessionClosed(with(any(IoSessionEx.class)));
+                will(countDown(closed));
             }
-
         });
+
+        acceptor.bind("wse://localhost:8080/path", handler);
         k3po.finish();
         assertTrue("wsebSession was not closed after 4 seconds", closed.await(4, SECONDS));
-        // Depending on timing of the upstream and downstream requests the server may or may not
-        // wait for a response to the WS CLOSE frame that it sends on the downstream
-        assertTrue(format("Time taken for ws close handshake %d ms should not greatly exceed ws close timeout of 2000 ms",
-                timeToClose.get()),
-                timeToClose.get() < 4000);
+
+        // Check no exceptions occurred (like "expected current thread... to match..." as in issue #427)
+        // except for IOException which is expected because of client abrupt close
+        final Set<String> EMPTY_STRING_SET = Collections.emptySet();
+        MemoryAppender.assertMessagesLogged(EMPTY_STRING_SET, Arrays.asList(new String[]{"[^O]Exception"}), null, false);
     }
 
     // Client only test

--- a/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/wse/acceptor/ClosingIT.java
+++ b/transport/wseb/src/test/java/org/kaazing/gateway/transport/wseb/specification/wse/acceptor/ClosingIT.java
@@ -128,7 +128,6 @@ public class ClosingIT {
 
     @Test
     @Specification("client.abruptly.closes.upstream/request")
-    @Ignore("https://github.com/kaazing/gateway/issues/427")
     public void clientAbruptlyClosesUpstream() throws Exception {
         final AtomicLong timeToClose = new AtomicLong(0);
         CountDownLatch closed = new CountDownLatch(1);


### PR DESCRIPTION
Fixes #427: the issue of exception stack traces "expected current thread ... to match..." happening when client abruptly closes the emulated WebSocket upstream or downstream by deferring the handling of the closed event in IoSessionChannelHandler is the session is not io registered (meaning it's in the process of being realigned). Reenables ClosingIT.clientAbruptlyClosesUpstream.

Also fixes check style plug-in configuration in mina.netty pom (gets rid of the check style errors in Eclipse).