### PR TITLE
[Work in progress] add support for sending empty payload frame (gateway issue #254)

### DIFF
--- a/mina.netty/src/main/java/org/kaazing/mina/core/session/AbstractIoSession.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/core/session/AbstractIoSession.java
@@ -59,6 +59,8 @@ import org.kaazing.mina.core.future.DefaultWriteFutureEx;
 import org.kaazing.mina.core.future.WriteFutureEx;
 import org.kaazing.mina.core.write.DefaultWriteRequestEx;
 import org.kaazing.mina.core.write.WriteRequestEx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base implementation of {@link IoSession}.
@@ -98,6 +100,8 @@ public abstract class AbstractIoSession implements IoSession, IoAlignment {
                 session.writtenBytesThroughput = 0;
             }
     };
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractIoSession.class);
 
     /**
      * An internal write request object that triggers session close.
@@ -426,9 +430,9 @@ public abstract class AbstractIoSession implements IoSession, IoAlignment {
         try {
             if (message instanceof IoBuffer
                     && !((IoBuffer) message).hasRemaining()) {
-                // Nothing to write : probably an error in the user code
-                throw new IllegalArgumentException(
-                "message is empty. Forgot to call flip()?");
+                if (LOG.isInfoEnabled()) {
+                    LOG.info("Message is empty. Forgot to call flip()?");
+                }
             } else if (message instanceof FileChannel) {
                 FileChannel fileChannel = (FileChannel) message;
                 message = new DefaultFileRegion(fileChannel, 0, fileChannel.size());

--- a/mina.netty/src/main/java/org/kaazing/mina/core/session/AbstractIoSession.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/core/session/AbstractIoSession.java
@@ -17,11 +17,7 @@ package org.kaazing.mina.core.session;
 
 import static java.lang.String.format;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.net.SocketAddress;
-import java.nio.channels.FileChannel;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.Set;
@@ -30,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.mina.core.buffer.IoBuffer;
-import org.apache.mina.core.file.DefaultFileRegion;
 import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.future.CloseFuture;
 import org.apache.mina.core.future.DefaultCloseFuture;
@@ -53,33 +48,33 @@ import org.apache.mina.core.write.WriteRequestQueue;
 import org.apache.mina.core.write.WriteTimeoutException;
 import org.apache.mina.core.write.WriteToClosedSessionException;
 import org.apache.mina.util.CircularQueue;
-import org.apache.mina.util.ExceptionMonitor;
 
 import org.kaazing.mina.core.future.DefaultWriteFutureEx;
 import org.kaazing.mina.core.future.WriteFutureEx;
 import org.kaazing.mina.core.write.DefaultWriteRequestEx;
 import org.kaazing.mina.core.write.WriteRequestEx;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base implementation of {@link IoSession}.
  */
 /* This has the following differences from the version in Mina 2.0.0-RC1:
- * 1. For efficiency reasons, do not update service statistics in the increaseReadBytes through
- *    decreaseScheduledWriteMessages methods
- * 2. getScheduledWriteBytes and getScheduledWriteMessages are no longer final
- * 3. Remove synchronization from poll method
- * 4. Note that this version does NOT have the guards in the increaseReadBufferSize and decreaseReadBufferSize methods
- *    that we added in our patched Mina version ("2.0.0-RC1g"): if (AbstractIoSessionConfig.ENABLE_BUFFER_SIZE)
- * 5. Change suspendRead/resumeRead and suspendWrite/resumeWrite to be atomic integer based (requires balanced calls)
- * 6. Do not always pass suspend/resumeWrite through to the processor, but still support them (for now) because used
- *    by the Gateway codebase
- * 7. Eliminate warnings by adding SuppressWarnings annotations where necessary
- * 8. Change closeOnFlush to call new method "protected abstract void doCloseOnFlush" so it can be
- *    overridden in AbstractIoSessionEx. Make CLOSE_REQUEST protected instead of private.
- * 9. Make lastIdleTimeFor..., lastReadTime and lastWriteTime volatile to allow multithreaded access (e.g. in
- *    DefaultIoSessionIdleTracker).
+ *  1. For efficiency reasons, do not update service statistics in the increaseReadBytes through
+ *     decreaseScheduledWriteMessages methods
+ *  2. getScheduledWriteBytes and getScheduledWriteMessages are no longer final
+ *  3. Remove synchronization from poll method
+ *  4. Note that this version does NOT have the guards in the increaseReadBufferSize and decreaseReadBufferSize methods
+ *     that we added in our patched Mina version ("2.0.0-RC1g"): if (AbstractIoSessionConfig.ENABLE_BUFFER_SIZE)
+ *  5. Change suspendRead/resumeRead and suspendWrite/resumeWrite to be atomic integer based (requires balanced calls)
+ *  6. Do not always pass suspend/resumeWrite through to the processor, but still support them (for now) because used
+ *     by the Gateway codebase
+ *  7. Eliminate warnings by adding SuppressWarnings annotations where necessary
+ *  8. Change closeOnFlush to call new method "protected abstract void doCloseOnFlush" so it can be
+ *     overridden in AbstractIoSessionEx. Make CLOSE_REQUEST protected instead of private.
+ *  9. Make lastIdleTimeFor..., lastReadTime and lastWriteTime volatile to allow multithreaded access (e.g. in
+ *     DefaultIoSessionIdleTracker).
+ * 10. Modify write(Object, SocketAddress) method in order to:
+ *       - remove logic for writing messages of File and FileChannel types
+ *       - allow writing of empty payload messages 
  */
 public abstract class AbstractIoSession implements IoSession, IoAlignment {
 
@@ -100,8 +95,6 @@ public abstract class AbstractIoSession implements IoSession, IoAlignment {
                 session.writtenBytesThroughput = 0;
             }
     };
