### PR TITLE
mina.netty: use selector.wakeup to speed up UDP event processing

### DIFF
--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -2,32 +2,33 @@ Analysis of netty-3.10.5.Final code compared to mina.netty
 ==========================================================
 mina.netty contains some classes copied from Netty and then altered. This file documents what changes were made.
 
-Note that some of our copies of the Netty classes which are present in mina.netty original came from Netty version 3.6.3.Final.
+Note that some of our copies of the Netty classes were copied from Netty version 3.6.3.Final.
 We only later upgraded our dependency to 3.10.5.Final. One purpose of this document is to check whether we pulled
-all the Netty changes into our copies.
+all the Netty changes between 3.6.3 and 3.10.5 into our copies.
 
 Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9)
 
-All classes are in sync with Netty 3.5.10.Final unless specifically stated.
+All classes are in sync with Netty 3.5.10.Final unless otherwise marked with an asterisk below.
 
 AbstractChannel
 (copied from netty 3.10.5.Final)
 - mina.netty adds a single line code change to ensure id is positive
 
-AbstractNioChannel (may not be in sync)
-(originally copied from netty 3.6.3.Final, some but not all changes were applied from netty 3.10.5.Final as part of upgrade)
+AbstractNioChannel
+(originally copied from netty 3.6.3.Final, all desirable changes from netty 3.10.5.Final have been incorporated)
 - mina.netty adds setWorker method (for thread migration)
-- mina.netty has some logic missing concerning setWritable() compared to Netty 3.5.10.Final
-  There is one commit missing:
-  - 452df045 Always fire interestChanged from IO thread
+- mina.netty version deliberately does not include the changes from the following commit:
+  452df045 Always fire interestChanged from IO thread
+  because in Kaazing the poll and offer methods on the WriteRequestQueue will always be called on the IO thread
+  so there is no need to incur the overhead of handling potential calls from other threads.
 
-AbstractNioSelector (not in sync)
+*AbstractNioSelector (not in sync)
 (appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)
 - mina.netty version adds cap on processTaskQueue duration plus some diagnostic log messages
 - mina.netty version adds processRead for udp
 - netty version now has no mention of the epoll bug
