### PR TITLE
WsnConnector doesn't send text frame by default.

### DIFF
--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnConnector.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnConnector.java
@@ -147,21 +147,20 @@ public class WsnConnector extends AbstractBridgeConnector<WsnSession> {
     public void addBridgeFilters(IoFilterChain filterChain) {
         IoSession session = filterChain.getSession();
         Encoding encoding = (Encoding) session.getAttribute(ENCODING_KEY);
-
-        switch (encoding) {
-        case BASE64:
-            // add framing before encoding
-            filterChain.addLast(CODEC_FILTER, codec);
-            filterChain.addLast(BASE64_FILTER, base64);
-            break;
-        case TEXT:
-            // add framing before encoding
-            filterChain.addLast(CODEC_FILTER, codec);
-            filterChain.addLast(TEXT_FILTER, text);
-            break;
-        default:
-            filterChain.addLast(CODEC_FILTER, codec);
-            break;
+        filterChain.addLast(CODEC_FILTER, codec);
+        if (encoding != null) {
+            switch (encoding) {
+                case BASE64:
+                    // add framing before encoding
+                    filterChain.addLast(BASE64_FILTER, base64);
+                    break;
+                case TEXT:
+                    // add framing before encoding
+                    filterChain.addLast(TEXT_FILTER, text);
+                    break;
+                default:
+                    break;
+            }
         }
 
         // We speak a new enough version of the WebSocket protocol that
@@ -581,8 +580,6 @@ public class WsnConnector extends AbstractBridgeConnector<WsnSession> {
                         parent.setAttribute(ENCODING_KEY, Encoding.BINARY);
                     } else if ("base64".equals(frameType)) {
                         parent.setAttribute(ENCODING_KEY, Encoding.BASE64);
-                    } else {
-                        parent.setAttribute(ENCODING_KEY, Encoding.TEXT);
                     }
 
                     WSN_SESSION_FACTORY_KEY.set(parent, createSession);

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/BaseFramingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/BaseFramingIT.java
@@ -54,7 +54,6 @@ public class BaseFramingIT {
                 .withLookingForStuckThread(true).build());
     private final TestRule trace = new MethodExecutionTrace();
 
-    private static String TEXT_FILTER_NAME = WsnProtocol.NAME + "#text";
     private static Charset UTF_8 = Charset.forName("UTF-8");
 
     private JUnitRuleMockery context = new JUnitRuleMockery() {
@@ -92,14 +91,6 @@ public class BaseFramingIT {
         assertTrue(connectFuture.isConnected());
 
         WsnSession wsnConnectSession = (WsnSession) connectFuture.getSession();
-        // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-        //                  instead of BINARY is resolved.
-        if (wsnConnectSession != null) {
-            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                parentFilterChain.remove(TEXT_FILTER_NAME);
-            }
-        }
 
         byte[] bytes = new byte[0];
         IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
@@ -136,14 +127,6 @@ public class BaseFramingIT {
         assertTrue(connectFuture.isConnected());
 
         WsnSession wsnConnectSession = (WsnSession) connectFuture.getSession();
-        // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-        //                  instead of BINARY is resolved.
-        if (wsnConnectSession != null) {
-            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                parentFilterChain.remove(TEXT_FILTER_NAME);
-            }
-        }
 
         IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
         WsBuffer wsBuffer = allocator.wrap(ByteBuffer.wrap(bytes), IoBufferEx.FLAG_SHARED);
@@ -180,14 +163,6 @@ public class BaseFramingIT {
         assertTrue(connectFuture.isConnected());
 
         WsnSession wsnConnectSession = (WsnSession) connectFuture.getSession();
-        // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-        //                  instead of BINARY is resolved.
-        if (wsnConnectSession != null) {
-            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                parentFilterChain.remove(TEXT_FILTER_NAME);
-            }
-        }
 
         IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
         WsBuffer wsBuffer = allocator.wrap(ByteBuffer.wrap(bytes), IoBufferEx.FLAG_SHARED);
@@ -224,14 +199,6 @@ public class BaseFramingIT {
         assertTrue(connectFuture.isConnected());
 
         WsnSession wsnConnectSession = (WsnSession) connectFuture.getSession();
-        // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-        //                  instead of BINARY is resolved.
-        if (wsnConnectSession != null) {
-            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                parentFilterChain.remove(TEXT_FILTER_NAME);
-            }
-        }
 
         IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
         WsBuffer wsBuffer = allocator.wrap(ByteBuffer.wrap(bytes), IoBufferEx.FLAG_SHARED);
@@ -269,14 +236,6 @@ public class BaseFramingIT {
         assertTrue(connectFuture.isConnected());
 
         WsnSession wsnConnectSession = (WsnSession) connectFuture.getSession();
-        // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-        //                  instead of BINARY is resolved.
-        if (wsnConnectSession != null) {
-            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                parentFilterChain.remove(TEXT_FILTER_NAME);
-            }
-        }
 
         IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
         WsBuffer wsBuffer = allocator.wrap(ByteBuffer.wrap(bytes), IoBufferEx.FLAG_SHARED);
@@ -313,14 +272,6 @@ public class BaseFramingIT {
         assertTrue(connectFuture.isConnected());
 
         WsnSession wsnConnectSession = (WsnSession) connectFuture.getSession();
-        // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-        //                  instead of BINARY is resolved.
-        if (wsnConnectSession != null) {
-            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                parentFilterChain.remove(TEXT_FILTER_NAME);
-            }
-        }
 
         IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
         WsBuffer wsBuffer = allocator.wrap(ByteBuffer.wrap(bytes), IoBufferEx.FLAG_SHARED);
@@ -357,15 +308,6 @@ public class BaseFramingIT {
         assertTrue(connectFuture.isConnected());
 
         WsnSession wsnConnectSession = (WsnSession) connectFuture.getSession();
-        // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-        //                  instead of BINARY is resolved.
-        if (wsnConnectSession != null) {
-            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                parentFilterChain.remove(TEXT_FILTER_NAME);
-            }
-        }
-
         IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
         WsBuffer wsBuffer = allocator.wrap(ByteBuffer.wrap(bytes), IoBufferEx.FLAG_SHARED);
         wsBuffer.setKind(WsBuffer.Kind.BINARY);

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/FragmentationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/FragmentationIT.java
@@ -49,7 +49,6 @@ import org.kaazing.test.util.ITUtil;
 import org.kaazing.test.util.MethodExecutionTrace;
 
 public class FragmentationIT {
-    private static String TEXT_FILTER_NAME = WsnProtocol.NAME + "#text";
     private final WsnConnectorRule connector = new WsnConnectorRule();
     private final K3poRule k3po = new K3poRule().setScriptRoot("org/kaazing/specification/ws/fragmentation");
     private final TestRule trace = new MethodExecutionTrace();
@@ -95,13 +94,6 @@ public class FragmentationIT {
                                 buffer.put(bb);
                             }
                             buffer.flip();
-
-                            // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-                            //                  instead of BINARY is resolved.
-                            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-                            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                                parentFilterChain.remove(TEXT_FILTER_NAME);
-                            }
 
                             IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
                             WsBuffer wsBuffer = allocator.wrap(buffer, IoBufferEx.FLAG_SHARED);
@@ -149,13 +141,6 @@ public class FragmentationIT {
                             }
                             buffer.flip();
 
-                            // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-                            //                  instead of BINARY is resolved.
-                            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-                            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                                parentFilterChain.remove(TEXT_FILTER_NAME);
-                            }
-
                             IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
                             WsBuffer wsBuffer = allocator.wrap(buffer, IoBufferEx.FLAG_SHARED);
                             wsBuffer.setKind(WsBuffer.Kind.BINARY);
@@ -201,13 +186,6 @@ public class FragmentationIT {
                                 buffer.put(bb);
                             }
                             buffer.flip();
-
-                            // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-                            //                  instead of BINARY is resolved.
-                            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-                            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                                parentFilterChain.remove(TEXT_FILTER_NAME);
-                            }
 
                             IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
                             WsBuffer wsBuffer = allocator.wrap(buffer, IoBufferEx.FLAG_SHARED);
@@ -255,13 +233,6 @@ public class FragmentationIT {
                             }
                             buffer.flip();
 
-                            // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-                            //                  instead of BINARY is resolved.
-                            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-                            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                                parentFilterChain.remove(TEXT_FILTER_NAME);
-                            }
-
                             IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
                             WsBuffer wsBuffer = allocator.wrap(buffer, IoBufferEx.FLAG_SHARED);
                             wsBuffer.setKind(WsBuffer.Kind.BINARY);
@@ -307,13 +278,6 @@ public class FragmentationIT {
                                 buffer.put(bb);
                             }
                             buffer.flip();
-
-                            // ### Issue# 316: Temporary hack till the issue related to Connector writing out TEXT frame
-                            //                  instead of BINARY is resolved.
-                            IoFilterChain parentFilterChain = wsnConnectSession.getParent().getFilterChain();
-                            if (parentFilterChain.contains(TEXT_FILTER_NAME)) {
-                                parentFilterChain.remove(TEXT_FILTER_NAME);
-                            }
 
                             IoBufferAllocatorEx<? extends WsBuffer> allocator = wsnConnectSession.getBufferAllocator();
                             WsBuffer wsBuffer = allocator.wrap(buffer, IoBufferEx.FLAG_SHARED);


### PR DESCRIPTION
If X-Frame-Type header is used to specify encoding. If it was not there, it was assumed as text encoding. That is removed so that so that binary frames are not written as text frames. This fixes https://github.com/kaazing/gateway/issues/316