### PR TITLE
Made authType.getSessionTimeout check for instance of != null as I wa…

### DIFF
--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
@@ -1037,7 +1037,7 @@ public class GatewayContextResolver {
             }
 
             //Login Module Inject Rule 4: Inject Timeout Module at Front of Chain
-            if (authType.isSetSessionTimeout()) {
+            if (authType.isSetSessionTimeout() && authType.getSessionTimeout() != null) {
                 Map<String, String> options = new HashMap<>();
                 if (authType.isSetSessionTimeout()) {
                     options.put("session-timeout", resolveTimeIntervalValue(authType.getSessionTimeout()));


### PR DESCRIPTION
…s seeing isSetSessionTimeout always being true.  This resulted in a cosmetic bug where the TimeoutLoginModule was failing on init with a RuntimeException, but due to logging in that class only logging that at trace level