### PR TITLE
Worker threads are going to PARK state unnecessarily

### DIFF
--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
@@ -59,6 +59,8 @@ import org.jboss.netty.util.ThreadRenamingRunnable;
 import org.jboss.netty.util.internal.DeadLockProofWorker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy;
+import uk.co.real_logic.agrona.concurrent.IdleStrategy;
 
 abstract class AbstractNioSelector implements NioSelector {
     protected static final Logger PERF_LOGGER = LoggerFactory.getLogger("performance.tcp");
@@ -68,6 +70,7 @@ abstract class AbstractNioSelector implements NioSelector {
     private static final long LATENCY_BEFORE_LOG_TASK = TimeUnit.MILLISECONDS.toNanos(100);
 
     private final int id = nextId.incrementAndGet();
+    private final IdleStrategy idleStrategy = new BackoffIdleStrategy(50, 50, 10000, 20000);
 
     /**
      * Internal Netty logger.
@@ -238,6 +241,7 @@ abstract class AbstractNioSelector implements NioSelector {
             wakenUp.set(false);
 
             try {
+                int workCount = 0;
                 long beforeSelect = System.nanoTime();
                 int selected = select(selector, quickSelect);
                 if (SelectorUtil.EPOLL_BUG_WORKAROUND && selected == 0 && !wakenupFromLoop && !wakenUp.get()) {
@@ -325,10 +329,10 @@ abstract class AbstractNioSelector implements NioSelector {
                 cancelledKeys = 0;
                 if (maximumProcessTaskQueueNanos > 0) {
                     long deadlineNanos = System.nanoTime() + maximumProcessTaskQueueNanos;
-                    quickSelect = processTaskQueue(deadlineNanos);
+                    workCount += processTaskQueue(deadlineNanos);
                 }
                 else {
-                    processTaskQueue();
+                    workCount += processTaskQueue();
                 }
                 selector = this.selector; // processTaskQueue() can call rebuildSelector()
 
@@ -336,7 +340,7 @@ abstract class AbstractNioSelector implements NioSelector {
                     this.selector = null;
 
                     // process one time again
-                    processTaskQueue();
+                    workCount += processTaskQueue();
 
                     for (SelectionKey k: selector.keys()) {
                         close(k);
@@ -351,8 +355,9 @@ abstract class AbstractNioSelector implements NioSelector {
                     shutdownLatch.countDown();
                     break;
                 } else {
-                    process(selector);
-                    processRead();
+                    workCount += process(selector);
+                    workCount += processRead();
+                    idleStrategy.idle(workCount);
                 }
             } catch (Throwable t) {
                 logger.warn(
@@ -401,13 +406,15 @@ abstract class AbstractNioSelector implements NioSelector {
         assert selector != null && selector.isOpen();
     }
 
-    protected void processTaskQueue() {
+    protected int processTaskQueue() {
+        int workCount = 0;
         for (;;) {
             final Runnable task = taskQueue.poll();
             if (task == null) {
                 break;
             }
             task.run();
+            workCount++;
 
             try {
                 cleanUpCancelledKeys();
@@ -415,17 +422,16 @@ abstract class AbstractNioSelector implements NioSelector {
                 // Ignore
             }
         }
+        return workCount;
     }
 
-    private boolean processTaskQueue(long deadLineNanos) {
-        long numTasks = 0;
+    private int processTaskQueue(long deadLineNanos) {
+        int numTasks = 0;
         boolean perfLogEnabled = PERF_LOGGER.isInfoEnabled();
         long startTime = perfLogEnabled ? System.nanoTime() : 0;
-        boolean quickSelect;
         for (;;) {
             final Runnable task = taskQueue.poll();
             if (task == null) {
-                quickSelect = false;
                 break;
             }
             numTasks++;
@@ -447,11 +453,10 @@ abstract class AbstractNioSelector implements NioSelector {
                     }
                 }
                 // Make sure select in run() loop is no wait or short since we still have tasks to do
-                quickSelect = true;
                 break;
             }
         }
-        return quickSelect;
+        return numTasks;
     }
 
     protected final void increaseCancelledKeys() {
@@ -486,10 +491,12 @@ abstract class AbstractNioSelector implements NioSelector {
         }
     }
 
-    protected abstract void process(Selector selector) throws IOException;
+    // returns work count
+    protected abstract int process(Selector selector) throws IOException;
 
-    protected void processRead() throws IOException {
-
+    // returns work count
+    protected int processRead() throws IOException {
+        return 0;
     }
 
     protected int select(Selector selector, boolean quickSelect) throws IOException {
@@ -497,7 +504,7 @@ abstract class AbstractNioSelector implements NioSelector {
     }
 
     protected int select(Selector selector) throws IOException {
-        return SelectorUtil.select(selector);
+        return SelectorUtil.select(selector, 0L);
     }
 
     protected abstract void close(SelectionKey k);

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
@@ -357,8 +357,8 @@ abstract class AbstractNioSelector implements NioSelector {
                 } else {
                     workCount += process(selector);
                     workCount += processRead();
-                    idleStrategy.idle(workCount);
                 }
+                idleStrategy.idle(workCount);
             } catch (Throwable t) {
                 logger.warn(
                         "Unexpected exception in the selector loop.", t);

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioClientBoss.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioClientBoss.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.netty.channel.socket.nio;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ConnectTimeoutException;
+import org.jboss.netty.util.ThreadNameDeterminer;
+import org.jboss.netty.util.ThreadRenamingRunnable;
+import org.jboss.netty.util.Timeout;
+import org.jboss.netty.util.Timer;
+import org.jboss.netty.util.TimerTask;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import static org.jboss.netty.channel.Channels.*;
+
+/**
+ * {@link Boss} implementation that handles the  connection attempts of clients
+ */
+public final class NioClientBoss extends AbstractNioSelector implements Boss {
+
+    private final TimerTask wakeupTask = new TimerTask() {
+        public void run(Timeout timeout) throws Exception {
+            // This is needed to prevent a possible race that can lead to a NPE
+            // when the selector is closed before this is run
+            //
+            // See https://github.com/netty/netty/issues/685
+            Selector selector = NioClientBoss.this.selector;
+
+            if (selector != null) {
+                if (wakenUp.compareAndSet(false, true)) {
+                    selector.wakeup();
+                }
+            }
+        }
+    };
+
+    private final Timer timer;
+
+    NioClientBoss(Executor bossExecutor, Timer timer, ThreadNameDeterminer determiner) {
+        super(bossExecutor, determiner);
+        this.timer = timer;
+    }
+
+    @Override
+    protected ThreadRenamingRunnable newThreadRenamingRunnable(int id, ThreadNameDeterminer determiner) {
+        return new ThreadRenamingRunnable(this, "New I/O boss #" + id, determiner);
+    }
+
+    @Override
+    protected Runnable createRegisterTask(Channel channel, ChannelFuture future) {
+        return new RegisterTask(this, (NioClientSocketChannel) channel);
+    }
+
+    @Override
+    protected int process(Selector selector) {
+        Set<SelectionKey> selectedKeys = selector.selectedKeys();
+        int workCount = selectedKeys.size();
+        processSelectedKeys(selectedKeys);
+
+        // Handle connection timeout every 10 milliseconds approximately.
+        long currentTimeNanos = System.nanoTime();
+        processConnectTimeout(selector.keys(), currentTimeNanos);
+        return workCount;
+    }
+
+    private void processSelectedKeys(Set<SelectionKey> selectedKeys) {
+
+        // check if the set is empty and if so just return to not create garbage by
+        // creating a new Iterator every time even if there is nothing to process.
+        // See https://github.com/netty/netty/issues/597
+        if (selectedKeys.isEmpty()) {
+            return;
+        }
+        for (Iterator<SelectionKey> i = selectedKeys.iterator(); i.hasNext();) {
+            SelectionKey k = i.next();
+            i.remove();
+
+            if (!k.isValid()) {
+                close(k);
+                continue;
+            }
+
+            try {
+                if (k.isConnectable()) {
+                    connect(k);
+                }
+            } catch (Throwable t) {
+                NioClientSocketChannel ch = (NioClientSocketChannel) k.attachment();
+                ch.connectFuture.setFailure(t);
+                fireExceptionCaught(ch, t);
+                k.cancel(); // Some JDK implementations run into an infinite loop without this.
+                ch.worker.close(ch, succeededFuture(ch));
+            }
+        }
+    }
+
+    private static void processConnectTimeout(Set<SelectionKey> keys, long currentTimeNanos) {
+        for (SelectionKey k: keys) {
+            if (!k.isValid()) {
+                // Comment the close call again as it gave us major problems
+                // with ClosedChannelExceptions.
+                //
+                // See:
+                // * https://github.com/netty/netty/issues/142
+                // * https://github.com/netty/netty/issues/138
+                //
+                // close(k);
+                continue;
+            }
+
+            NioClientSocketChannel ch = (NioClientSocketChannel) k.attachment();
+            if (ch.connectDeadlineNanos > 0 &&
+                    currentTimeNanos >= ch.connectDeadlineNanos) {
+
+                // Create a new ConnectException everytime and not cache it as otherwise we end up with
+                // using the wrong remoteaddress in the ConnectException message.
+                //
+                // See https://github.com/netty/netty/issues/2713
+                ConnectException cause =
+                        new ConnectTimeoutException("connection timed out: " + ch.requestedRemoteAddress);
+
+                ch.connectFuture.setFailure(cause);
+                fireExceptionCaught(ch, cause);
+                ch.worker.close(ch, succeededFuture(ch));
+            }
+        }
+    }
+
+    private static void connect(SelectionKey k) throws IOException {
+        NioClientSocketChannel ch = (NioClientSocketChannel) k.attachment();
+        try {
+            if (ch.channel.finishConnect()) {
+                k.cancel();
+                if (ch.timoutTimer != null) {
+                    ch.timoutTimer.cancel();
+                }
+                ch.worker.register(ch, ch.connectFuture);
+            }
+        } catch (ConnectException e) {
+            ConnectException newE = new ConnectException(e.getMessage() + ": " + ch.requestedRemoteAddress);
+            newE.setStackTrace(e.getStackTrace());
+            throw newE;
+        }
+    }
+
+    @Override
+    protected void close(SelectionKey k) {
+        NioClientSocketChannel ch = (NioClientSocketChannel) k.attachment();
+        ch.worker.close(ch, succeededFuture(ch));
+    }
+
+    private final class RegisterTask implements Runnable {
+        private final NioClientBoss boss;
+        private final NioClientSocketChannel channel;
+
+        RegisterTask(NioClientBoss boss, NioClientSocketChannel channel) {
+            this.boss = boss;
+            this.channel = channel;
+        }
+
+        public void run() {
+            int timeout = channel.getConfig().getConnectTimeoutMillis();
+            if (timeout > 0) {
+                if (!channel.isConnected()) {
+                    channel.timoutTimer = timer.newTimeout(wakeupTask,
+                            timeout, TimeUnit.MILLISECONDS);
+                }
+            }
+            try {
+                channel.channel.register(
+                        boss.selector, SelectionKey.OP_CONNECT, channel);
+            } catch (ClosedChannelException e) {
+                channel.worker.close(channel, succeededFuture(channel));
+            }
+
+            int connectTimeout = channel.getConfig().getConnectTimeoutMillis();
+            if (connectTimeout > 0) {
+                channel.connectDeadlineNanos = System.nanoTime() + connectTimeout * 1000000L;
+            }
+        }
+    }
+}

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioServerBoss.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioServerBoss.java
@@ -139,7 +139,7 @@ public final class NioServerBoss extends AbstractNioSelector
     }
 
     @Override
-    protected void process(Selector selector) {
+    protected int process(Selector selector) {
         Iterator<ChannelFuture> iter = channelUnregisteredFutures.iterator();
         if (iter.hasNext()) {
             boolean isDebugEnabled = logger.isDebugEnabled();
@@ -168,8 +168,9 @@ public final class NioServerBoss extends AbstractNioSelector
         }
 
         Set<SelectionKey> selectedKeys = selector.selectedKeys();
+        int workCount = selectedKeys.size();
         if (selectedKeys.isEmpty()) {
-            return;
+            return 0;
         }
         for (Iterator<SelectionKey> i = selectedKeys.iterator(); i.hasNext();) {
             SelectionKey k = i.next();
@@ -207,6 +208,7 @@ public final class NioServerBoss extends AbstractNioSelector
                 }
             }
         }
+        return workCount;
     }
 
     private static void registerAcceptedChannel(NioServerSocketChannel parent, SocketChannel acceptedSocket,


### PR DESCRIPTION
Worker threads were going to PARK state since processRead() doesn't have any work done in ring buffer.  Now the work done from the selector (plus work
done from reading ring buffer) is fed into idle strategy.

Also, selector selects immediately. If there is no work done idle strategy
takes care of parking etc