### PR TITLE
Un-suspended successful test case

### DIFF
--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/specification/ws/connector/OpeningHandshakeIT.java
@@ -306,8 +306,6 @@ public class OpeningHandshakeIT {
     }
 
     @Test
-    @Ignore("Issue# 312: Upgrade header set to invalid value in the handshake response."
-            + " connectFuture.isConnected() must return false")
     @Specification({
         "response.header.upgrade.not.websocket/handshake.response" })
     public void shouldFailConnectionWhenResponseHeaderUpgradeNotWebSocket() throws Exception {


### PR DESCRIPTION
This test case is passing successfully, but was suspended. 
This refers to [this bug](https://github.com/kaazing/gateway/issues/312). The fix was done in [this commit](https://github.com/kaazing/gateway/commit/c61f093d44051cf0f7441191f55092d53ede5b2b)