### PR TITLE
Sync with netty 3.5.10 (apply to release/5.3.1)

### DIFF
--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -2,32 +2,33 @@ Analysis of netty-3.10.5.Final code compared to mina.netty
 ==========================================================
 mina.netty contains some classes copied from Netty and then altered. This file documents what changes were made.
 
-Note that some of our copies of the Netty classes which are present in mina.netty original came from Netty version 3.6.3.Final.
+Note that some of our copies of the Netty classes were copied from Netty version 3.6.3.Final.
 We only later upgraded our dependency to 3.10.5.Final. One purpose of this document is to check whether we pulled
-all the Netty changes into our copies.
+all the Netty changes between 3.6.3 and 3.10.5 into our copies.
 
 Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9)
 
-All classes are in sync with Netty 3.5.10.Final unless specifically stated.
+All classes are in sync with Netty 3.5.10.Final unless otherwise marked with an asterisk below.
 
 AbstractChannel
 (copied from netty 3.10.5.Final)
 - mina.netty adds a single line code change to ensure id is positive
 
-AbstractNioChannel (may not be in sync)
-(originally copied from netty 3.6.3.Final, some but not all changes were applied from netty 3.10.5.Final as part of upgrade)
+AbstractNioChannel
+(originally copied from netty 3.6.3.Final, all desirable changes from netty 3.10.5.Final have been incorporated)
 - mina.netty adds setWorker method (for thread migration)
-- mina.netty has some logic missing concerning setWritable() compared to Netty 3.5.10.Final
-  There is one commit missing:
-  - 452df045 Always fire interestChanged from IO thread
+- mina.netty version deliberately does not include the changes from the following commit:
+  452df045 Always fire interestChanged from IO thread
+  because in Kaazing the poll and offer methods on the WriteRequestQueue will always be called on the IO thread
+  so there is no need to incur the overhead of handling potential calls from other threads.
 
-AbstractNioSelector (not in sync)
+*AbstractNioSelector (not in sync)
 (appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)
 - mina.netty version adds cap on processTaskQueue duration plus some diagnostic log messages
 - mina.netty version adds processRead for udp
 - netty version now has no mention of the epoll bug
