### PR TITLE
Added changes for having the network interface syntax regexp exposed …

### DIFF
--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
@@ -99,7 +99,7 @@ public final class ResolutionUtils {
             if (matcher.find()) {
                 return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));
             }
-            
+
             // host:port (let URI handle it including ipv6)
             String tmpAddress = "scheme://" + bindAddress;
             URI uri = URI.create(tmpAddress);

--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/ResolutionUtils.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.kaazing.gateway.resource.address.uri.URIUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +94,7 @@ public final class ResolutionUtils {
                 return new InetSocketAddress(Integer.parseInt(bindAddress));
             }
             // Test for network interface syntax
-            Pattern pattern = Pattern.compile("^(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1}):([0-9]*)$");
+            Pattern pattern = Pattern.compile(URIUtils.NETWORK_INTERFACE_AUTHORITY_PORT);
             Matcher matcher = pattern.matcher(bindAddress);
             if (matcher.find()) {
                 return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));

--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
@@ -27,6 +27,8 @@ import org.kaazing.gateway.resource.address.URLUtils;
  *
  */
 public final class URIUtils {
+    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1}):([0-9]*)";
+    private static final String NETWORK_INTERFACE_AUTHORITY = "(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1})";
     private static final String MOCK_HOST = "127.0.0.1";
 
     /**
@@ -294,7 +296,7 @@ public final class URIUtils {
         try {
             URI uriObj = new URI(uri);
             // code below modifies new authority considering also network interface syntax
-            Pattern pattern = Pattern.compile("(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1})");
+            Pattern pattern = Pattern.compile(NETWORK_INTERFACE_AUTHORITY);
             Matcher matcher = pattern.matcher(newAuthority);
             String matchedToken = MOCK_HOST;
             // if newAuthority corresponds to NetworkInterfaceURI syntax
@@ -566,7 +568,7 @@ public final class URIUtils {
                     throw new IllegalArgumentException("Network interface URI syntax should only "
                             + "be applicable for tcp and udp schemes");
                 }
-                Pattern pattern = Pattern.compile("(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1})");
+                Pattern pattern = Pattern.compile(NETWORK_INTERFACE_AUTHORITY);
                 Matcher matcher = pattern.matcher(uri);
                 if (!matcher.find()) {
                     throw new IllegalArgumentException("Invalid network interface URI syntax");

--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
@@ -27,7 +27,7 @@ import org.kaazing.gateway.resource.address.URLUtils;
  *
  */
 public final class URIUtils {
-    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1}):([0-9]*)";
+    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "^(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1}):([0-9]*)$";
     private static final String NETWORK_INTERFACE_AUTHORITY = "(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1})";
     private static final String MOCK_HOST = "127.0.0.1";
 

--- a/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/ResolutionUtilsTest.java
+++ b/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/ResolutionUtilsTest.java
@@ -27,57 +27,57 @@ public class ResolutionUtilsTest {
     public void shouldParsePortOnly() {
         assertEquals(new InetSocketAddress(2020), ResolutionUtils.parseBindAddress("2020"));
     }
-    
+
     @Test
     public void shouldParseIpV4WithPort() {
         assertEquals(new InetSocketAddress("127.0.0.1", 2020), ResolutionUtils.parseBindAddress("127.0.0.1:2020"));
     }
-    
+
     @Test
     public void shouldParseIpV6WithPort() {
         assertEquals( new InetSocketAddress("[::1]", 2020), ResolutionUtils.parseBindAddress("[::1]:2020"));
     }
-    
+
     @Test
     public void shouldParseNetwokInterfaceWithPort() {
         assertEquals(new InetSocketAddress("@eth0", 2020), ResolutionUtils.parseBindAddress("@eth0:2020"));
     }
-    
+
     @Test
     public void shouldParseComplexNetwokInterfaceWithPort() {
         assertEquals(new InetSocketAddress("[@Local Area Connection]", 2020), ResolutionUtils.parseBindAddress("[@Local Area Connection]:2020"));
     }
-    
+
     @Test
     public void shouldParseSubNetwokInterfaceWithPort() {
         assertEquals( new InetSocketAddress("[@eth0:1]", 2020), ResolutionUtils.parseBindAddress("[@eth0:1]:2020"));
     }
-    
+
     @Test (expected = IllegalArgumentException.class)
     public void shouldRequireExplicitPort() {
         ResolutionUtils.parseBindAddress("localhost");
     }
-    
+
     @Test (expected = IllegalArgumentException.class)
     public void shouldRequireExplicitPortOnIpv4() {
         ResolutionUtils.parseBindAddress("127.0.0.1");
     }
-    
+
     @Test (expected = IllegalArgumentException.class)
     public void shouldRequireExplicitPortOnIpv6() {
         ResolutionUtils.parseBindAddress("[::1]");
     }
-    
+
     @Test (expected = IllegalArgumentException.class)
     public void shouldRequireExplicitPortOnNetworkInterface() {
         ResolutionUtils.parseBindAddress("[@eth0:1]");
     }
-    
+
     @Test (expected = IllegalArgumentException.class)
     public void shouldRequireIpV4WithoutSquareBrackets() {
         assertEquals( new InetSocketAddress("[192.168.0.1]", 2020), ResolutionUtils.parseBindAddress("[192.168.0.1]:2020"));
     }
-    
+
     @Test (expected = IllegalArgumentException.class)
     public void shouldRequireCorrectPort() {
         ResolutionUtils.parseBindAddress("host:90000");

--- a/resource.address/tcp/src/main/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpi.java
+++ b/resource.address/tcp/src/main/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpi.java
@@ -106,25 +106,6 @@ public class TcpResourceAddressFactorySpi extends ResourceAddressFactorySpi<TcpR
         } else if (bindAddress instanceof String) {
             return ResolutionUtils.parseBindAddress((String) bindAddress);
         }
-        else if (bindAddress instanceof String) {
-            String[] bindParts = ((String) bindAddress).split(":");
-            switch (bindParts.length) {
-            case 1:
-                // port only
-                return new InetSocketAddress(parseInt(bindParts[0]));
-            case 2:
-                // hostname, port
-                String hostname = bindParts[0];
-                int port = parseInt(bindParts[1]);
-                return new InetSocketAddress(hostname, port);
-            }
-            // otherwise (more than one ":" separator encountered)
-            Pattern pattern = Pattern.compile(URIUtils.NETWORK_INTERFACE_AUTHORITY_PORT);
-            Matcher matcher = pattern.matcher((String) bindAddress);
-            if (matcher.find()) {
-                return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));
-            }
-        }
 
         throw new IllegalArgumentException(BIND_ADDRESS.name());
     }