-- netty version has different logic in run() to tell is key should be cancelled (inc. fix for https://github.com/netty/netty/issues/2931)
-- netty version has logic in run() to deal with case where thread was interrupted during select ( bug fix)
+- netty version has different logic in run() to tell if key should be cancelled (inc. fix for https://github.com/netty/netty/issues/2931)
+- netty version has logic in run() to deal with case where thread was interrupted during select (another bug fix)
 - netty version uses SelectorUtil.open() instead of Selector.open()
 
 AbstractNioWorker

--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -6,6 +6,8 @@ Note that some of our copies of the Netty classes were copied from Netty version
 Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9).
 We only later upgraded our dependency to 3.10.5.Final (tag netty-3.10.5.Final).
 All changes made in Netty between 3.6.3 and 3.10.5 have now been applied to our copies.
+So if our copies are diff'd against https://github.com/netty/netty/tree/netty-3.10.5.Final
+the changes seen are only those we deliberaately made for Kaazing usage.
 
 AbstractChannel
 - mina.netty adds a single line code change to ensure id is positive

--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -22,7 +22,7 @@ AbstractNioChannel (may not be in sync)
   - 452df045 Always fire interestChanged from IO thread
 
 AbstractNioSelector (not in sync)
-(appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)k
+(appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)
 - mina.netty version adds cap on processTaskQueue duration plus some diagnostic log messages
 - mina.netty version adds processRead for udp
 - netty version now has no mention of the epoll bug

--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -1,0 +1,68 @@
+Analysis of netty-3.10.5.Final code compared to mina.netty
+==========================================================
+mina.netty contains some classes copied from Netty and then altered. This file documents what changes were made.
+
+Note that some of our copies of the Netty classes which are present in mina.netty original came from Netty version 3.6.3.Final.
+We only later upgraded our dependency to 3.10.5.Final. One purpose of this document is to check whether we pulled
+all the Netty changes into our copies.
+
+Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9)
+
+All classes are in sync with Netty 3.5.10.Final unless specifically stated.
+
+AbstractChannel
+(copied from netty 3.10.5.Final)
+- mina.netty adds a single line code change to ensure id is positive
+
+AbstractNioChannel (may not be in sync)
+(originally copied from netty 3.6.3.Final, some but not all changes were applied from netty 3.10.5.Final as part of upgrade)
+- mina.netty adds setWorker method (for thread migration)
+- mina.netty has some logic missing concerning setWritable() compared to Netty 3.5.10.Final
+  There is one commit missing:
+  - 452df045 Always fire interestChanged from IO thread
+
+AbstractNioSelector (not in sync)
+(appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)k
+- mina.netty version adds cap on processTaskQueue duration plus some diagnostic log messages
+- mina.netty version adds processRead for udp
+- netty version now has no mention of the epoll bug
+- netty version has different logic in run() to tell is key should be cancelled (inc. fix for https://github.com/netty/netty/issues/2931)
+- netty version has logic in run() to deal with case where thread was interrupted during select ( bug fix)
+- netty version uses SelectorUtil.open() instead of Selector.open()
+
+AbstractNioWorker
+(originally copied from netty 3.6.3.Final, all of the changes from netty 3.10.5.Final have been incorporated)
+- mina.netty version adds support for udp
+- mina.netty version adds deregister and register methods for thread migration
+- mina.netty version reduces GC by using a single writeCompletionEvent object
+- mina.netty version checks worker != null in isIoThread for migration support
+
+NioClientBoss
+(copied from netty-3.10.5.Final)
+- mina.netty version adds int return from process (workDone)
+
+NioDatagramChannel
+(copied from netty-3.10.5.Final)
+- mina.netty version adds a getWorker method
+- mina.netty version moves fireChannelConnected from NioDatagramPipelineSink to NioDatagramWorker
+
+NioDatagramPipelineSink
+(copied from netty-3.10.5.Final)
+- mina.netty version moves fireChannelConnected from NioDatagramPipelineSink to NioDatagramWorker
+
+NioServiceBoss
+(originally copied from netty 3.6.3.Final, but no changes were made in Netty between that and 3.10.5.Final)
+- mina.netty version has a major fix to close() method for Windows (which also necessitated changes to process method).
+
+NioWorker
+(originally copied from netty 3.6.3.Final, but the only change made between that and 3.10.5.Final has been applied)
+- mina.netty version has extra code added to limit how long we spend in processTasks() to avoid a lengthy task queue from excessively delaying processing of I/O events.
+
+NioChildDatagramChannel
+NioChildDatagramPipelineSink
+NioClientDatagramChannelFactory
+NioDatagramBossPool
+NioServerDatagramBoss
+NioServerDatagramChannelFactory
+- do not exist in netty 3.6.3.Final
+

--- a/mina.netty/README.txt
+++ b/mina.netty/README.txt
@@ -3,61 +3,54 @@ Analysis of netty-3.10.5.Final code compared to mina.netty
 mina.netty contains some classes copied from Netty and then altered. This file documents what changes were made.
 
 Note that some of our copies of the Netty classes were copied from Netty version 3.6.3.Final.
-We only later upgraded our dependency to 3.10.5.Final. One purpose of this document is to check whether we pulled
-all the Netty changes between 3.6.3 and 3.10.5 into our copies.
-
-Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9)
-
-All classes are in sync with Netty 3.5.10.Final unless otherwise marked with an asterisk below.
+Netty version 3.6.3.Final is tag netty-3.6.3.Final (commit d70e3c1561f9).
+We only later upgraded our dependency to 3.10.5.Final (tag netty-3.10.5.Final).
+All changes made in Netty between 3.6.3 and 3.10.5 have now been applied to our copies.
 
 AbstractChannel
-(copied from netty 3.10.5.Final)
 - mina.netty adds a single line code change to ensure id is positive
 
 AbstractNioChannel
-(originally copied from netty 3.6.3.Final, all desirable changes from netty 3.10.5.Final have been incorporated)
 - mina.netty adds setWorker method (for thread migration)
 - mina.netty version deliberately does not include the changes from the following commit:
   452df045 Always fire interestChanged from IO thread
   because in Kaazing the poll and offer methods on the WriteRequestQueue will always be called on the IO thread
   so there is no need to incur the overhead of handling potential calls from other threads.
 
