### PR TITLE
Altered NioWorker.select and AbstractNioSelector.select to use 10ms select timeout

### DIFF
--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
@@ -361,7 +361,7 @@ abstract class AbstractNioSelector implements NioSelector {
                     workCount += process(selector);
                     workCount += processRead();
                 }
-                idleStrategy.idle(workCount);
+                //idleStrategy.idle(workCount);
             } catch (Throwable t) {
                 logger.warn(
                         "Unexpected exception in the selector loop.", t);
@@ -503,11 +503,15 @@ abstract class AbstractNioSelector implements NioSelector {
     }
 
     protected int select(Selector selector, boolean quickSelect) throws IOException {
-        return select(selector);
+        if (quickSelect) {
+            return SelectorUtil.select(selector, 0L);
+        } else {
+            return select(selector);
+        }
     }
 
     protected int select(Selector selector) throws IOException {
-        return SelectorUtil.select(selector, 0L);
+        return SelectorUtil.select(selector, 10L);
     }
 
     protected abstract void close(SelectionKey k);

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioWorker.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioWorker.java
@@ -178,7 +178,7 @@ public class NioWorker extends AbstractNioWorker {
         if (quickSelect) {
             return SelectorUtil.select(selector, QUICK_SELECT_TIMEOUT);
         } else {
-            return SelectorUtil.select(selector, 0L);
+            return SelectorUtil.select(selector, 10L);
         }
     }
 


### PR DESCRIPTION
… instead of 0, and commented out use of idleStrategy in AbstractNioSelector.run.

Note: this is a preliminary fix for a performance regression. A better fix (using selector.wakeUp) will be done for the next release.