### PR TITLE
Gateway returns incorrect error code when payload is too long (1002 instead of 1009)

### DIFF
--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/WsCloseMessage.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/WsCloseMessage.java
@@ -26,6 +26,7 @@ import org.kaazing.gateway.util.Utils;
 public class WsCloseMessage extends WsMessage {
     public static final WsCloseMessage NORMAL_CLOSE = new WsCloseMessage(1000, null);
     public static final WsCloseMessage PROTOCOL_ERROR = new WsCloseMessage(1002, null);
+    public static final WsCloseMessage MESSAGE_TOO_LONG_ERROR = new WsCloseMessage(1009, null);
     public static final WsCloseMessage UNEXPECTED_CONDITION = new WsCloseMessage(1011, null);
 
     private final int status;

--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/bridge/filter/WsFrameDecoder.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/bridge/filter/WsFrameDecoder.java
@@ -32,6 +32,7 @@ import org.kaazing.gateway.transport.ws.WsPingMessage;
 import org.kaazing.gateway.transport.ws.WsPongMessage;
 import org.kaazing.gateway.transport.ws.WsTextMessage;
 import org.kaazing.gateway.transport.ws.bridge.filter.WsFrameEncodingSupport.Opcode;
+import org.kaazing.gateway.transport.ws.util.WSMessageTooLongException;
 import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
 import org.kaazing.mina.core.buffer.IoBufferEx;
 import org.kaazing.mina.filter.codec.CumulativeProtocolDecoderEx;
@@ -255,10 +256,10 @@ public class WsFrameDecoder extends CumulativeProtocolDecoderEx {
         buf.position(start);
     }
 
-    private void validateMessageSize(long messageSize) throws ProtocolDecoderException {
+    private void validateMessageSize(long messageSize) throws WSMessageTooLongException {
         // note: negative size indicates large unsigned value, larger than Long.MAX_VALUE
         if (maxMessageSize > 0 && (messageSize < 0 || messageSize > maxMessageSize)) {
-            throw new ProtocolDecoderException(String.format("Incoming message size %d bytes exceeds permitted maximum of %d bytes", messageSize, maxMessageSize));
+            throw new WSMessageTooLongException(String.format("Incoming message size %d bytes exceeds permitted maximum of %d bytes", messageSize, maxMessageSize));
         }
     }
 

--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/util/WSMessageTooLongException.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/util/WSMessageTooLongException.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.transport.ws.util;
+
+import org.apache.mina.filter.codec.ProtocolDecoderException;
+
+public class WSMessageTooLongException extends ProtocolDecoderException {
+
+    public WSMessageTooLongException() {
+    }
+
+    public WSMessageTooLongException(String message) {
+        super(message);
+    }
+
+    public WSMessageTooLongException(Throwable cause) {
+        super(cause);
+    }
+
+    public WSMessageTooLongException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsCloseFilter.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsCloseFilter.java
@@ -34,6 +34,7 @@ import org.apache.mina.filter.codec.ProtocolDecoderException;
 import org.kaazing.gateway.transport.ws.WsCloseMessage;
 import org.kaazing.gateway.transport.ws.WsFilterAdapter;
 import org.kaazing.gateway.transport.ws.WsMessage;
+import org.kaazing.gateway.transport.ws.util.WSMessageTooLongException;
 import org.kaazing.gateway.util.Utils;
 import org.kaazing.gateway.util.ws.WebSocketWireProtocol;
 import org.kaazing.mina.core.future.DefaultWriteFutureEx;
@@ -239,7 +240,7 @@ public class WsCloseFilter
                 // in time, we terminate the session anyway.
 
                 if (logger != null && logger.isTraceEnabled()) {
-                    logger.trace(format("sending WS CLOSE frame, then waiting %d milliseconds for peer CLOSE", closeTimeout));
+                    logger.trace(format("sending WS CLOSE frame %s, then waiting %d milliseconds for peer CLOSE", message, closeTimeout));
                 }
                 closeNextFilter = nextFilter;
                 closeSession = session;
@@ -317,8 +318,14 @@ public class WsCloseFilter
             // sessionOpened() in upstream closes the session.
             Throwable cause = wsnSession == null ? null : wsnSession.getCloseException();
             WsCloseMessage closeMessage;
-            if (cause != null && cause instanceof ProtocolDecoderException) {
-                closeMessage = WsCloseMessage.PROTOCOL_ERROR;
+            if (cause != null) {
+                if (cause instanceof WSMessageTooLongException) {
+                    closeMessage = WsCloseMessage.MESSAGE_TOO_LONG_ERROR;
+                } else if(cause instanceof ProtocolDecoderException) {
+                    closeMessage = WsCloseMessage.PROTOCOL_ERROR;
+                } else {
+                    closeMessage = WsCloseMessage.NORMAL_CLOSE;
+                }
             } else {
                 closeMessage = WsCloseMessage.NORMAL_CLOSE;
             }


### PR DESCRIPTION
Implement a new close message type triggerd by a different exception. Set the response code to value 1009 (0xf1) when closing the session, if the message length exceeds the maximum length configured in accept-options/ws.maximum.message.size. Fix a trace message to include the actual close frame sent.