### PR TITLE
Improved regexp to require brackets for network interface containing spaces

### DIFF
--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
@@ -27,7 +27,7 @@ import org.kaazing.gateway.resource.address.URLUtils;
  *
  */
 public final class URIUtils {
-    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "^(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1}):([0-9]*)$";
+    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "^(\\[@[a-zA-Z0-9 :]*\\]|@[a-zA-Z0-9:]*):([0-9]*)$";
     private static final String NETWORK_INTERFACE_AUTHORITY = "(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1})";
     private static final String MOCK_HOST = "127.0.0.1";
 

--- a/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/ResolutionUtilsTest.java
+++ b/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/ResolutionUtilsTest.java
@@ -75,12 +75,17 @@ public class ResolutionUtilsTest {
 
     @Test (expected = IllegalArgumentException.class)
     public void shouldRequireIpV4WithoutSquareBrackets() {
-        assertEquals( new InetSocketAddress("[192.168.0.1]", 2020), ResolutionUtils.parseBindAddress("[192.168.0.1]:2020"));
+        ResolutionUtils.parseBindAddress("[192.168.0.1]:2020");
     }
 
     @Test (expected = IllegalArgumentException.class)
     public void shouldRequireCorrectPort() {
         ResolutionUtils.parseBindAddress("host:90000");
+    }
+    
+    @Test (expected = IllegalArgumentException.class)
+    public void shouldRequireComplexInterfaceBetweenBrackets() {
+        ResolutionUtils.parseBindAddress("@Local Area Connection:2020");
     }
 
 }


### PR DESCRIPTION
The regular expression matched a network interface definition that was not between brackets but contained spaces. In this case the test in class HttpTransportOptionsTest and method shouldConstructCorrectLocalAndRemoteAddressesForHttpAcceptAndConnectSessionsOverrideTcpNoBrackets failed because the expected exception was thrown later in the code and the message was different.