### PR TITLE
redirected failsafe reports to surefire directory as a workaround to …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,8 @@
                     <configuration>
                         <argLine>@{failsafeArgLine}</argLine>
                         <skipTests>${skipITs}</skipTests>
+                        <!-- workaround to get the total(unit and integration) number of tests in the sonar dashboard -->
+                        <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
…get the full number of tests in sonar