--- a/resource.address/tcp/src/main/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpi.java
+++ b/resource.address/tcp/src/main/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpi.java
@@ -15,7 +15,6 @@
  */
 package org.kaazing.gateway.resource.address.tcp;
 
-import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static org.kaazing.gateway.resource.address.ResourceAddress.RESOLVER;
 import static org.kaazing.gateway.resource.address.ResourceAddress.TRANSPORT;

--- a/resource.address/tcp/src/main/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpi.java
+++ b/resource.address/tcp/src/main/java/org/kaazing/gateway/resource/address/tcp/TcpResourceAddressFactorySpi.java
@@ -117,7 +117,7 @@ public class TcpResourceAddressFactorySpi extends ResourceAddressFactorySpi<TcpR
                 return new InetSocketAddress(hostname, port);
             }
             // otherwise (more than one ":" separator encountered)
-            Pattern pattern = Pattern.compile("(\\[{1}@[a-zA-Z0-9 :]*\\]{1}):([0-9]*)");
+            Pattern pattern = Pattern.compile(URIUtils.NETWORK_INTERFACE_AUTHORITY_PORT);
             Matcher matcher = pattern.matcher((String) bindAddress);
             if (matcher.find()) {
                 return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));

--- a/resource.address/udp/src/main/java/org/kaazing/gateway/resource/address/udp/UdpResourceAddressFactorySpi.java
+++ b/resource.address/udp/src/main/java/org/kaazing/gateway/resource/address/udp/UdpResourceAddressFactorySpi.java
@@ -15,7 +15,6 @@
  */
 package org.kaazing.gateway.resource.address.udp;
 
-import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static org.kaazing.gateway.resource.address.ResourceAddress.RESOLVER;
 import static org.kaazing.gateway.resource.address.udp.UdpResourceAddress.BIND_ADDRESS;
@@ -108,23 +107,7 @@ public class UdpResourceAddressFactorySpi extends ResourceAddressFactorySpi<UdpR
             return (InetSocketAddress) bindAddress;
         }
         else if (bindAddress instanceof String) {
-            String[] bindParts = ((String) bindAddress).split(":");
-            switch (bindParts.length) {
-            case 1:
-                // port only
-                return new InetSocketAddress(parseInt(bindParts[0]));
-            case 2:
-                // hostname, port
-                String hostname = bindParts[0];
-                int port = parseInt(bindParts[1]);
-                return new InetSocketAddress(hostname, port);
-            }
-            // otherwise (more than one ":" separator encountered)
-            Pattern pattern = Pattern.compile(URIUtils.NETWORK_INTERFACE_AUTHORITY_PORT);
-            Matcher matcher = pattern.matcher((String) bindAddress);
-            if (matcher.find()) {
-                return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));
-            }
+            return ResolutionUtils.parseBindAddress((String) bindAddress);
         }
 
         throw new IllegalArgumentException(BIND_ADDRESS.name());

--- a/resource.address/udp/src/main/java/org/kaazing/gateway/resource/address/udp/UdpResourceAddressFactorySpi.java
+++ b/resource.address/udp/src/main/java/org/kaazing/gateway/resource/address/udp/UdpResourceAddressFactorySpi.java
@@ -120,7 +120,7 @@ public class UdpResourceAddressFactorySpi extends ResourceAddressFactorySpi<UdpR
                 return new InetSocketAddress(hostname, port);
             }
             // otherwise (more than one ":" separator encountered)
-            Pattern pattern = Pattern.compile("(\\[{1}@[a-zA-Z0-9 :]*\\]{1}):([0-9]*)");
+            Pattern pattern = Pattern.compile(URIUtils.NETWORK_INTERFACE_AUTHORITY_PORT);
             Matcher matcher = pattern.matcher((String) bindAddress);
             if (matcher.find()) {
                 return new InetSocketAddress(matcher.group(1), parseInt(matcher.group(2)));


### PR DESCRIPTION
…within a specific constant

Also fixed the fact that tcp and udp binds previously had mandatory [ ] due to differences between regular expressions used.

TODO: Need to test this on Linux.