-- netty version has different logic in run() to tell is key should be cancelled (inc. fix for https://github.com/netty/netty/issues/2931)
-- netty version has logic in run() to deal with case where thread was interrupted during select ( bug fix)
+- netty version has different logic in run() to tell if key should be cancelled (inc. fix for https://github.com/netty/netty/issues/2931)
+- netty version has logic in run() to deal with case where thread was interrupted during select (another bug fix)
 - netty version uses SelectorUtil.open() instead of Selector.open()
 
 AbstractNioWorker

--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -6,6 +6,8 @@ Note that some of our copies of the Netty classes were copied from Netty version
 Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9).
 We only later upgraded our dependency to 3.10.5.Final (tag netty-3.10.5.Final).
 All changes made in Netty between 3.6.3 and 3.10.5 have now been applied to our copies.
+So if our copies are diff'd against https://github.com/netty/netty/tree/netty-3.10.5.Final
+the changes seen are only those we deliberaately made for Kaazing usage.
 
 AbstractChannel
 - mina.netty adds a single line code change to ensure id is positive

--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -22,7 +22,7 @@ AbstractNioChannel (may not be in sync)
   - 452df045 Always fire interestChanged from IO thread
 
 AbstractNioSelector (not in sync)
-(appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)k
+(appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)
 - mina.netty version adds cap on processTaskQueue duration plus some diagnostic log messages
 - mina.netty version adds processRead for udp
 - netty version now has no mention of the epoll bug

--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -1,0 +1,68 @@
+Analysis of netty-3.10.5.Final code compared to mina.netty
+==========================================================
+mina.netty contains some classes copied from Netty and then altered. This file documents what changes were made.
+
+Note that some of our copies of the Netty classes which are present in mina.netty original came from Netty version 3.6.3.Final.
+We only later upgraded our dependency to 3.10.5.Final. One purpose of this document is to check whether we pulled
+all the Netty changes into our copies.
+
+Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9)
+
+All classes are in sync with Netty 3.5.10.Final unless specifically stated.
+
+AbstractChannel
+(copied from netty 3.10.5.Final)
+- mina.netty adds a single line code change to ensure id is positive
+
+AbstractNioChannel (may not be in sync)
+(originally copied from netty 3.6.3.Final, some but not all changes were applied from netty 3.10.5.Final as part of upgrade)
+- mina.netty adds setWorker method (for thread migration)
+- mina.netty has some logic missing concerning setWritable() compared to Netty 3.5.10.Final
+  There is one commit missing:
+  - 452df045 Always fire interestChanged from IO thread
+
+AbstractNioSelector (not in sync)
+(appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)k
+- mina.netty version adds cap on processTaskQueue duration plus some diagnostic log messages
+- mina.netty version adds processRead for udp
+- netty version now has no mention of the epoll bug
+- netty version has different logic in run() to tell is key should be cancelled (inc. fix for https://github.com/netty/netty/issues/2931)
+- netty version has logic in run() to deal with case where thread was interrupted during select ( bug fix)
+- netty version uses SelectorUtil.open() instead of Selector.open()
+
+AbstractNioWorker
+(originally copied from netty 3.6.3.Final, all of the changes from netty 3.10.5.Final have been incorporated)
+- mina.netty version adds support for udp
+- mina.netty version adds deregister and register methods for thread migration
+- mina.netty version reduces GC by using a single writeCompletionEvent object
+- mina.netty version checks worker != null in isIoThread for migration support
+
+NioClientBoss
+(copied from netty-3.10.5.Final)
+- mina.netty version adds int return from process (workDone)
+
+NioDatagramChannel
+(copied from netty-3.10.5.Final)
+- mina.netty version adds a getWorker method
+- mina.netty version moves fireChannelConnected from NioDatagramPipelineSink to NioDatagramWorker
+
+NioDatagramPipelineSink
+(copied from netty-3.10.5.Final)
+- mina.netty version moves fireChannelConnected from NioDatagramPipelineSink to NioDatagramWorker
+
+NioServiceBoss
+(originally copied from netty 3.6.3.Final, but no changes were made in Netty between that and 3.10.5.Final)
+- mina.netty version has a major fix to close() method for Windows (which also necessitated changes to process method).
+
+NioWorker
+(originally copied from netty 3.6.3.Final, but the only change made between that and 3.10.5.Final has been applied)
+- mina.netty version has extra code added to limit how long we spend in processTasks() to avoid a lengthy task queue from excessively delaying processing of I/O events.
+
+NioChildDatagramChannel
+NioChildDatagramPipelineSink
+NioClientDatagramChannelFactory
+NioDatagramBossPool
+NioServerDatagramBoss
+NioServerDatagramChannelFactory
+- do not exist in netty 3.6.3.Final
+

--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -3,61 +3,54 @@ Analysis of netty-3.10.5.Final code compared to mina.netty
 mina.netty contains some classes copied from Netty and then altered. This file documents what changes were made.
 
 Note that some of our copies of the Netty classes were copied from Netty version 3.6.3.Final.
-We only later upgraded our dependency to 3.10.5.Final. One purpose of this document is to check whether we pulled
-all the Netty changes between 3.6.3 and 3.10.5 into our copies.
-
-Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9)
-
-All classes are in sync with Netty 3.5.10.Final unless otherwise marked with an asterisk below.
+Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9).
+We only later upgraded our dependency to 3.10.5.Final (tag netty-3.10.5.Final).
+All changes made in Netty between 3.6.3 and 3.10.5 have now been applied to our copies.
 
 AbstractChannel
-(copied from netty 3.10.5.Final)
 - mina.netty adds a single line code change to ensure id is positive
 
 AbstractNioChannel
-(originally copied from netty 3.6.3.Final, all desirable changes from netty 3.10.5.Final have been incorporated)
 - mina.netty adds setWorker method (for thread migration)
 - mina.netty version deliberately does not include the changes from the following commit:
   452df045 Always fire interestChanged from IO thread
   because in Kaazing the poll and offer methods on the WriteRequestQueue will always be called on the IO thread
   so there is no need to incur the overhead of handling potential calls from other threads.
 
-*AbstractNioSelector (not in sync)
-(appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)
+AbstractNioSelector
 - mina.netty version adds cap on processTaskQueue duration plus some diagnostic log messages
 - mina.netty version adds processRead for udp
