### PR TITLE
Removing draft resource address components from distribution

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -175,14 +175,6 @@
         </dependency>
         <dependency>
             <groupId>org.kaazing</groupId>
-            <artifactId>gateway.resource.address.wsdraft</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.kaazing</groupId>
-            <artifactId>gateway.resource.address.wsxdraft</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.kaazing</groupId>
             <artifactId>gateway.resource.address.pipe</artifactId>
         </dependency>
         <dependency>
@@ -196,10 +188,6 @@
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>gateway.resource.address.httpx</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.kaazing</groupId>
-            <artifactId>gateway.resource.address.httpxdraft</artifactId>
         </dependency>
         <dependency>
             <groupId>org.kaazing</groupId>

--- a/distribution/src/main/assembly/generic-bin.xml
+++ b/distribution/src/main/assembly/generic-bin.xml
@@ -37,13 +37,10 @@
         <include>org.kaazing:gateway.resource.address.tcp</include>
         <include>org.kaazing:gateway.resource.address.wsn</include>
         <include>org.kaazing:gateway.resource.address.httpxe</include>
-        <include>org.kaazing:gateway.resource.address.wsdraft</include>
-        <include>org.kaazing:gateway.resource.address.wsxdraft</include>
         <include>org.kaazing:gateway.resource.address.pipe</include>
         <include>org.kaazing:gateway.resource.address.sse</include>
         <include>org.kaazing:gateway.resource.address.wsx</include>
         <include>org.kaazing:gateway.resource.address.httpx</include>
-        <include>org.kaazing:gateway.resource.address.httpxdraft</include>
         <include>org.kaazing:gateway.resource.address.rtmp</include>
         <include>org.kaazing:gateway.resource.address.udp</include>
         <include>org.kaazing:gateway.resource.address.wse</include>


### PR DESCRIPTION
Not removing the draft version components' code yet.