### PR TITLE
Fix for issue #363 Trailing slash mismatch in <accept> & <connect> exception message

### DIFF
--- a/service/http.proxy/src/main/java/org/kaazing/gateway/service/http/proxy/HttpProxyService.java
+++ b/service/http.proxy/src/main/java/org/kaazing/gateway/service/http/proxy/HttpProxyService.java
@@ -27,7 +27,8 @@ import org.kaazing.gateway.service.proxy.AbstractProxyService;
  * Http proxy service
  */
 public class HttpProxyService extends AbstractProxyService<HttpProxyServiceHandler> {
-    private static final String TRAILING_SLASH_ERROR = "Accept URI is '%s' and connect URI is '%s'. Either both URI should end with / or both not.";
+    private static final String TRAILING_SLASH_ERROR = "The accept URI is '%s' and the connect URI is '%s'. "
+            + "One has a trailing slash and one doesn't. Both URIs either need to include a trailing slash or omit it.";
 
     @Override
     public String getType() {

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyServiceTest.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyServiceTest.java
@@ -21,6 +21,9 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.kaazing.gateway.service.ServiceFactory;
 import org.kaazing.test.util.MethodExecutionTrace;
+import org.kaazing.gateway.server.test.Gateway;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
 
 public class HttpProxyServiceTest {
     @Rule
@@ -31,4 +34,32 @@ public class HttpProxyServiceTest {
         HttpProxyService service = (HttpProxyService)ServiceFactory.newServiceFactory().newService("http.proxy");
         Assert.assertNotNull("Failed to create http.proxy service", service);
     }
+
+    @Test
+    public void shouldFailGatewayStartupAccepAndConnectDifferentEndingSlashes() throws Exception {
+        Gateway gateway = new Gateway();
+        // @formatter:off
+        GatewayConfiguration configuration =
+                new GatewayConfigurationBuilder()
+                    .service()
+                        .accept("http://localhost:8080/a")
+                        .connect("http://localhost:8081/")
+                        .name("Proxy Service")
+                        .type("http.proxy")
+                        .connectOption("http.keepalive", "disabled")
+                    .done()
+                .done();
+        // @formatter:on
+        try {
+            gateway.start(configuration);
+            throw new AssertionError("Gateway should fail to start. IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue("Wrong error message", e.getMessage().contains(
+                    "The accept URI is 'http://localhost:8080/a' and the connect URI is 'http://localhost:8081/'. "
+                            + "One has a trailing slash and one doesn't. Both URIs either need to include a trailing slash or omit it."));
+        } finally {
+            gateway.stop();
+        }
+    }
+
 }


### PR DESCRIPTION
I have updated the error message when accept and connect have different ending slashes.