### PR TITLE
WsPingMessage's empty buffer needs to shared buffer

### DIFF
--- a/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/AbstractWsControlMessage.java
+++ b/transport/ws/src/main/java/org/kaazing/gateway/transport/ws/AbstractWsControlMessage.java
@@ -21,7 +21,7 @@ import org.kaazing.mina.core.buffer.IoBufferEx;
 
 public abstract class AbstractWsControlMessage extends WsMessage {
 
-    private static final IoBufferEx EMPTY_BUFFER = BUFFER_ALLOCATOR.wrap(BUFFER_ALLOCATOR.allocate(0));
+    private static final IoBufferEx EMPTY_BUFFER = BUFFER_ALLOCATOR.wrap(BUFFER_ALLOCATOR.allocate(0), IoBufferEx.FLAG_SHARED);
 
     public AbstractWsControlMessage() {
         setBytes(EMPTY_BUFFER);


### PR DESCRIPTION
WsPingMessage's empty buffer is shared across all the instances. Now creating EMPTY_BUFFER is created FLAGS_SHARED flag