### PR TITLE
shutdown causes selector loop not terminate

### DIFF
--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioSelector.java
@@ -346,12 +346,16 @@ abstract class AbstractNioSelector implements NioSelector {
                     workCount += processTaskQueue();
 
                     for (SelectionKey k: selector.keys()) {
-                        close(k);
+                        try {
+                            close(k);
+                        } catch (Throwable e) {
+                            logger.warn("Failed to close a selection key.", e);
+                        }
                     }
 
                     try {
                         selector.close();
-                    } catch (IOException e) {
+                    } catch (Throwable e) {
                         logger.warn(
                                 "Failed to close a selector.", e);
                     }


### PR DESCRIPTION
Fix for: https://github.com/kaazing/tickets/issues/825

shutdown block sets selector to null. If there is some exception during the close of SelectionKey, it goes into infinite loop. Fixing this.