### PR TITLE
Fix OpeningHandshakeIT

### DIFF
--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
@@ -51,7 +51,7 @@ public class OpeningHandshakeIT {
     private TestRule contextRule = ITUtil.toTestRule(context);
 
     @Rule
-    public TestRule chain = RuleChain.outerRule(trace).around(timeoutRule).around(k3po).around(connector)
+    public TestRule chain = RuleChain.outerRule(trace).around(connector).around(k3po).around(timeoutRule)
             .around(contextRule);
 
     @Test

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
@@ -51,7 +51,7 @@ public class OpeningHandshakeIT {
     private TestRule contextRule = ITUtil.toTestRule(context);
 
     @Rule
-    public TestRule chain = RuleChain.outerRule(trace).around(connector).around(k3po).around(timeoutRule)
+    public TestRule chain = RuleChain.outerRule(trace).around(timeoutRule).around(k3po).around(connector)
             .around(contextRule);
 
     @Test
@@ -97,6 +97,8 @@ public class OpeningHandshakeIT {
         connectFuture.awaitUninterruptibly();
         assertTrue(connectFuture.isConnected());
 
+        Thread.sleep(100);
+
         k3po.finish();
     }
 
@@ -110,7 +112,7 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 
@@ -131,13 +133,14 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 
         ConnectFuture connectFuture = connector.connect("ws://localhost:8080/path?query", null, handler);
         connectFuture.awaitUninterruptibly();
         assertTrue(connectFuture.isConnected());
+
 
         k3po.finish();
     }
@@ -152,13 +155,15 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 
         ConnectFuture connectFuture = connector.connect("ws://localhost:8080/path?query", null, handler);
         connectFuture.awaitUninterruptibly();
         assertTrue(connectFuture.isConnected());
+
+        Thread.sleep(100);
 
         k3po.finish();
     }
@@ -174,7 +179,7 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 
@@ -197,7 +202,7 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 
@@ -220,7 +225,7 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 
@@ -243,7 +248,7 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 
@@ -453,9 +458,9 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler1).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler1).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler1).sessionOpened(with(any(IoSessionEx.class)));
                 oneOf(handler2).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler2).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler2).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
@@ -89,15 +89,13 @@ public class OpeningHandshakeIT {
         context.checking(new Expectations() {
             {
                 oneOf(handler).sessionCreated(with(any(IoSessionEx.class)));
-                oneOf(handler).sessionOpened(with(any(IoSessionEx.class)));
+                atMost(1).of(handler).sessionOpened(with(any(IoSessionEx.class)));
             }
         });
 
         ConnectFuture connectFuture = connector.connect("ws://localhost:8080/path?query", null, handler);
         connectFuture.awaitUninterruptibly();
         assertTrue(connectFuture.isConnected());
-
-        Thread.sleep(100);
 
         k3po.finish();
     }


### PR DESCRIPTION
It cannot be guaranteed that sessionOpened is called before connectFuture.awaitUninterruptibly() exits.  Current implementation releases the lock when a value is set on the future which happens at sessionCreate time (before session opened).