### PR TITLE
Updating slf4j to 1.7.21 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <k3po.version>3.0.0-alpha-34</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
-        <slf4j.log4j.version>1.7.5</slf4j.log4j.version>
+        <slf4j.log4j.version>1.7.21</slf4j.log4j.version>
         <agrona.version>0.4.2</agrona.version>
         <enforcer.skip>true</enforcer.skip>
         <!-- Try to avoid huge heap size on Travis builds -->


### PR DESCRIPTION
Some point we should update to log4j 2 (as it has many features - lambda support, no GC)