### PR TITLE
Add checks for invalid UTF-8 reason on Close frame

### DIFF
--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/ClosingHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/ClosingHandshakeIT.java
@@ -151,7 +151,6 @@ public class ClosingHandshakeIT {
     }
 
     @Test
-    @Ignore("Issue# 307: Gateway sends back the invalid UTF8 payload/reason instead of just sending the CLOSE code 1002")
     @Specification({
         "server.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.response.and.frame" })
     public void shouldFailWebSocketConnectionWhenServerSendCloseFrameWithCode1000AndInvalidUTF8Reason() throws Exception {


### PR DESCRIPTION
When receiving a CLOSE frame the reason was simply sent back.

This PR adds checks on the  reason:

- if the reason is a valid UTF-8 string, a close frame with the same reason is sent back.
- if the reason is an invalid UTF-8 string, a close frame with the code 1002 (protocol error) and no reason is sent back.