### PR TITLE
Removed static from urlCacheControlMap and made it thread safe

### DIFF
--- a/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceHandler.java
+++ b/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceHandler.java
@@ -22,12 +22,12 @@ import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.kaazing.gateway.service.ServiceContext;
 import org.kaazing.gateway.service.http.directory.cachecontrol.CacheControlHandler;
@@ -53,7 +53,7 @@ class HttpDirectoryServiceHandler extends IoHandlerAdapter<HttpAcceptSession> {
     private boolean indexes;
 
     private List<PatternCacheControl> patterns;
-    private static Map<String, CacheControlHandler> urlCacheControlMap = new HashMap<String, CacheControlHandler>();
+    private Map<String, CacheControlHandler> urlCacheControlMap = new ConcurrentHashMap<String, CacheControlHandler>();
 
     private static final DateFormat RFC822_FORMAT_PATTERN =
             new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);


### PR DESCRIPTION
This was only tested by reloading the demo page several times and checking that the urlCacheControlMap is properly populated.
All tests from the gateway.service.http.directory module passed.