### PR TITLE
Adding get/setInternalInterestOps() methods to AbstractNioChannel

### DIFF
--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
@@ -174,6 +174,16 @@ abstract class AbstractNioChannel<C extends SelectableChannel & WritableByteChan
     @Override
     public abstract NioChannelConfig getConfig();
 
+    @Override
+    protected int getInternalInterestOps() {
+        return super.getInternalInterestOps();
+    }
+
+    @Override
+    protected void setInternalInterestOps(int interestOps) {
+        super.setInternalInterestOps(interestOps);
+    }
+
     public void setWorker(NioWorker newWorker) {
         if (newWorker == null) {
             if (worker == null) {


### PR DESCRIPTION
Copied these methods from netty's AbstractNioChannel (need as part of  netty 3.10.5 upgrade).
This is the problem with keeping separate copies of netty classes. Otherwise, you would see the following errors during runtime !

```
java.lang.IllegalAccessError: tried to access method org.jboss.netty.channel.AbstractChannel.getInternalInterestOps()I from class org.jboss.netty.channel.socket.nio.NioDatagramWorker$ChannelRegistionTask
	at org.jboss.netty.channel.socket.nio.NioDatagramWorker$ChannelRegistionTask.run(NioDatagramWorker.java:184)
	at org.jboss.netty.channel.socket.nio.AbstractNioSelector.processTaskQueue(AbstractNioSelector.java:409)
	at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:331)
```
