### PR TITLE
Anisotrop fix ipv6 accept options

### DIFF
--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
@@ -86,6 +86,7 @@ public final class ResolutionUtils {
     * @return
     */
     public static InetSocketAddress parseBindAddress(String bindAddress) {
+        Exception cause = null;
         try {
             if (!bindAddress.contains(":")) {
                 // port only
@@ -106,8 +107,11 @@ public final class ResolutionUtils {
             }
         } catch (Exception e) {
             // Exception handled outside catch
+            cause = e;
         }
-        throw new IllegalArgumentException(String.format("bind address %s should be in host:port or port format", bindAddress));
+        throw new IllegalArgumentException(String.format("Bind address \"%s\" should be in "
+                + "\"host/ipv4:port\", \"[ipv6]:port\", \"@network_interface:port\", \"[@network interface]:port\" or \"port\" "
+                + "format.", bindAddress), cause);
     }
    
    /**

--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
@@ -93,7 +93,7 @@ public final class ResolutionUtils {
                 return new InetSocketAddress(Integer.parseInt(bindAddress));
             }
             // Test for network interface syntax
-            Pattern pattern = Pattern.compile("^(\\[{1}@[a-zA-Z0-9 :]*\\]{1}|@[a-zA-Z0-9]*):([0-9]*)$");
+            Pattern pattern = Pattern.compile("^(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1}):([0-9]*)$");
             Matcher matcher = pattern.matcher(bindAddress);
             if (matcher.find()) {
                 return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));

--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
@@ -15,18 +15,23 @@
  */
 package org.kaazing.gateway.resource.address;
 
+import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,6 +79,38 @@ public final class ResolutionUtils {
    }
 
    /**
+    * Method creating an InetAddress from String.
+    * @param bindAddress syntax host:port
+    *     host optional, can be specified as IPv4, IPv6, NetworkInterface
+    *     port mandatory
+    * @return
+    */
+    public static InetSocketAddress parseBindAddress(String bindAddress) {
+        try {
+            if (!bindAddress.contains(":")) {
+                // port only
+                return new InetSocketAddress(Integer.parseInt(bindAddress));
+            }
+            // Test for network interface syntax
+            Pattern pattern = Pattern.compile("^(\\[{1}@[a-zA-Z0-9 :]*\\]{1}|@[a-zA-Z0-9]*):([0-9]*)$");
+            Matcher matcher = pattern.matcher(bindAddress);
+            if (matcher.find()) {
+                return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));
+            }
+            
+            // host:port (let URI handle it including ipv6)
+            String tmpAddress = "scheme://" + bindAddress;
+            URI uri = URI.create(tmpAddress);
+            if (uri.getPort() != -1) {
+                return new InetSocketAddress(uri.getHost(), uri.getPort());
+            }
+        } catch (Exception e) {
+            // Exception handled outside catch
+        }
+        throw new IllegalArgumentException(String.format("bind address %s should be in host:port or port format", bindAddress));
+    }
+   
+   /**
     * Method performing device address resolution
     * @param deviceName
     * @param networkInterfaces
@@ -116,6 +153,7 @@ public final class ResolutionUtils {
 
         return resolvedAddresses;
     }
+   
 
    /**
     * Method cloning list of strings (used for network interfaces)

--- a/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/ResolutionUtilsTest.java
+++ b/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/ResolutionUtilsTest.java
@@ -1,0 +1,61 @@
+package org.kaazing.gateway.resource.address;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Test;
+
+public class ResolutionUtilsTest {
+
+    @Test
+    public void shouldParsePortOnly() {
+        assertEquals(new InetSocketAddress(2020), ResolutionUtils.parseBindAddress("2020"));
+    }
+    
+    @Test
+    public void shouldParseIpV4WithPort() {
+        assertEquals(new InetSocketAddress("127.0.0.1", 2020), ResolutionUtils.parseBindAddress("127.0.0.1:2020"));
+    }
+    
+    @Test
+    public void shouldParseIpV6WithPort() {
+        assertEquals( new InetSocketAddress("[::1]", 2020), ResolutionUtils.parseBindAddress("[::1]:2020"));
+    }
+    
+    @Test
+    public void shouldParseNetwokInterfaceWithPort() {
+        assertEquals(new InetSocketAddress("@eth0", 2020), ResolutionUtils.parseBindAddress("@eth0:2020"));
+    }
+    
+    @Test
+    public void shouldParseComplexNetwokInterfaceWithPort() {
+        assertEquals(new InetSocketAddress("[@Local Area Connection]", 2020), ResolutionUtils.parseBindAddress("[@Local Area Connection]:2020"));
+    }
+    
+    @Test
+    public void shouldParseSubNetwokInterfaceWithPort() {
+        assertEquals( new InetSocketAddress("[@eth0:1]", 2020), ResolutionUtils.parseBindAddress("[@eth0:1]:2020"));
+    }
+    
+    @Test (expected = IllegalArgumentException.class)
+    public void shouldRequireExplicitPort() {
+        ResolutionUtils.parseBindAddress("localhost");
+    }
+    
+    @Test (expected = IllegalArgumentException.class)
+    public void shouldRequireExplicitPortOnIpv4() {
+        ResolutionUtils.parseBindAddress("127.0.0.1");
+    }
+    
+    @Test (expected = IllegalArgumentException.class)
+    public void shouldRequireExplicitPortOnIpv6() {
+        ResolutionUtils.parseBindAddress("[::1]");
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRequireExplicitPortOnNetworkInterface() {
+        ResolutionUtils.parseBindAddress("[@eth0:1]");
+    }
+
+}

--- a/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/ResolutionUtilsTest.java
+++ b/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/ResolutionUtilsTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kaazing.gateway.resource.address;
 
 import static org.junit.Assert.assertEquals;
@@ -53,9 +68,19 @@ public class ResolutionUtilsTest {
         ResolutionUtils.parseBindAddress("[::1]");
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test (expected = IllegalArgumentException.class)
     public void shouldRequireExplicitPortOnNetworkInterface() {
         ResolutionUtils.parseBindAddress("[@eth0:1]");
+    }
+    
+    @Test (expected = IllegalArgumentException.class)
+    public void shouldRequireIpV4WithoutSquareBrackets() {
+        assertEquals( new InetSocketAddress("[192.168.0.1]", 2020), ResolutionUtils.parseBindAddress("[192.168.0.1]:2020"));
+    }
+    
+    @Test (expected = IllegalArgumentException.class)
+    public void shouldRequireCorrectPort() {
+        ResolutionUtils.parseBindAddress("host:90000");
     }
 
 }

--- a/resource.address/tcp/src/main/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpi.java
+++ b/resource.address/tcp/src/main/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpi.java
@@ -104,20 +104,7 @@ public class TcpResourceAddressFactorySpi extends ResourceAddressFactorySpi<TcpR
         if (bindAddress instanceof InetSocketAddress) {
             return (InetSocketAddress) bindAddress;
         } else if (bindAddress instanceof String) {
-            String address = (String) bindAddress;
-            // host and port
-            Pattern pattern = Pattern.compile("(.*):([0-9]*)");
-            Matcher matcher = pattern.matcher((String) bindAddress);
-            if (matcher.find()) {
-                return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));
-            }
-            // port only
-            try {
-                return new InetSocketAddress(parseInt(address));
-            } catch (NumberFormatException e) {
-                throw new IllegalArgumentException(
-                        String.format("%s port is mandatory for: %s", BIND_ADDRESS.name(), address));
-            }
+            return ResolutionUtils.parseBindAddress((String) bindAddress);
         }
         throw new IllegalArgumentException(BIND_ADDRESS.name());
     }

--- a/resource.address/tcp/src/test/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpiTest.java
+++ b/resource.address/tcp/src/test/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpiTest.java
@@ -95,16 +95,16 @@ public class TcpResourceAddressFactorySpiTest {
         factory.newResourceAddress("tcp://127.0.0.1");
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldRequireExplicitPortOnIPv6() throws Exception {
         factory.newResourceAddress("tcp://[::1]");
     }
     
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldRequireExplicitPortOnIPv6FromString() throws Exception {
         Map<String, Object> options = new HashMap<>();
         options.put(BIND_ADDRESS.name(), "[::1]");
-        TcpResourceAddress address = factory.newResourceAddress("tcp://[::1]:2020", options);
+        factory.newResourceAddress("tcp://[::1]:2020", options);
     }
 
     @Test
@@ -212,4 +212,6 @@ public class TcpResourceAddressFactorySpiTest {
         alternate = alternate.getOption(ALTERNATE);
         assertNull(alternate);
     }
+    
+
 }

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpTransportOptionsTest.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpTransportOptionsTest.java
@@ -245,7 +245,9 @@ public class HttpTransportOptionsTest {
         connectOptionsParam.put("http.transport", "tcp://@" + networkInterface + ":8080");
         if (networkInterface.contains(" ")) {
             thrown.expect(IllegalArgumentException.class);
-            thrown.expectMessage("Network interface syntax host contains spaces but misses bracket(s)");
+            thrown.expectMessage(String.format("Bind address \"%s\" should be in "
+                    + "\"host/ipv4:port\", \"[ipv6]:port\", \"@network_interface:port\", \"[@network interface]:port\" or \"port\" "
+                    + "format.", "@" + networkInterface + ":8080"));
         }
         helperConstructLocalRemoteAddressesForAcceptAndConnectSessions( acceptOptionsParam, connectOptionsParam);
     }


### PR DESCRIPTION
Resolved conflicts with develop. The regular expression seemed to miss an IPv6 adress between brackets (because of the mandatory @ sign). Proposing a simplification to try to extract the host and port by generic expression. If the expression doesn't match the value could be a port. Otherwise is host only and it should be rejected. Some of the tests don't cover the changed method since they fail earlier.
* shouldRequireExplicitPortOnIPv6FromString
* shouldRequireExplicitPortOnIPv6

Exception is thrown at 	
```java
org.kaazing.gateway.resource.address.URLUtils.modifyURIAuthority(URLUtils.java:61)
	at org.kaazing.gateway.resource.address.uri.URIUtils.modifyURIAuthority(URIUtils.java:305)
	at org.kaazing.gateway.resource.address.tcp.TcpResourceAddressFactorySpi.newResourceAddresses0(TcpResourceAddressFactorySpi.java:203)
	at org.kaazing.gateway.resource.address.ResourceAddressFactorySpi.newResourceAddress(ResourceAddressFactorySpi.java:130)
	at org.kaazing.gateway.resource.address.ResourceAddressFactorySpi.newResourceAddress(ResourceAddressFactorySpi.java:72)
	at org.kaazing.gateway.resource.address.ResourceAddressFactorySpi.newResourceAddress(ResourceAddressFactorySpi.java:68)
	at org.kaazing.gateway.resource.address.tcp.TcpResourceAddressFactorySpiTest.shouldRequireExplicitPortOnIPv6(TcpResourceAddressFactorySpiTest.java:100)
[...]
```