### PR TITLE
Selector.selectNow is triggered by passing timeout=0L

### DIFF
--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioWorker.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioWorker.java
@@ -178,7 +178,7 @@ public class NioWorker extends AbstractNioWorker {
         if (quickSelect) {
             return SelectorUtil.select(selector, QUICK_SELECT_TIMEOUT);
         } else {
-            return SelectorUtil.select(selector);
+            return SelectorUtil.select(selector, 0L);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <hazelcast.version>1.9.4.8</hazelcast.version>
-        <k3po.version>3.0.0-alpha-50</k3po.version>
+        <k3po.version>3.0.0-alpha-51</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
         <slf4j.log4j.version>1.7.21</slf4j.log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <hazelcast.version>1.9.4.8</hazelcast.version>
-        <k3po.version>3.0.0-alpha-45</k3po.version>
+        <k3po.version>3.0.0-alpha-50</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
         <slf4j.log4j.version>1.7.21</slf4j.log4j.version>


### PR DESCRIPTION
Now we have idle strategy, we just want to pass timeout=0L so that selectNow() is triggered. This helps UDP esp since the worker threads don't do anything with the selector.