### PR TITLE
http.transport accept and connect option

### DIFF
--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultAcceptOptionsContext.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultAcceptOptionsContext.java
@@ -211,6 +211,7 @@ public class DefaultAcceptOptionsContext implements AcceptOptionsContext {
         result.put(TCP_TRANSPORT, getTransportURI("tcp.transport"));
         result.put(SSL_TRANSPORT, getTransportURI("ssl.transport"));
         result.put("http[http/1.1].transport", getTransportURI("http.transport"));
+        result.put("http.transport", null);
 
         result.put(TCP_MAXIMUM_OUTBOUND_RATE, getTcpMaximumOutboundRate());
 

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultConnectOptionsContext.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultConnectOptionsContext.java
@@ -94,6 +94,7 @@ public class DefaultConnectOptionsContext implements ConnectOptionsContext {
         result.put(TCP_TRANSPORT, getTransportURI("tcp.transport"));
         result.put(SSL_TRANSPORT, getTransportURI("ssl.transport"));
         result.put("http[http/1.1].transport", getTransportURI("http.transport"));
+        result.put("http.transport", null);
 
         result.put(SSL_ENCRYPTION_ENABLED, isSslEncryptionEnabled());
         result.put("udp.interface", getUdpInterface());

--- a/server/src/test/java/org/kaazing/gateway/server/context/resolve/AcceptOptionsTest.java
+++ b/server/src/test/java/org/kaazing/gateway/server/context/resolve/AcceptOptionsTest.java
@@ -95,6 +95,12 @@ public class AcceptOptionsTest {
     }
 
     @Test
+    public void testHttpTransportOption() throws Exception {
+        expectSuccess("http.transport", "tcp://127.0.0.1:80", "http[http/1.1].transport", "tcp://127.0.0.1:80");
+        expectSuccess("http.transport", "tcp://127.0.0.1:80", "http.transport", null);
+    }
+
+    @Test
     @Ignore("XSD no longer validates accept-options types")
     public void testWsMaximumMessageSizeOption() throws Exception {
         expectSuccess("ws.maximum.message.size", "10k", "ws.maxMessageSize", 10240);

--- a/server/src/test/java/org/kaazing/gateway/server/context/resolve/ConnectOptionsTest.java
+++ b/server/src/test/java/org/kaazing/gateway/server/context/resolve/ConnectOptionsTest.java
@@ -80,14 +80,10 @@ public class ConnectOptionsTest {
         expectValidateFailure("tcp.transport", null);
     }
 
-    @Test @Ignore
+    @Test
     public void testHttpTransportOption() throws Exception {
-        expectSuccess("http.transport", "tcp://127.0.0.1:80", "http[http/1.1].transport", URI.create("tcp://127.0.0.1:80"));
-
-        expectValidateFailure("tcp.transport", "//not.absolute");
-        expectValidateFailure("tcp.transport", "-1");
-        expectValidateFailure("tcp.transport", "");
-        expectValidateFailure("tcp.transport", null);
+        expectSuccess("http.transport", "tcp://127.0.0.1:80", "http[http/1.1].transport", "tcp://127.0.0.1:80");
+        expectSuccess("http.transport", "tcp://127.0.0.1:80", "http.transport", null);
     }
 
     @Test @Ignore


### PR DESCRIPTION
http.transport is expanded in two options http.transport, http[http/1.1].transport.
should expand to http[http/1.1].transport *only*, otherwise it creates problems for
httpxe.

I think we need to do similar thing for other options http.bind, http.keepaliveTimeout etc. I think these two option files needs to be rewritten:
- copy options
- produce an options map using copied options.
That way, we know what options are taken care of and what options are not.
For now, left as it is.