### PR TITLE
Corrected namespace for management.xsd

### DIFF
--- a/management/src/main/xsd/management.xsd
+++ b/management/src/main/xsd/management.xsd
@@ -17,9 +17,9 @@
 
 -->
 <schema elementFormDefault="qualified"
-        targetNamespace="http://xmlns.kaazing.org/2015/11/gateway"
+        targetNamespace="http://xmlns.kaazing.org/2016/06/gateway"
         xmlns="http://www.w3.org/2001/XMLSchema"
-        xmlns:gateway="http://xmlns.kaazing.org/2015/11/gateway">
+        xmlns:gateway="http://xmlns.kaazing.org/2016/06/gateway">
     <annotation>
         <documentation>Configuration for the Kaazing gateway Management service
             extensions.


### PR DESCRIPTION
Management.xsd also needs to be migrated to 2016/06 namespace