### PR TITLE
Reduced number of follows in ConnectorMultiFactorAuthIT such that tes…

### DIFF
--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/multi/auth/ConnectorMultiFactorAuthIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/multi/auth/ConnectorMultiFactorAuthIT.java
@@ -71,7 +71,7 @@ public class ConnectorMultiFactorAuthIT {
             setImposteriser(ClassImposteriser.INSTANCE);
         }
     };
-    
+
     @Before
     public void before(){
         testState = context.states("testState").startsAs("initial-state");
@@ -116,7 +116,7 @@ public class ConnectorMultiFactorAuthIT {
     @Test
     @Specification({"response.with.secure.challenge.identity/server"})
     public void clientShouldAttachSecChallengeIdentityToFollowingRequests() throws Exception {
-        connector.getConnectOptions().put("http.max.authentication.attempts", "5");
+        connector.getConnectOptions().put("http.max.authentication.attempts", "1");
         final IoHandler handler = context.mock(IoHandler.class);
         context.checking(new Expectations() {
             {


### PR DESCRIPTION
…t will only try to follow 401 the exact number of times as in the script, other wise there is a race between following the last 401 and test completion, the former resulting in an extra call to the mock