### PR TITLE
Add transport.tcp logger to the OOTB log4j config.xml file

### DIFF
--- a/distribution/src/main/assembly/filter.properties
+++ b/distribution/src/main/assembly/filter.properties
@@ -16,7 +16,7 @@
 
 product.version=5.0
 
-gateway.name.long=KAAZING Gateway
+gateway.name.long=Kaazing Gateway
 gateway.version=5.0
 gateway.version.jvm=40
 gateway.version.old=4.0
@@ -24,4 +24,4 @@ gateway.version.next=5.1
 gateway.edition=Community Edition
 gateway.edition.short=gateway
 gateway.cap=Gateway
-gateway.name.short=KAAZING Gateway
+gateway.name.short=Kaazing Gateway

--- a/distribution/src/main/gateway/conf/log4j-config.xml
+++ b/distribution/src/main/gateway/conf/log4j-config.xml
@@ -75,6 +75,10 @@
         </layout>
     </appender>
 
+    <logger name="transport.tcp">
+        <level value="info"/>
+    </logger>
+
     <logger name="transport.http">
         <level value="info"/>
         <appender-ref ref="AccessFile"/>


### PR DESCRIPTION
…to add logger "transport.tcp" since it is often useful for auditing or support purposes. Altered distribution\src\main\assembly\filter.properties to change "KAAZING Gateway" to "Kaazing Gateway" in line with marketing directives.

This change will make it easier for people to use the identity logging feature This was pointed out to me by @michaelcretzman in an email discussion: he was not able to get the (very useful) tcp host and port  part of the identity logging feature working because there was no entry for logger "transport.tcp" in his log4j-config.xml file. Adding it OOTB will make things easier for customers.

I also made a slight wording change in another file since marketing have abandoned the earlier directive we had to use the spelling KAAZING.