-*AbstractNioSelector (not in sync)
-(appears to be based on netty-3.6.3.Final with no attempt at pulling in changes from 3.10.5.Final)
+AbstractNioSelector
 - mina.netty version adds cap on processTaskQueue duration plus some diagnostic log messages
 - mina.netty version adds processRead for udp
-- netty version now has no mention of the epoll bug
-- netty version has different logic in run() to tell if key should be cancelled (inc. fix for https://github.com/netty/netty/issues/2931)
-- netty version has logic in run() to deal with case where thread was interrupted during select (another bug fix)
-- netty version uses SelectorUtil.open() instead of Selector.open()
+- mina.netty version only walks through keys and tests for thread interrupted in case where EPOLL_WORKAROUND 
+  is enabled. This is an optimization compared to Netty 3.10.5 and was done while apply Netty commit 
+  cfa10742 "[#2426] Not cause busy loop when interrupt Thread of AbstractNioSelector".
 
 AbstractNioWorker
-(originally copied from netty 3.6.3.Final, all of the changes from netty 3.10.5.Final have been incorporated)
 - mina.netty version adds support for udp
 - mina.netty version adds deregister and register methods for thread migration
 - mina.netty version reduces GC by using a single writeCompletionEvent object
 - mina.netty version checks worker != null in isIoThread for migration support
 
 NioClientBoss
-(copied from netty-3.10.5.Final)
 - mina.netty version adds int return from process (workDone)
 
 NioDatagramChannel
-(copied from netty-3.10.5.Final)
 - mina.netty version adds a getWorker method
 - mina.netty version moves fireChannelConnected from NioDatagramPipelineSink to NioDatagramWorker
 
 NioDatagramPipelineSink
-(copied from netty-3.10.5.Final)
 - mina.netty version moves fireChannelConnected from NioDatagramPipelineSink to NioDatagramWorker
 
 NioServiceBoss
-(originally copied from netty 3.6.3.Final, but no changes were made in Netty between that and 3.10.5.Final)
 - mina.netty version has a major fix to close() method for Windows (which also necessitated changes to process method).
 
 NioWorker
-(originally copied from netty 3.6.3.Final, but the only change made between that and 3.10.5.Final has been applied)
 - mina.netty version has extra code added to limit how long we spend in processTasks() to avoid a lengthy task queue from excessively delaying processing of I/O events.
+
+SelectorUtil
+- mina.netty version adds method select(Selector selector, long timeout)
+
+SocketSendBufferPool
+- mina.netty version has changes to reduce GC by using shared objects (send buffer) when possible.
 
 NioChildDatagramChannel
 NioChildDatagramPipelineSink

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
@@ -39,7 +39,6 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioChannel.java
@@ -318,6 +318,15 @@ abstract class AbstractNioChannel<C extends SelectableChannel & WritableByteChan
             if (newWriteBufferSize >= highWaterMark) {
                 if (newWriteBufferSize - messageSize < highWaterMark) {
                     highWaterMarkCounter.incrementAndGet();
+                    // For Kaazing the poll and offer methods on the WriteRequestQueue will always be called on the IO thread
+                    // so we do not need to incur the overhead of the following check (which was added in Netty 3.5.10
+                    // commit: 452df045 Always fire interestChanged from IO thread):
+                    /*
+                    if (setUnwritable()) {
+                        if (!isIoThread(AbstractNioChannel.this)) {
+                            fireChannelInterestChangedLater(AbstractNioChannel.this);
+                        } else
+                    */
                     if (!notifying.get()) {
                         notifying.set(Boolean.TRUE);
                         fireChannelInterestChanged(AbstractNioChannel.this);
@@ -339,6 +348,15 @@ abstract class AbstractNioChannel<C extends SelectableChannel & WritableByteChan
                 if (newWriteBufferSize == 0 || newWriteBufferSize < lowWaterMark) {
                     if (newWriteBufferSize + messageSize >= lowWaterMark) {
                         highWaterMarkCounter.decrementAndGet();
+                        // For Kaazing the poll and offer methods on the WriteRequestQueue will always be called on the IO thread
+                        // so we do not need to incur the overhead of the following check (which was added in Netty 3.5.10
+                        // commit: 452df045 Always fire interestChanged from IO thread):
+                        /*
+                        if (isConnected() && setWritable()) {
+                            if (!isIoThread(AbstractNioChannel.this)) {
+                               fireChannelInterestChangedLater(AbstractNioChannel.this);
+                            } else if (!notifying.get()) {
+                        */
                         if (isConnected() && !notifying.get()) {
                             notifying.set(Boolean.TRUE);
                             fireChannelInterestChanged(AbstractNioChannel.this);

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
@@ -244,7 +244,6 @@ abstract class AbstractNioSelector implements NioSelector {
             wakenUp.set(false);
 
             try {
-                int workCount = 0;
                 long beforeSelect = System.nanoTime();
                 int selected = select(selector, quickSelect);
                 // The SelectorUtil.EPOLL_BUG_WORKAROUND condition was removed in Netty 3.10.5 and instead
@@ -353,10 +352,10 @@ abstract class AbstractNioSelector implements NioSelector {
                 cancelledKeys = 0;
                 if (maximumProcessTaskQueueNanos > 0) {
                     long deadlineNanos = System.nanoTime() + maximumProcessTaskQueueNanos;
-                    workCount += processTaskQueue(deadlineNanos);
+                    quickSelect = processTaskQueue(deadlineNanos);
                 }
                 else {
-                    workCount += processTaskQueue();
+                    processTaskQueue();
                 }
                 selector = this.selector; // processTaskQueue() can call rebuildSelector()
 
@@ -364,7 +363,7 @@ abstract class AbstractNioSelector implements NioSelector {
                     this.selector = null;
 
                     // process one time again
-                    workCount += processTaskQueue();
+                    processTaskQueue();
 
                     for (SelectionKey k: selector.keys()) {
                         close(k);
@@ -379,10 +378,9 @@ abstract class AbstractNioSelector implements NioSelector {
                     shutdownLatch.countDown();
                     break;
                 } else {
-                    workCount += process(selector);
-                    workCount += processRead();
+                    process(selector);
+                    processRead();
                 }
-                //idleStrategy.idle(workCount);
             } catch (Throwable t) {
                 logger.warn(
                         "Unexpected exception in the selector loop.", t);
@@ -430,15 +428,13 @@ abstract class AbstractNioSelector implements NioSelector {
         assert selector != null && selector.isOpen();
     }
 
-    protected int processTaskQueue() {
-        int workCount = 0;
+    protected void processTaskQueue() {
         for (;;) {
             final Runnable task = taskQueue.poll();
             if (task == null) {
                 break;
             }
-            task.run();
-            workCount++;
+            task.run();;
 
             try {
                 cleanUpCancelledKeys();
@@ -446,16 +442,17 @@ abstract class AbstractNioSelector implements NioSelector {
                 // Ignore
             }
         }
-        return workCount;
     }
 
-    private int processTaskQueue(long deadLineNanos) {
+    private boolean processTaskQueue(long deadLineNanos) {
         int numTasks = 0;
         boolean perfLogEnabled = PERF_LOGGER.isInfoEnabled();
         long startTime = perfLogEnabled ? System.nanoTime() : 0;
+        boolean quickSelect;
         for (;;) {
             final Runnable task = taskQueue.poll();
             if (task == null) {
+                quickSelect = false;
                 break;
             }
             numTasks++;
@@ -477,10 +474,11 @@ abstract class AbstractNioSelector implements NioSelector {
                     }
                 }
                 // Make sure select in run() loop is no wait or short since we still have tasks to do
+                quickSelect = true;
                 break;
             }
         }
-        return numTasks;
+        return quickSelect;
     }
 
     protected final void increaseCancelledKeys() {
@@ -515,24 +513,17 @@ abstract class AbstractNioSelector implements NioSelector {
         }
     }
 
-    // returns work count
-    protected abstract int process(Selector selector) throws IOException;
+    protected abstract void process(Selector selector) throws IOException;
 
-    // returns work count
-    protected int processRead() throws IOException {
-        return 0;
+    protected void processRead() throws IOException {
     }
 
     protected int select(Selector selector, boolean quickSelect) throws IOException {
-        if (quickSelect) {
-            return SelectorUtil.select(selector, 0L);
-        } else {
-            return select(selector);
-        }
+        return select(selector);
     }
 
     protected int select(Selector selector) throws IOException {
-        return SelectorUtil.select(selector, 10L);
+        return SelectorUtil.select(selector);
     }
 
     protected abstract void close(SelectionKey k);

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
@@ -248,7 +248,7 @@ abstract class AbstractNioSelector implements NioSelector {
                 long beforeSelect = System.nanoTime();
                 int selected = select(selector, quickSelect);
                 // The SelectorUtil.EPOLL_BUG_WORKAROUND condition was removed in Netty 3.10.5 and instead
-                // put in the if (selectReturnsImmediately == 1024) condition later on. This seems inefficient
+                // added to the if (selectReturnsImmediately == 1024) condition later on. This seems inefficient
                 // for the (common) case where the workaround is not enabled since in that case there's no point
                 // in looping through the selector keys, so we are keeping the condition here. There's no risk
                 // of a busy loop (https://github.com/netty/netty/issues/2426) when the workaround is not enabled.

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioClientBoss.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioClientBoss.java
@@ -90,15 +90,13 @@ public final class NioClientBoss extends AbstractNioSelector implements Boss {
     }
 
     @Override
-    protected int process(Selector selector) {
+    protected void process(Selector selector) {
         Set<SelectionKey> selectedKeys = selector.selectedKeys();
-        int workCount = selectedKeys.size();
         processSelectedKeys(selectedKeys);
 
         // Handle connection timeout every 10 milliseconds approximately.
         long currentTimeNanos = System.nanoTime();
         processConnectTimeout(selector.keys(), currentTimeNanos);
-        return workCount;
     }
 
     private void processSelectedKeys(Set<SelectionKey> selectedKeys) {

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioServerBoss.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioServerBoss.java
@@ -139,7 +139,7 @@ public final class NioServerBoss extends AbstractNioSelector
     }
 
     @Override
-    protected int process(Selector selector) {
+    protected void process(Selector selector) {
         Iterator<ChannelFuture> iter = channelUnregisteredFutures.iterator();
         if (iter.hasNext()) {
             boolean isDebugEnabled = logger.isDebugEnabled();
@@ -168,9 +168,8 @@ public final class NioServerBoss extends AbstractNioSelector
         }
 
         Set<SelectionKey> selectedKeys = selector.selectedKeys();
-        int workCount = selectedKeys.size();
         if (selectedKeys.isEmpty()) {
-            return 0;
+            return;
         }
         for (Iterator<SelectionKey> i = selectedKeys.iterator(); i.hasNext();) {
             SelectionKey k = i.next();
@@ -208,7 +207,6 @@ public final class NioServerBoss extends AbstractNioSelector
                 }
             }
         }
-        return workCount;
     }
 
     private static void registerAcceptedChannel(NioServerSocketChannel parent, SocketChannel acceptedSocket,

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioWorker.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioWorker.java
@@ -178,7 +178,7 @@ public class NioWorker extends AbstractNioWorker {
         if (quickSelect) {
             return SelectorUtil.select(selector, QUICK_SELECT_TIMEOUT);
         } else {
-            return SelectorUtil.select(selector, 10L);
+            return SelectorUtil.select(selector);
         }
     }
 

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/SelectorUtil.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/SelectorUtil.java
@@ -74,6 +74,10 @@ final class SelectorUtil {
         }
     }
 
+    static Selector open() throws IOException {
+        return Selector.open();
+    }
+
     static int select(Selector selector) throws IOException {
         return select(selector, SELECT_TIMEOUT);
     }


### PR DESCRIPTION
This PR is for issue #752.
Added code to wakeup the selector in AbstractNioWorker.messageReceived so we process UDP events immediately. Undid the code changes to return workCount from the various process methods, and restored the logic to use quickSelect if processTasks(deadline) finds there are still tasks waiting to complete.