### PR TITLE
Revert "Changed turn.rest json response to include stun URLs"

### DIFF
--- a/service/turn.rest/src/main/java/org/kaazing/gateway/service/turn/rest/internal/TurnRestJSONResponse.java
+++ b/service/turn.rest/src/main/java/org/kaazing/gateway/service/turn/rest/internal/TurnRestJSONResponse.java
@@ -22,18 +22,12 @@ public final class TurnRestJSONResponse {
     private TurnRestJSONResponse() {
     }
 
-    public static String createResponse(String username, char[] password, String ttl, String turnUrls, String stunUrls) {
+    public static String createResponse(String username, char[] password, String ttl, String urls) {
         String response = "";
         if (username != null && password != null) {
             response = MessageFormat.format("\"username\":\"{0}\",\"credential\":\"{1}\",", username, new String(password));
         }
-        if (stunUrls.length() != 0) {
-            stunUrls = MessageFormat.format("'{'\"urls\":[{0}]'}',", stunUrls);
-        }
-        if (turnUrls.length() != 0) {
-            turnUrls = MessageFormat.format(",\"urls\":[{0}]", turnUrls);
-        }
-        response = MessageFormat.format("[{0}'{'{1}\"ttl\":{2}{3}'}']", stunUrls, response, ttl, turnUrls);
+        response = MessageFormat.format("'{'{0}\"ttl\":{1},\"urls\":[{2}]'}'", response, ttl, urls);
         return response;
     }
 }

--- a/service/turn.rest/src/main/java/org/kaazing/gateway/service/turn/rest/internal/TurnRestService.java
+++ b/service/turn.rest/src/main/java/org/kaazing/gateway/service/turn/rest/internal/TurnRestService.java
@@ -67,13 +67,12 @@ public class TurnRestService implements Service {
         EarlyAccessFeatures.TURN_REST_SERVICE.assertEnabled(getConfiguration(), serviceContext.getLogger());
         ServiceProperties properties = serviceContext.getProperties();
 
-        String turnUrls = getUrls(properties, "turn");
-        String stunUrls = getUrls(properties, "stun");
+        String urls = getTurnURLs(properties);
         TurnRestCredentialsGenerator credentialGeneratorInstance = setUpCredentialsGenerator(properties);
 
         String ttl = properties.get("credentials.ttl") != null ? properties.get("credentials.ttl") : DEFAULT_CREDENTIALS_TTL;
         handler = new TurnRestServiceHandler(Long.toString(Utils.parseTimeInterval(ttl, TimeUnit.SECONDS, 0)),
-                        credentialGeneratorInstance, turnUrls, stunUrls);
+                        credentialGeneratorInstance, urls);
     }
 
     private TurnRestCredentialsGenerator setUpCredentialsGenerator(ServiceProperties properties)
@@ -91,17 +90,13 @@ public class TurnRestService implements Service {
         return credentialGeneratorInstance;
     }
 
-    private String getUrls(ServiceProperties properties, String protocolName) {
-        StringBuilder urls = new StringBuilder();
+    private String getTurnURLs(ServiceProperties properties) {
+        StringBuilder u = new StringBuilder();
         for (String url : properties.get("url").split(LIST_SEPARATOR)) {
-            if (url.toLowerCase().startsWith(protocolName)) {
-                urls.append("\"").append(url).append("\",");
-            }
+            u.append("\"").append(url).append("\",");
         }
-        if (urls.length() != 0) {
-            urls.setLength(urls.length() - 1);
-        }
-        return urls.toString();
+        u.setLength(u.length() - 1);
+        return u.toString();
     }
 
     private Key resolveSharedSecret(ServiceProperties properties) {

--- a/service/turn.rest/src/main/java/org/kaazing/gateway/service/turn/rest/internal/TurnRestServiceHandler.java
+++ b/service/turn.rest/src/main/java/org/kaazing/gateway/service/turn/rest/internal/TurnRestServiceHandler.java
@@ -37,16 +37,17 @@ class TurnRestServiceHandler extends IoHandlerAdapter<HttpAcceptSession> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TurnRestServiceHandler.class);
     private TurnRestCredentialsGenerator credentialGenerator;
-    private String turnUrls;
-    private String stunUrls;
+    private String urls;
 
     private String ttl;
 
-    TurnRestServiceHandler(String ttl, TurnRestCredentialsGenerator credentialGenerator, String turnUrls, String stunUrls) {
+    TurnRestServiceHandler(String ttl, TurnRestCredentialsGenerator credentialGenerator,
+            String urls) {
+
         this.ttl = ttl;
         this.credentialGenerator = credentialGenerator;
-        this.turnUrls = turnUrls;
-        this.stunUrls = stunUrls;
+        this.urls = urls;
+
     }
 
     @Override
@@ -81,7 +82,7 @@ class TurnRestServiceHandler extends IoHandlerAdapter<HttpAcceptSession> {
             LOGGER.info(String.format("%s Generated username: %s", session, username));
         }
 
-        String response = TurnRestJSONResponse.createResponse(username, password, ttl, turnUrls, stunUrls);
+        String response = TurnRestJSONResponse.createResponse(username, password, ttl, this.urls);
 
         if (password != null) {
             Arrays.fill(password, '0');


### PR DESCRIPTION
Reverts kaazing/gateway#701.

There are no tests for this, and it changes the response from a json object to an array.  By spec, this should not be the case.  See https://tools.ietf.org/html/draft-uberti-rtcweb-turn-rest-00#section-2.2