-
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractIoSession.class);
 
     /**
      * An internal write request object that triggers session close.
@@ -423,29 +416,6 @@ public abstract class AbstractIoSession implements IoSession, IoAlignment {
             return future;
         }
 
-        FileChannel openedFileChannel = null;
-
-        // TODO: remove this code as soon as we use InputStream
-        // instead of Object for the message.
-        try {
-            if (message instanceof IoBuffer
-                    && !((IoBuffer) message).hasRemaining()) {
-                if (LOG.isInfoEnabled()) {
-                    LOG.info("Message is empty. Forgot to call flip()?");
-                }
-            } else if (message instanceof FileChannel) {
-                FileChannel fileChannel = (FileChannel) message;
-                message = new DefaultFileRegion(fileChannel, 0, fileChannel.size());
-            } else if (message instanceof File) {
-                File file = (File) message;
-                openedFileChannel = new FileInputStream(file).getChannel();
-                message = new DefaultFileRegion(openedFileChannel, 0, openedFileChannel.size());
-            }
-        } catch (IOException e) {
-            ExceptionMonitor.getInstance().exceptionCaught(e);
-            return DefaultWriteFutureEx.newNotWrittenFuture(this, e);
-        }
-
         // Now, we can write the message. First, create a future
         WriteRequestEx writeRequest = nextWriteRequest(message, remoteAddress);
         WriteFutureEx writeFuture = writeRequest.getFuture();
@@ -453,23 +423,6 @@ public abstract class AbstractIoSession implements IoSession, IoAlignment {
         // Then, get the chain and inject the WriteRequest into it
         IoFilterChain filterChain = getFilterChain();
         filterChain.fireFilterWrite(writeRequest);
-
-        // TODO : This is not our business ! The caller has created a FileChannel,
-        // he has to close it !
-        if (openedFileChannel != null) {
-            // If we opened a FileChannel, it needs to be closed when the write has completed
-            final FileChannel finalChannel = openedFileChannel;
-            writeFuture.addListener(new IoFutureListener<WriteFuture>() {
-                @Override
-                public void operationComplete(WriteFuture future) {
-                    try {
-                        finalChannel.close();
-                    } catch (IOException e) {
-                        ExceptionMonitor.getInstance().exceptionCaught(e);
-                    }
-                }
-            });
-        }
 
         // Return the WriteFuture.
         return writeFuture;

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/acceptor/BaseFramingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/acceptor/BaseFramingIT.java
@@ -17,7 +17,6 @@ package org.kaazing.gateway.transport.wsn.specification.ws.acceptor;
 
 import static org.kaazing.test.util.ITUtil.createRuleChain;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -56,8 +55,6 @@ public class BaseFramingIT {
     public TestRule chain = createRuleChain(gateway, k3po);
 
     @Test
-    @Ignore("Error: expected 'read [0x82 0x00]', actual 'Disconnected', Not echoing 0 length payload, "
-            + "Bug filed: Gateway #254 `WSN Transport Bug : shouldEchoBinaryFrameWithPayloadLength0`")
     @Specification({
         "echo.binary.payload.length.0/handshake.request.and.frame"
         })
@@ -114,8 +111,6 @@ public class BaseFramingIT {
     }
 
     @Test
-    @Ignore("Error: expected 'read [0x82 0x00]', actual 'Disconnected', Not echoing 0 length payload"
-            + "Bug filed: Gateway #254 `WSN Transport Bug : shouldEchoTextFrameWithPayloadLength0`")
     @Specification({
         "echo.text.payload.length.0/handshake.request.and.frame"
         })

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/acceptor/FragmentationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/acceptor/FragmentationIT.java
@@ -82,7 +82,6 @@ public class FragmentationIT {
     }
 
     @Test
-    @Ignore("Gateway throws error when trying to send empty payload")
     @Specification({
         "client.echo.text.payload.length.0.fragmented/handshake.request.and.frames"
         })
@@ -93,7 +92,6 @@ public class FragmentationIT {
     }
 
     @Test
-    @Ignore("Gateway throws error when trying to send empty payload")
     @Specification({
         "client.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frames"
         })
@@ -165,7 +163,6 @@ public class FragmentationIT {
     }
 
     @Test
-    @Ignore("Gateway throws error when trying to send empty payload")
     @Specification({
         "client.echo.binary.payload.length.0.fragmented/handshake.request.and.frames"
         })
@@ -176,7 +173,6 @@ public class FragmentationIT {
     }
 
     @Test
-    @Ignore("Gateway throws error when trying to send empty payload")
     @Specification({
         "client.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frames"
         })

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/BaseFramingIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/BaseFramingIT.java
@@ -27,7 +27,6 @@ import org.apache.mina.core.future.ConnectFuture;
 import org.apache.mina.core.service.IoHandler;
 import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -67,7 +66,6 @@ public class BaseFramingIT {
             .around(contextRule);
 
     @Test
-    @Ignore("Issue# 306: IllegalArgumentException: message is empty. Forgot to call flip")
     @Specification({
         "echo.binary.payload.length.0/handshake.response.and.frame"
         })
@@ -316,7 +314,6 @@ public class BaseFramingIT {
     }
 
     @Test
-    @Ignore("Issue# 306: IllegalArgumentException: message is empty. Forgot to call flip")
     @Specification({
         "echo.text.payload.length.0/handshake.response.and.frame"
         })

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/FragmentationIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/FragmentationIT.java
@@ -30,7 +30,6 @@ import org.jmock.api.Invocation;
 import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.jmock.lib.action.CustomAction;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -65,7 +64,6 @@ public class FragmentationIT {
             .around(contextRule);
 
     @Test
-    @Ignore("Issue# 306: IllegalArgumentException: message is empty. Forgot to call flip")
     @Specification({
         "server.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frames" })
     public void shouldEchoServerSendBinaryFrameWithEmptyPayloadFragmentedAndInjectedPingPong() throws Exception {
@@ -296,7 +294,6 @@ public class FragmentationIT {
     }
 
     @Test
-    @Ignore("Issue# 306: IllegalArgumentException: message is empty. Forgot to call flip")
     @Specification({
         "server.echo.text.payload.length.0.fragmented/handshake.response.and.frames"
         })
@@ -344,7 +341,6 @@ public class FragmentationIT {
     }
 
     @Test
-    @Ignore("Issue# 306: IllegalArgumentException: message is empty. Forgot to call flip")
     @Specification({
         "server.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frames"
         })


### PR DESCRIPTION
Changed just the write() method of the AbstractIoSession class in the mina.netty module to not throw IllegalArgumentException, as debugging revelead that this class is the one being used, and not the one in the mina.core module.
Should I also perform the change in the AbstractIoSession from mina.core? When is one class used over the other? Also, what's the purpose of the mina.build module?
I removed the @Ignore annotations from impacted ITs and they all pass.