### PR TITLE
Fix for issue 558 Directory service property directory must start with a / #558

### DIFF
--- a/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryService.java
+++ b/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryService.java
@@ -210,10 +210,10 @@ public class HttpDirectoryService implements Service {
             URI locationURI = URI.create(location);
             locationFile = new File(locationURI.getPath());
             if (locationURI.getScheme() == null) {
-                if (location.charAt(0) == '/') {
+                if (location.length() > 0 && location.charAt(0) == '/') {
                     location = location.substring(1);
-                    locationFile = new File(rootDir, location);
                 }
+                locationFile = new File(rootDir, location);
             } else if (!"file".equals(locationURI.getScheme())) {
                 throw new IllegalArgumentException("Unexpected resources directory: " + location);
             }

--- a/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryService.java
+++ b/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryService.java
@@ -210,9 +210,6 @@ public class HttpDirectoryService implements Service {
             URI locationURI = URI.create(location);
             locationFile = new File(locationURI.getPath());
             if (locationURI.getScheme() == null) {
-                if (location.length() > 0 && location.charAt(0) == '/') {
-                    location = location.substring(1);
-                }
                 locationFile = new File(rootDir, location);
             } else if (!"file".equals(locationURI.getScheme())) {
                 throw new IllegalArgumentException("Unexpected resources directory: " + location);

--- a/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryService.java
+++ b/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryService.java
@@ -205,7 +205,7 @@ public class HttpDirectoryService implements Service {
      * @return the file corresponding to the location
      */
     private File toFile(File rootDir, String location) {
-        File locationFile = null;
+        File locationFile = rootDir;
         if (location != null) {
             URI locationURI = URI.create(location);
             locationFile = new File(locationURI.getPath());

--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceIT.java
@@ -36,6 +36,10 @@ public class HttpDirectoryServiceIT {
     private static final String ASTRISK_ORIGIN_DIRECTORY_SERVICE_ACCEPT = "http://localhost:8002/";
     private static final String KEEPALIVE_DIRECTORY_SERVICE_ACCEPT = "http://localhost:8003/keepAlive";
     private static final String NO_SERVER_HEADER = "http://localhost:8004/";
+    private static final String DIRECTORY_SERVICE_NO_SLASH = "http://localhost:8005/";
+    private static final String DIRECTORY_SERVICE_DOT_SLASH = "http://localhost:8006/";
+    private static final String DIRECTORY_SERVICE_NO_PATH = "http://localhost:8007/";
+    private static final String DIRECTORY_SERVICE_WRONG_PATH = "http://localhost:8008/";
 
     private final K3poRule robot = new K3poRule();
 
@@ -81,6 +85,30 @@ public class HttpDirectoryServiceIT {
                             .property("directory", "/public")
                             .property("welcome-file", "index.html")
                             .crossOrigin().allowOrigin("*").done()
+                        .done()
+                        .service()
+                            .accept(DIRECTORY_SERVICE_NO_SLASH)
+                            .type("directory")
+                            .property("directory", "public")
+                            .property("welcome-file", "index.html")
+                        .done()
+                        .service()
+                            .accept(DIRECTORY_SERVICE_DOT_SLASH)
+                            .type("directory")
+                            .property("directory", "./public")
+                            .property("welcome-file", "index.html")
+                        .done()
+                        .service()
+                            .accept(DIRECTORY_SERVICE_NO_PATH)
+                            .type("directory")
+                            .property("directory", "")
+                            .property("welcome-file", "index.html")
+                        .done()
+                        .service()
+                            .accept(DIRECTORY_SERVICE_WRONG_PATH)
+                            .type("directory")
+                            .property("directory", ".public")
+                            .property("welcome-file", "index.html")
                         .done()
                     .done();
             // @formatter:on
@@ -348,4 +376,27 @@ public class HttpDirectoryServiceIT {
         robot.finish();
     }
 
+    @Specification("directory.no.slash.code.200")
+    @Test
+    public void shouldFindResourceWithNoSlashInDirectory() throws Exception {
+        robot.finish();
+    }
+
+    @Specification("directory.dot.slash.code.200")
+    @Test
+    public void shouldFindResourceWithDotSlashInDirectory() throws Exception {
+        robot.finish();
+    }
+
+    @Specification("directory.no.path.code.200")
+    @Test
+    public void shouldFindRootWithNoPathInDirectory() throws Exception {
+        robot.finish();
+    }
+
+    @Specification("directory.wrong.path.code.404")
+    @Test
+    public void shouldNotFindResourceWithWrongPathInDirectory() throws Exception {
+        robot.finish();
+    }
 }

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.dot.slash.code.200.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.dot.slash.code.200.rpt
@@ -14,14 +14,18 @@
 # limitations under the License.
 #
 
-connect tcp://localhost:8006
+connect http://localhost:8006/
 connected
 
-write "GET /index.html HTTP/1.1\r\n"
-write "Host: localhost:8006\r\n"
-write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:8.0) Gecko/20100101 Firefox/8.0\r\nAccept: text/html, application/xhtml+xml, application/xml;q=0.9,*/*;q=0.8\r\n\r\n"
+write method "GET"
+write version "HTTP/1.1"
+write header "User-Agent" "curl/7.37.1"
+write header host
+write header "Accept" "text/css"
+write flush
 
-read "HTTP/1.1 200 OK\r\n"
+read status "200" "OK"
+read version "HTTP/1.1"
 
 close
 closed

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.dot.slash.code.200.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.dot.slash.code.200.rpt
@@ -1,0 +1,27 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect tcp://localhost:8006
+connected
+
+write "GET /index.html HTTP/1.1\r\n"
+write "Host: localhost:8006\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:8.0) Gecko/20100101 Firefox/8.0\r\nAccept: text/html, application/xhtml+xml, application/xml;q=0.9,*/*;q=0.8\r\n\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+
+close
+closed

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.no.path.code.200.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.no.path.code.200.rpt
@@ -1,0 +1,27 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect tcp://localhost:8007
+connected
+
+write "GET /index.html HTTP/1.1\r\n"
+write "Host: localhost:8007\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:8.0) Gecko/20100101 Firefox/8.0\r\nAccept: text/html, application/xhtml+xml, application/xml;q=0.9,*/*;q=0.8\r\n\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+
+close
+closed

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.no.path.code.200.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.no.path.code.200.rpt
@@ -14,14 +14,18 @@
 # limitations under the License.
 #
 
-connect tcp://localhost:8007
+connect http://localhost:8007/index.html
 connected
 
-write "GET /index.html HTTP/1.1\r\n"
-write "Host: localhost:8007\r\n"
-write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:8.0) Gecko/20100101 Firefox/8.0\r\nAccept: text/html, application/xhtml+xml, application/xml;q=0.9,*/*;q=0.8\r\n\r\n"
+write method "GET"
+write version "HTTP/1.1"
+write header "User-Agent" "curl/7.37.1"
+write header host
+write header "Accept" "text/css"
+write flush
 
-read "HTTP/1.1 200 OK\r\n"
+read status "200" "OK"
+read version "HTTP/1.1"
 
 close
 closed

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.no.slash.code.200.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.no.slash.code.200.rpt
@@ -1,0 +1,27 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect tcp://localhost:8005
+connected
+
+write "GET /index.html HTTP/1.1\r\n"
+write "Host: localhost:8005\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:8.0) Gecko/20100101 Firefox/8.0\r\nAccept: text/html, application/xhtml+xml, application/xml;q=0.9,*/*;q=0.8\r\n\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+
+close
+closed

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.no.slash.code.200.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.no.slash.code.200.rpt
@@ -14,14 +14,18 @@
 # limitations under the License.
 #
 
-connect tcp://localhost:8005
+connect http://localhost:8005/index.html
 connected
 
-write "GET /index.html HTTP/1.1\r\n"
-write "Host: localhost:8005\r\n"
-write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:8.0) Gecko/20100101 Firefox/8.0\r\nAccept: text/html, application/xhtml+xml, application/xml;q=0.9,*/*;q=0.8\r\n\r\n"
+write method "GET"
+write version "HTTP/1.1"
+write header "User-Agent" "curl/7.37.1"
+write header host
+write header "Accept" "text/css"
+write flush
 
-read "HTTP/1.1 200 OK\r\n"
+read status "200" "OK"
+read version "HTTP/1.1"
 
 close
 closed

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.wrong.path.code.404.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.wrong.path.code.404.rpt
@@ -14,14 +14,18 @@
 # limitations under the License.
 #
 
-connect tcp://localhost:8008
+connect http://localhost:8008/index.html
 connected
 
-write "GET /index.html HTTP/1.1\r\n"
-write "Host: localhost:8008\r\n"
-write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:8.0) Gecko/20100101 Firefox/8.0\r\nAccept: text/html, application/xhtml+xml, application/xml;q=0.9,*/*;q=0.8\r\n\r\n"
+write method "GET"
+write version "HTTP/1.1"
+write header "User-Agent" "curl/7.37.1"
+write header host
+write header "Accept" "text/css"
+write flush
 
-read "HTTP/1.1 404 Not Found\r\n"
+read status "404" "Not Found"
+read version "HTTP/1.1"
 
 close
 closed

--- a/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.wrong.path.code.404.rpt
+++ b/service/http.directory/src/test/scripts/org/kaazing/gateway/service/http/directory/directory.wrong.path.code.404.rpt
@@ -1,0 +1,27 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect tcp://localhost:8008
+connected
+
+write "GET /index.html HTTP/1.1\r\n"
+write "Host: localhost:8008\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:8.0) Gecko/20100101 Firefox/8.0\r\nAccept: text/html, application/xhtml+xml, application/xml;q=0.9,*/*;q=0.8\r\n\r\n"
+
+read "HTTP/1.1 404 Not Found\r\n"
+
+close
+closed

--- a/service/http.directory/src/test/webapp/index.html
+++ b/service/http.directory/src/test/webapp/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head> 
+ <meta charset="utf-8">
+</head>
+
+<body>
+ <h1> THIS PAGE EXISTS!! </h1>
+</body>
+
+</html>


### PR DESCRIPTION
This is a fix for [issue 558](Directory service property directory must start with a / #558).