### PR TITLE
Configure Agrona's buffer size for udp child channels

### DIFF
--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioWorker.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioWorker.java
@@ -42,6 +42,7 @@ import static org.jboss.netty.channel.Channels.fireExceptionCaught;
 import static org.jboss.netty.channel.Channels.fireExceptionCaughtLater;
 import static org.jboss.netty.channel.Channels.fireWriteCompleteLater;
 import static org.jboss.netty.channel.Channels.succeededFuture;
+import static org.kaazing.mina.netty.config.InternalSystemProperty.UDP_CHANNEL_BUFFER_SIZE;
 import static uk.co.real_logic.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
 
 import java.io.IOException;
@@ -81,13 +82,14 @@ import org.kaazing.mina.netty.channel.DefaultWriteCompletionEventEx;
 import uk.co.real_logic.agrona.DirectBuffer;
 import uk.co.real_logic.agrona.collections.Int2ObjectHashMap;
 import uk.co.real_logic.agrona.concurrent.AtomicBuffer;
-import uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy;
-import uk.co.real_logic.agrona.concurrent.IdleStrategy;
 import uk.co.real_logic.agrona.concurrent.UnsafeBuffer;
 import uk.co.real_logic.agrona.concurrent.ringbuffer.OneToOneRingBuffer;
 
 public abstract class AbstractNioWorker extends AbstractNioSelector implements Worker {
     private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(AbstractNioWorker.class);
+
+    private final int UDP_CHANNEL_BUFFER_SIZE_PER_WORKER
+            = UDP_CHANNEL_BUFFER_SIZE.getIntProperty(System.getProperties());
 
     protected final SocketReceiveBufferAllocator recvBufferPool = new SocketReceiveBufferAllocator();
     protected final SocketSendBufferPool sendBufferPool = new SocketSendBufferPool();
@@ -103,7 +105,7 @@ public abstract class AbstractNioWorker extends AbstractNioSelector implements W
 
     AbstractNioWorker(Executor executor, ThreadNameDeterminer determiner) {
         super(executor, determiner);
-        ByteBuffer byteBuffer = ByteBuffer.allocateDirect((16 * 1024) + TRAILER_LENGTH);
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(UDP_CHANNEL_BUFFER_SIZE_PER_WORKER + TRAILER_LENGTH);
         ringBuffer = new OneToOneRingBuffer(new UnsafeBuffer(byteBuffer));
         channels = new Int2ObjectHashMap<>();
     }

--- a/mina.netty/src/main/java/org/kaazing/mina/netty/config/InternalSystemProperty.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/netty/config/InternalSystemProperty.java
@@ -31,7 +31,11 @@ public enum InternalSystemProperty {
     // The value used should be large enough to guarantee we do get socket readable/writable notification from
     // the kernel (selectNow, done if the value is 0, does not always seem to achieve this) but small enough
     // not to waste too much time if there are no ready ops.
-    QUICK_SELECT_TIMEOUT("org.kaazing.netty.QUICK_SELECT_TIMEOUT", "0"); // use selectNow by default
+    QUICK_SELECT_TIMEOUT("org.kaazing.netty.QUICK_SELECT_TIMEOUT", "0"), // use selectNow by default
+
+    // A worker is serving multiple UDP child channels and they share an Agrona buffer.
+    // This configures the buffer size in bytes. It must be a positive power of 2
+    UDP_CHANNEL_BUFFER_SIZE("org.kaazing.netty.UDP_CHANNEL_BUFFER_SIZE", "1048576");
 
     private final String name;
     private final String defaultValue;


### PR DESCRIPTION
Providing a system property to configure agrona's buffer size. The buffer (per thread)
is shared by mutliple child channels which are serviced by the same worker thread