### PR TITLE
Avoid possible NPE in WsnAcceptor.ioBridgeHandler.sessionClosed

### DIFF
--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
@@ -684,8 +684,8 @@ public class WsnAcceptor extends AbstractBridgeAcceptor<WsnSession, WsnBindings.
         @Override
         protected void doSessionClosed(IoSessionEx session) throws Exception {
             WsnSession wsnSession = SESSION_KEY.remove(session);
-            boolean isWsx = !wsnSession.getLocalAddress().getOption(CODEC_REQUIRED);
             if (wsnSession != null && !wsnSession.isClosing()) {
+                boolean isWsx = !wsnSession.getLocalAddress().getOption(CODEC_REQUIRED);
                 if (isWsx) {
                     wsnSession.getProcessor().remove(wsnSession);
                 } else {


### PR DESCRIPTION
(forward port of https://github.com/kaazing-private/gateway.server/pull/89)