### PR TITLE
Early access features in Gateway

### DIFF
--- a/distribution/src/main/gateway/bin/gateway.aws.start
+++ b/distribution/src/main/gateway/bin/gateway.aws.start
@@ -63,11 +63,26 @@ fi
 # below sets the Java maximum memory to 512MB.
 [ -z "$GATEWAY_OPTS" ] && GATEWAY_OPTS="-Xmx512m"
 
+# You can define flags to opt into using early access features by setting the value
+# of the GATEWAY_FEATURES environment variable to a comma separated list of features
+# to enable before calling this script.
+# The script itself should not be changed.
+FEATURE_OPTS=""
+if [ -n "$GATEWAY_FEATURES" ]
+then
+   echo Enabling early access features: $GATEWAY_FEATURES  
+   set -f; IFS=,
+   for feature in $GATEWAY_FEATURES; do
+      FEATURE_OPTS="$FEATURE_OPTS -Dfeature.$feature"
+   done
+   set =f; unset IFS
+fi
+
 # Add a directory for management support
 JAVA_LIBRARY_PATH="$GW_HOME/lib/sigar"
 
 if [ $INSTALLED_LINUX == "true" ]; then
-    exec java $GATEWAY_OPTS -Djava.library.path="$JAVA_LIBRARY_PATH" -Dgateway.hostname=$HOSTNAME -cp "$GW_HOME/lib/*" org.kaazing.gateway.server.InstalledLinuxMain $*
+    exec java $GATEWAY_OPTS $FEATURE_OPTS -Djava.library.path="$JAVA_LIBRARY_PATH" -Dgateway.hostname=$HOSTNAME -cp "$GW_HOME/lib/*" org.kaazing.gateway.server.InstalledLinuxMain $*
 else
-    exec java $GATEWAY_OPTS -Djava.library.path="$JAVA_LIBRARY_PATH" -Dgateway.hostname=$HOSTNAME -cp "$GW_HOME/lib/*" org.kaazing.gateway.server.Main $*
+    exec java $GATEWAY_OPTS $FEATURE_OPTS -Djava.library.path="$JAVA_LIBRARY_PATH" -Dgateway.hostname=$HOSTNAME -cp "$GW_HOME/lib/*" org.kaazing.gateway.server.Main $*
 fi

--- a/distribution/src/main/gateway/bin/gateway.start
+++ b/distribution/src/main/gateway/bin/gateway.start
@@ -48,6 +48,21 @@ if [ -z "$GATEWAY_OPTS" ]; then
   GATEWAY_OPTS="$GATEWAY_OPTS -Djava.security.egd=file:/dev/urandom"
 fi
 
+# You can define flags to opt into using early access features by setting the value
+# of the GATEWAY_FEATURES environment variable to a comma separated list of features
+# to enable before calling this script.
+# The script itself should not be changed.
+FEATURE_OPTS=""
+if [ -n "$GATEWAY_FEATURES" ]
+then
+   echo Enabling early access features: $GATEWAY_FEATURES  
+   set -f; IFS=,
+   for feature in $GATEWAY_FEATURES; do
+      FEATURE_OPTS="$FEATURE_OPTS -Dfeature.$feature"
+   done
+   set =f; unset IFS
+fi
+
 # Add a directory for management support
 JAVA_LIBRARY_PATH="$GW_HOME/lib/sigar"
 
@@ -58,4 +73,4 @@ if [ "$GATEWAY_IDENTIFIER" != "" ]; then
 fi
 
 # Startup the gateway
-exec java $GATEWAY_OPTS $GW_ID -Djava.library.path="$JAVA_LIBRARY_PATH" -XX:+HeapDumpOnOutOfMemoryError -cp "$GW_HOME/lib/*" org.kaazing.gateway.server.Main $*
+exec java $GATEWAY_OPTS $FEATURE_OPTS $GW_ID -Djava.library.path="$JAVA_LIBRARY_PATH" -XX:+HeapDumpOnOutOfMemoryError -cp "$GW_HOME/lib/*" org.kaazing.gateway.server.Main $*

--- a/distribution/src/main/gateway/bin/gateway.start.bat
+++ b/distribution/src/main/gateway/bin/gateway.start.bat
@@ -37,6 +37,16 @@ if "%GATEWAY_OPTS%" == "" (
     set GATEWAY_OPTS=-Xmx512m
 )
 
