### PR TITLE
RFC 7232: Directory Service responds with 200 OK when If-Modified-Since

### DIFF
--- a/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceHandler.java
+++ b/service/http.directory/src/main/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceHandler.java
@@ -222,6 +222,7 @@ class HttpDirectoryServiceHandler extends IoHandlerAdapter<HttpAcceptSession> {
         if (!modified) {
             // file has not been modified so set status and close session
             session.setWriteHeader("ETag", etag);
+            session.setWriteHeader("Last-Modified", RFC822_FORMAT_PATTERN.format(requestFile.lastModified()));
             session.setStatus(HttpStatus.REDIRECT_NOT_MODIFIED);
             session.close(false);
             return;

--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/rfc7232/IfModifiedSinceIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/rfc7232/IfModifiedSinceIT.java
@@ -63,14 +63,14 @@ public class IfModifiedSinceIT {
     @Rule
     public final TestRule chain = outerRule(timeout).around(k3po).around(gateway);
 
-    @Ignore("https://github.com/kaazing/gateway/issues/383")
+    //@Ignore("https://github.com/kaazing/gateway/issues/383")
     @Test
     @Specification("condition.failed.get.status.304/request")
     public void shouldResultInNotModifiedResponseWithGetAndConditionFailed() throws Exception {
         k3po.finish();
     }
 
-    @Ignore("https://github.com/kaazing/gateway/issues/383")
+    //@Ignore("https://github.com/kaazing/gateway/issues/383")
     @Test
     @Specification("condition.failed.head.status.304/request")
     public void shouldResultInNotModifiedResponseWithHeadAndConditionFailed() throws Exception {

--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/rfc7232/IfModifiedSinceIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/rfc7232/IfModifiedSinceIT.java
@@ -63,14 +63,12 @@ public class IfModifiedSinceIT {
     @Rule
     public final TestRule chain = outerRule(timeout).around(k3po).around(gateway);
 
-    //@Ignore("https://github.com/kaazing/gateway/issues/383")
     @Test
     @Specification("condition.failed.get.status.304/request")
     public void shouldResultInNotModifiedResponseWithGetAndConditionFailed() throws Exception {
         k3po.finish();
     }
 
-    //@Ignore("https://github.com/kaazing/gateway/issues/383")
     @Test
     @Specification("condition.failed.head.status.304/request")
     public void shouldResultInNotModifiedResponseWithHeadAndConditionFailed() throws Exception {

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpUtils.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpUtils.java
@@ -57,9 +57,11 @@ import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
 import org.kaazing.mina.core.buffer.IoBufferEx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import static java.lang.Math.abs;
+import static java.lang.Math.floor;
 
 public class HttpUtils {
+    
 	// An optional header for requests to the gateway to turn on long-polling
 	// X-Kaazing-Proxy-Buffering: on | off
 	// "on" means an intermediary between the client and gateway is buffering.
@@ -74,15 +76,15 @@ public class HttpUtils {
 
 
 	private static final DateFormat[] RFC822_PARSE_PATTERNS = new DateFormat[] {
-	    new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH),
-		new SimpleDateFormat("EEE, d MMM yy HH:mm:ss z", Locale.ENGLISH),
-		new SimpleDateFormat("EEE, d MMM yy HH:mm z", Locale.ENGLISH),
-		new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z", Locale.ENGLISH),
-		new SimpleDateFormat("EEE, d MMM yyyy HH:mm z", Locale.ENGLISH),
-		new SimpleDateFormat("d MMM yy HH:mm z", Locale.ENGLISH),
-		new SimpleDateFormat("d MMM yy HH:mm:ss z", Locale.ENGLISH),
-		new SimpleDateFormat("d MMM yyyy HH:mm z", Locale.ENGLISH),
-		new SimpleDateFormat("d MMM yyyy HH:mm:ss z", Locale.ENGLISH)
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH),
+            new SimpleDateFormat("EEE, d MMM yy HH:mm:ss z", Locale.ENGLISH),
+            new SimpleDateFormat("EEE, d MMM yy HH:mm z", Locale.ENGLISH),
+            new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z", Locale.ENGLISH),
+            new SimpleDateFormat("EEE, d MMM yyyy HH:mm z", Locale.ENGLISH),
+            new SimpleDateFormat("d MMM yy HH:mm z", Locale.ENGLISH),
+            new SimpleDateFormat("d MMM yy HH:mm:ss z", Locale.ENGLISH),
+            new SimpleDateFormat("d MMM yyyy HH:mm z", Locale.ENGLISH),
+            new SimpleDateFormat("d MMM yyyy HH:mm:ss z", Locale.ENGLISH)
 	};
 
 	private static final DateFormat RFC822_FORMAT_PATTERN = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
@@ -285,8 +287,8 @@ public class HttpUtils {
 		}
 
 		// check modified time against file last modified
-		double time_difference = Math.floor(Math.abs(lastModified - ifModifiedSinceDate.getTime())/1000);
-		return time_difference>0;
+		double time_difference = floor(abs(lastModified - ifModifiedSinceDate.getTime())/1000);
+        return time_difference > 0;
 	}
 
 	public static void addLastModifiedHeader(HttpSession session, File requestFile) {

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpUtils.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpUtils.java
@@ -74,6 +74,7 @@ public class HttpUtils {
 
 
 	private static final DateFormat[] RFC822_PARSE_PATTERNS = new DateFormat[] {
+	    new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH),
 		new SimpleDateFormat("EEE, d MMM yy HH:mm:ss z", Locale.ENGLISH),
 		new SimpleDateFormat("EEE, d MMM yy HH:mm z", Locale.ENGLISH),
 		new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z", Locale.ENGLISH),
@@ -158,6 +159,7 @@ public class HttpUtils {
 					out.put(buf, 0, length);
 				}
 				out.flip();
+				in.close();
 
 				httpResponse.setHeader("ETag", etag);
 				httpResponse.setHeader("Last-Modified", RFC822_FORMAT_PATTERN.format(requestFile.lastModified()));
@@ -194,7 +196,7 @@ public class HttpUtils {
                     out.put(buf, 0, length);
                 }
                 out.flip();
-
+                in.close();
                 httpSession.setWriteHeader("ETag", etag);
                 httpSession.setWriteHeader("Last-Modified", RFC822_FORMAT_PATTERN.format(requestFile.lastModified()));
                 httpSession.setWriteHeader("Expires", RFC822_FORMAT_PATTERN.format(System.currentTimeMillis()));
@@ -283,7 +285,8 @@ public class HttpUtils {
 		}
 
 		// check modified time against file last modified
-		return lastModified > ifModifiedSinceDate.getTime();
+		double time_difference = Math.floor(Math.abs(lastModified - ifModifiedSinceDate.getTime())/1000);
+		return time_difference>0;
 	}
 
 	public static void addLastModifiedHeader(HttpSession session, File requestFile) {


### PR DESCRIPTION
Issue was caused by a difference of less than one second between the value
of the header  If-Modified-Since and the actual date of the modification
of the file.
Additionally the header Last-Modified was not sent when sending the status
304.

I have also took the liberty of closing certain FileInputStream which were
opened but never closed.