-- netty version now has no mention of the epoll bug
-- netty version has different logic in run() to tell if key should be cancelled (inc. fix for https://github.com/netty/netty/issues/2931)
-- netty version has logic in run() to deal with case where thread was interrupted during select (another bug fix)
-- netty version uses SelectorUtil.open() instead of Selector.open()
+- mina.netty version only walks through keys and tests for thread interrupted in case where EPOLL_WORKAROUND 
+  is enabled. This is an optimization compared to Netty 3.10.5 and was done while apply Netty commit 
+  cfa10742 "[#2426] Not cause busy loop when interrupt Thread of AbstractNioSelector".
 
 AbstractNioWorker
-(originally copied from netty 3.6.3.Final, all of the changes from netty 3.10.5.Final have been incorporated)
 - mina.netty version adds support for udp
 - mina.netty version adds deregister and register methods for thread migration
 - mina.netty version reduces GC by using a single writeCompletionEvent object
 - mina.netty version checks worker != null in isIoThread for migration support
 
 NioClientBoss
-(copied from netty-3.10.5.Final)
 - mina.netty version adds int return from process (workDone)
 
 NioDatagramChannel
-(copied from netty-3.10.5.Final)
 - mina.netty version adds a getWorker method
 - mina.netty version moves fireChannelConnected from NioDatagramPipelineSink to NioDatagramWorker
 
 NioDatagramPipelineSink
-(copied from netty-3.10.5.Final)
 - mina.netty version moves fireChannelConnected from NioDatagramPipelineSink to NioDatagramWorker
 
 NioServiceBoss
-(originally copied from netty 3.6.3.Final, but no changes were made in Netty between that and 3.10.5.Final)
 - mina.netty version has a major fix to close() method for Windows (which also necessitated changes to process method).
 
 NioWorker
-(originally copied from netty 3.6.3.Final, but the only change made between that and 3.10.5.Final has been applied)
 - mina.netty version has extra code added to limit how long we spend in processTasks() to avoid a lengthy task queue from excessively delaying processing of I/O events.
+
+SelectorUtil
+- mina.netty version adds method select(Selector selector, long timeout)
+
+SocketSendBufferPool
+- mina.netty version has changes to reduce GC by using shared objects (send buffer) when possible.
 
 NioChildDatagramChannel
 NioChildDatagramPipelineSink

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
@@ -39,7 +39,6 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
@@ -318,6 +318,15 @@ abstract class AbstractNioChannel<C extends SelectableChannel & WritableByteChan
             if (newWriteBufferSize >= highWaterMark) {
                 if (newWriteBufferSize - messageSize < highWaterMark) {
                     highWaterMarkCounter.incrementAndGet();
+                    // For Kaazing the poll and offer methods on the WriteRequestQueue will always be called on the IO thread
+                    // so we do not need to incur the overhead of the following check (which was added in Netty 3.5.10
+                    // commit: 452df045 Always fire interestChanged from IO thread):
+                    /*
+                    if (setUnwritable()) {
+                        if (!isIoThread(AbstractNioChannel.this)) {
+                            fireChannelInterestChangedLater(AbstractNioChannel.this);
+                        } else
+                    */
                     if (!notifying.get()) {
                         notifying.set(Boolean.TRUE);
                         fireChannelInterestChanged(AbstractNioChannel.this);
@@ -339,6 +348,15 @@ abstract class AbstractNioChannel<C extends SelectableChannel & WritableByteChan
                 if (newWriteBufferSize == 0 || newWriteBufferSize < lowWaterMark) {
                     if (newWriteBufferSize + messageSize >= lowWaterMark) {
                         highWaterMarkCounter.decrementAndGet();
+                        // For Kaazing the poll and offer methods on the WriteRequestQueue will always be called on the IO thread
+                        // so we do not need to incur the overhead of the following check (which was added in Netty 3.5.10
+                        // commit: 452df045 Always fire interestChanged from IO thread):
+                        /*
+                        if (isConnected() && setWritable()) {
+                            if (!isIoThread(AbstractNioChannel.this)) {
+                               fireChannelInterestChangedLater(AbstractNioChannel.this);
+                            } else if (!notifying.get()) {
+                        */
                         if (isConnected() && !notifying.get()) {
                             notifying.set(Boolean.TRUE);
                             fireChannelInterestChanged(AbstractNioChannel.this);

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
@@ -248,7 +248,7 @@ abstract class AbstractNioSelector implements NioSelector {
                 long beforeSelect = System.nanoTime();
                 int selected = select(selector, quickSelect);
                 // The SelectorUtil.EPOLL_BUG_WORKAROUND condition was removed in Netty 3.10.5 and instead
-                // put in the if (selectReturnsImmediately == 1024) condition later on. This seems inefficient
+                // added to the if (selectReturnsImmediately == 1024) condition later on. This seems inefficient
                 // for the (common) case where the workaround is not enabled since in that case there's no point
                 // in looping through the selector keys, so we are keeping the condition here. There's no risk
                 // of a busy loop (https://github.com/netty/netty/issues/2426) when the workaround is not enabled.

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/SelectorUtil.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/SelectorUtil.java
@@ -74,6 +74,10 @@ final class SelectorUtil {
         }
     }
 
+    static Selector open() throws IOException {
+        return Selector.open();
+    }
+
     static int select(Selector selector) throws IOException {
         return select(selector, SELECT_TIMEOUT);
     }


### PR DESCRIPTION
I went through  all of our classes in mina.netty which are copies of classes from Netty, checking if all changes that were made in Netty between releases 3.6.3 (from which some of our classes were originally copied) and 3.10.5 (which we are now using as a dependency) have been applied to our copies. Some changes have not been applied, so this PR applies them. It also adds a mina.netty/README.txt file giving a summary of differences between our copies and Netty 3.10.5.

Note that I did not fully apply the changes to AbstractNioSelector and AbstractNioChannel. Comments in the code explain why (there was a risk of degrading performance).

If you diff our classes with Netty 3.10.5, the differences you see now consist only of changes we actually need to adapt them for Kaazing usage.