+rem You can opt into using early access features by setting the value 
+rem of the GATEWAY_FEATURES environment variable to a comma separated 
+rem list of features to enable before calling this script.
+rem The script itself should not be changed.
+set FEATURE_OPTS= 
+if not "%GATEWAY_FEATURES%" == "" (
+   echo Enabling early access features: %GATEWAY_FEATURES%
+   set FEATURE_OPTS=-Dfeature.%GATEWAY_FEATURES:,= -Dfeature.%
+)
+
 rem Create the classpath.
 
 rem Add a directory for management support
@@ -49,4 +59,4 @@ if "%GATEWAY_IDENTIFIER%" NEQ "" (
 )
 
 rem Startup the gateway
-java %GATEWAY_OPTS% %GW_ID% -Djava.library.path="%JAVA_LIBRARY_PATH%" -XX:+HeapDumpOnOutOfMemoryError -cp "%GW_HOME%\lib\*" org.kaazing.gateway.server.WindowsMain %*
+java %FEATURE_OPTS% %GATEWAY_OPTS% %GW_ID% -Djava.library.path="%JAVA_LIBRARY_PATH%" -XX:+HeapDumpOnOutOfMemoryError -cp "%GW_HOME%\lib\*" org.kaazing.gateway.server.WindowsMain %*

--- a/service/http.proxy/pom.xml
+++ b/service/http.proxy/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>gateway.service.proxy</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/service/http.proxy/src/main/java/org/kaazing/gateway/service/http/proxy/HttpProxyService.java
+++ b/service/http.proxy/src/main/java/org/kaazing/gateway/service/http/proxy/HttpProxyService.java
@@ -18,10 +18,14 @@ package org.kaazing.gateway.service.http.proxy;
 import static java.lang.String.format;
 
 import java.util.Collection;
+import java.util.Properties;
+
+import javax.annotation.Resource;
 
 import org.kaazing.gateway.resource.address.uri.URIUtils;
 import org.kaazing.gateway.service.ServiceContext;
 import org.kaazing.gateway.service.proxy.AbstractProxyService;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 
 /**
  * Http proxy service
@@ -30,6 +34,8 @@ public class HttpProxyService extends AbstractProxyService<HttpProxyServiceHandl
     private static final String TRAILING_SLASH_ERROR = "The accept URI is '%s' and the connect URI is '%s'. "
             + "One has a trailing slash and one doesn't. Both URIs either need to include a trailing slash or omit it.";
 
+    private Properties configuration;
+
     @Override
     public String getType() {
         return "http.proxy";
@@ -37,6 +43,7 @@ public class HttpProxyService extends AbstractProxyService<HttpProxyServiceHandl
 
     @Override
     public void init(ServiceContext serviceContext) throws Exception {
+        EarlyAccessFeatures.HTTP_PROXY_SERVICE.assertEnabled(configuration, serviceContext.getLogger());
         super.init(serviceContext);
         Collection<String> connectURIs = serviceContext.getConnects();
         if (connectURIs == null || connectURIs.isEmpty()) {
@@ -48,6 +55,11 @@ public class HttpProxyService extends AbstractProxyService<HttpProxyServiceHandl
         HttpProxyServiceHandler handler = getHandler();
         handler.setConnectURIs(connectURIs);
         handler.init();
+    }
+
+    @Resource(name = "configuration")
+    public void setConfiguration(Properties configuration) {
+        this.configuration = configuration;
     }
 
     private void checkForTrailingSlashes(ServiceContext serviceContext) {

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyChainedProxiesInLoopIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyChainedProxiesInLoopIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyChainedProxiesInLoopIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8010")
                             .connect("http://localhost:8020")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyChainedProxiesViaHeaderIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyChainedProxiesViaHeaderIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyChainedProxiesViaHeaderIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8010/client")
                             .connect("http://localhost:8020/proxy1")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyChunkingIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyChunkingIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyChunkingIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110")
                             .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyConfigTest.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyConfigTest.java
@@ -27,6 +27,7 @@ import org.kaazing.gateway.server.config.parse.GatewayConfigParser;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.test.util.MethodExecutionTrace;
 
 public class HttpProxyConfigTest {
@@ -52,6 +53,7 @@ public class HttpProxyConfigTest {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .name("simple")
                             .accept("http://localhost:8110")
@@ -75,6 +77,7 @@ public class HttpProxyConfigTest {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .name("nested")
                             .accept("http://localhost:8110")
@@ -105,6 +108,7 @@ public class HttpProxyConfigTest {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .name("useForwarded")
                             .accept("http://localhost:8110")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyCookieIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyCookieIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyCookieIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110")
                             .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyForwardedIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyForwardedIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -34,6 +35,7 @@ public class HttpProxyForwardedIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110/")
                             .connect("http://localhost:8080/")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadMethodIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadMethodIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyHeadMethodIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110")
                             .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadersIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyHeadersIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -34,6 +35,7 @@ public class HttpProxyHeadersIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110")
                             .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyPathIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyPathIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyPathIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110/a")
                             .connect("http://localhost:8080/b/c")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyPersistenceIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyPersistenceIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyPersistenceIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110")
                             .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyPersistenceTest.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyPersistenceTest.java
@@ -33,6 +33,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.test.util.ITUtil;
 
 public class HttpProxyPersistenceTest {
@@ -49,6 +50,7 @@ public class HttpProxyPersistenceTest {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                    .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                     .service()
                         .accept("http://localhost:8110")
                         .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRedirectIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRedirectIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyRedirectIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110")
                             .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRequestIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRequestIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyRequestIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110")
                             .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRequestResourceIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyRequestResourceIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyRequestResourceIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110/index.html")
                             .connect("http://localhost:8080/examples/css/resource.css")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyResponseStatusCodesIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyResponseStatusCodesIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -34,6 +35,7 @@ public class HttpProxyResponseStatusCodesIT {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                    .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                     .service()
                         .accept("http://localhost:8080/")
                         .connect("http://localhost:8080/")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxySecureIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxySecureIT.java
@@ -38,6 +38,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -79,6 +80,7 @@ public class HttpProxySecureIT {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                    .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                     .service()
                         .accept("https://localhost:8110")
                         .connect("https://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxySecurePersistenceTest.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxySecurePersistenceTest.java
@@ -35,6 +35,7 @@ import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 
 public class HttpProxySecurePersistenceTest {
     private final KeyStore keyStore = TlsTestUtil.keyStore();
@@ -53,6 +54,7 @@ public class HttpProxySecurePersistenceTest {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                    .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                     .service()
                         .accept("https://localhost:8110")
                         .connect("https://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxySecureTest.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxySecureTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.test.util.MethodExecutionTrace;
 
 public class HttpProxySecureTest {
@@ -50,6 +51,7 @@ public class HttpProxySecureTest {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                    .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                     .service()
                         .accept("https://localhost:8110")
                         .connect("https://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyServiceTest.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.kaazing.gateway.service.ServiceFactory;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.test.util.MethodExecutionTrace;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
@@ -41,6 +42,7 @@ public class HttpProxyServiceTest {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                    .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                     .service()
                         .accept("http://localhost:8080/a")
                         .connect("http://localhost:8081/")
@@ -57,6 +59,32 @@ public class HttpProxyServiceTest {
             Assert.assertTrue("Wrong error message", e.getMessage().contains(
                     "The accept URI is 'http://localhost:8080/a' and the connect URI is 'http://localhost:8081/'. "
                             + "One has a trailing slash and one doesn't. Both URIs either need to include a trailing slash or omit it."));
+        } finally {
+            gateway.stop();
+        }
+    }
+
+    @Test
+    public void shouldFailGatewayStartupWhenEarlyAccessFeaturePropertyNotSet() throws Exception {
+        Gateway gateway = new Gateway();
+        // @formatter:off
+        GatewayConfiguration configuration =
+                new GatewayConfigurationBuilder()
+                    .service()
+                        .accept("http://localhost:8080/a")
+                        .connect("http://localhost:8081/")
+                        .name("Proxy Service")
+                        .type("http.proxy")
+                        .connectOption("http.keepalive", "disabled")
+                    .done()
+                .done();
+        // @formatter:on
+        try {
+            gateway.start(configuration);
+            throw new AssertionError("Gateway should fail to start because early access feature not enabled.");
+        } catch (UnsupportedOperationException e) {
+            Assert.assertTrue("Wrong error message: " + e.getMessage(), e.getMessage().matches(
+                    "Feature \"http.proxy\".*not enabled"));
         } finally {
             gateway.stop();
         }

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyStreamingIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyStreamingIT.java
@@ -30,6 +30,7 @@ import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.kaazing.test.util.MethodExecutionTrace;
@@ -43,6 +44,7 @@ public class HttpProxyStreamingIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                            .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                             .service()
                                 .accept("http://localhost:8110")
                                 .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyUpgradeIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyUpgradeIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 import org.kaazing.gateway.server.test.GatewayRule;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 
@@ -35,6 +36,7 @@ public class HttpProxyUpgradeIT {
             // @formatter:off
             GatewayConfiguration configuration =
                     new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                         .service()
                             .accept("http://localhost:8110")
                             .connect("http://localhost:8080")

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyWssUpgradeTest.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyWssUpgradeTest.java
@@ -35,6 +35,7 @@ import org.junit.rules.Timeout;
 import org.kaazing.gateway.server.test.Gateway;
 import org.kaazing.gateway.server.test.config.GatewayConfiguration;
 import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
 
 public class HttpProxyWssUpgradeTest {
     private final KeyStore keyStore = TlsTestUtil.keyStore();
@@ -51,6 +52,7 @@ public class HttpProxyWssUpgradeTest {
         // @formatter:off
         GatewayConfiguration configuration =
                 new GatewayConfigurationBuilder()
+                    .property(EarlyAccessFeatures.HTTP_PROXY_SERVICE.getPropertyName(), "true")
                     .service()
                         .accept("https://localhost:8110")
                         .connect("https://localhost:8080")

--- a/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeature.java
+++ b/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeature.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.util.feature;
+
+import static java.lang.String.format;
+
+import java.util.Properties;
+
+import org.slf4j.Logger;
+
+/**
+ * Represents an early access feature, that is, a new product feature that is intended
+ * to be used for development and testing purposes only and is not yet ready for use
+ * in a production environment.
+ */
+public class EarlyAccessFeature {
+
+    private final boolean enabledByDefault;
+    private final String name;
+    private final String description;
+    private final EarlyAccessFeature[] impliedBy;
+
+    public EarlyAccessFeature(String name, String description, boolean enabledByDefault,
+                              EarlyAccessFeature... impliedBy) {
+        this.name = name;
+        this.description = description;
+        this.enabledByDefault = enabledByDefault;
+        this.impliedBy = impliedBy;
+    }
+
+    public void assertEnabled(Properties configuration, Logger logger) {
+        if (!isEnabled(configuration)) {
+            String message = "Early access feature {} is disabled. To use it you must set " +
+                    "system property \"feature.{}\", or include {} in environment variable " +
+                    "GATEWAY_FEATURES (a comma separated list) if you are using " +
+                    "the standard Gateway startup script";
+            logger.error(message, toString(), name, name);
+            throw new UnsupportedOperationException(format("Feature %s not enabled", toString()));
+        }
+    }
+
+    public boolean isEnabled(Properties configuration) {
+        Boolean explicit = getExplicitSetting(configuration);
+        return explicit != null ? explicit : enabledByDefault || implied(configuration);
+    }
+
+    private Boolean getExplicitSetting(Properties configuration) {
+        String value = configuration.getProperty(getPropertyName());
+        if (value == null) {
+            return null;
+        }
+        if (value.length() == 0) {
+            return true;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    private String getPropertyName() {
+        return "feature." + name;
+    }
+
+    private boolean implied(Properties configuration) {
+        for (EarlyAccessFeature feature : impliedBy) {
+            if (feature.isEnabled(configuration)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return format("\"%s\" (%s)", name, description);
+    }
+
+}

--- a/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeature.java
+++ b/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeature.java
@@ -68,7 +68,8 @@ public class EarlyAccessFeature {
         return Boolean.parseBoolean(value);
     }
 
-    private String getPropertyName() {
+    // public to allow use by tests
+    public String getPropertyName() {
         return "feature." + name;
     }
 

--- a/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeatures.java
+++ b/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeatures.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.util.feature;
+
+/**
+ * Specifies new features which are being released as early access features.
+ */
+public interface EarlyAccessFeatures {
+
+    static EarlyAccessFeature HTTP_PROXY_SERVICE = new EarlyAccessFeature("http.proxy", "HTTP Proxy Service", false);
+
+}

--- a/util/src/test/java/org/kaazing/gateway/util/feature/EarlyAccessFeatureTest.java
+++ b/util/src/test/java/org/kaazing/gateway/util/feature/EarlyAccessFeatureTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.util.feature;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Properties;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.jmock.Expectations;
+import org.junit.Test;
+import org.kaazing.test.util.Mockery;
+import org.slf4j.Logger;
+
+public class EarlyAccessFeatureTest {
+
+    @Test
+    public void shouldDefaultToDisabled() {
+        Properties configuration = new Properties();
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", false);
+        assertFalse(feature.isEnabled(configuration));
+    }
+
+    @Test
+    public void shouldDefaultToEnabled() {
+        Properties configuration = new Properties();
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", true);
+        assertTrue(feature.isEnabled(configuration));
+    }
+
+    @Test
+    public void shouldBeEnabledByEmptyProperty() {
+        Properties configuration = new Properties();
+        configuration.setProperty("feature.test", "");
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", false);
+        assertTrue(feature.isEnabled(configuration));
+    }
+
+    @Test
+    public void shouldBeEnabledByTrueProperty() {
+        Properties configuration = new Properties();
+        configuration.setProperty("feature.test", "True");
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", false);
+        assertTrue(feature.isEnabled(configuration));
+    }
+
+    @Test
+    public void shouldBeDisabledByFalseProperty() {
+        Properties configuration = new Properties();
+        configuration.setProperty("feature.test", "false");
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", true);
+        assertFalse(feature.isEnabled(configuration));
+    }
+
+    @Test
+    public void shouldBeEnabledByAssociatedFeature() {
+        Properties configuration = new Properties();
+        configuration.setProperty("feature.test", "true");
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", false);
+        EarlyAccessFeature implied = new EarlyAccessFeature("implied", "implied feature", false, feature);
+        assertTrue(feature.isEnabled(configuration));
+        assertTrue(implied.isEnabled(configuration));
+    }
+
+    @Test
+    public void shouldNotBeEnabledByAssociatedFeatureIfExplicityDisabled() {
+        Properties configuration = new Properties();
+        configuration.setProperty("feature.test", "true");
+        configuration.setProperty("feature.implied", "false");
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", false);
+        EarlyAccessFeature implied = new EarlyAccessFeature("implied", "implied feature", false, feature);
+        assertTrue(feature.isEnabled(configuration));
+        assertFalse(implied.isEnabled(configuration));
+    }
+
+    @Test
+    public void shouldAssertFeatureEnabledWhenEnabled() {
+        Mockery context = new Mockery();
+        final Logger logger = context.mock(Logger.class);
+        Properties configuration = new Properties();
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", true);
+        feature.assertEnabled(configuration, logger);
+        context.assertIsSatisfied();
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void shouldFailAssertFeatureEnabledWhenDisabled() {
+        Mockery context = new Mockery();
+        final Logger logger = context.mock(Logger.class);
+        Properties configuration = new Properties();
+        EarlyAccessFeature feature = new EarlyAccessFeature("test", "test description", false);
+
+        context.checking(new Expectations() {
+            {
+                oneOf(logger).error(with(
+                        new BaseMatcher<String>() {
+                            @Override
+                            public boolean matches(Object arg0) {
+                                String value = (String)arg0;
+                                return value.matches(".*must set system property \"feature.\\{\\}.*");
+                            }
+                            @Override
+                            public void describeTo(Description arg0) {
+                                arg0.appendText("string matches regular expression ");
+                            }
+                        }),
+                        with(new Object[]{feature.toString(), "test", "test"}));
+            }
+        });
+        try {
+            feature.assertEnabled(configuration, logger);
+        }
+        catch(Throwable t) {
+            assertTrue(t.getMessage().matches(".*\"test\".*"));
+            throw t;
+        }
+        context.assertIsSatisfied();
+    }
+
+    @Test
+    public void toStringShouldReturnHelpfulValue() {
+        EarlyAccessFeature feature = new EarlyAccessFeature("shortName", "description", false);
+        String result = feature.toString();
+        assertTrue(result.contains("shortName"));
+        assertTrue(result.contains("description"));
+    }
+
+}


### PR DESCRIPTION
- Utility class EarlyAccessFeature and unit test
- EarlyAccessFeatures interface (listing the early access features: http.proxy service)
- Http proxy service test changes to accomodate need for the feature property
- gateway startup script changes to make it easier to turn on early access features by setting GATEWAY_FEATURES env. var. to "http.proxy" (or more generally, comma-separated list of features to enable).