### PR TITLE
(service/proxy) Make AbstractProxyHandler.setMaximumPendingBytes public

### DIFF
--- a/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/AbstractProxyAcceptHandler.java
+++ b/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/AbstractProxyAcceptHandler.java
@@ -95,7 +95,7 @@ public abstract class AbstractProxyAcceptHandler extends AbstractProxyHandler {
     }
 
     @Override
-    void setMaximumPendingBytes(int maximumPendingBytes) {
+    public void setMaximumPendingBytes(int maximumPendingBytes) {
         super.setMaximumPendingBytes(maximumPendingBytes);
         connectHandler.setMaximumPendingBytes(maximumPendingBytes);
     }

--- a/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/AbstractProxyHandler.java
+++ b/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/AbstractProxyHandler.java
@@ -67,7 +67,7 @@ public abstract class AbstractProxyHandler extends IoHandlerAdapter {
         // TODO: consider adding a new SessionClosingFilter on the network end of the filter chain to fulfill the
         // session close future if an IOEXception is reported in exceptionCaught. Then session.isClosing() would
         // suffice here and anywhere else we may need this logic.
-        boolean connectionClosing = session.isClosing() || (cause instanceof IOException); 
+        boolean connectionClosing = session.isClosing() || (cause instanceof IOException);
         session.close(connectionClosing);
     }
 
@@ -122,7 +122,7 @@ public abstract class AbstractProxyHandler extends IoHandlerAdapter {
         }
     }
 
-    void setMaximumPendingBytes(int maximumPendingBytes) {
+    public void setMaximumPendingBytes(int maximumPendingBytes) {
         this.maximumPendingBytes = maximumPendingBytes;
         thresholdPendingBytes = maximumPendingBytes / 2;
         if (LOGGER.isDebugEnabled()) {

--- a/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/AbstractProxyService.java
+++ b/service/proxy/src/main/java/org/kaazing/gateway/service/proxy/AbstractProxyService.java
@@ -29,7 +29,6 @@ import org.kaazing.gateway.service.Service;
 import org.kaazing.gateway.service.ServiceContext;
 import org.kaazing.gateway.service.ServiceProperties;
 import org.kaazing.gateway.util.scheduler.SchedulerProvider;
-import org.slf4j.Logger;
 
 
 /**


### PR DESCRIPTION
(consistent with setMaximumRecoveryInterval) so it can be used by other services whose handlers extend AbstractProxyHandler.
Also removed an unused import from AbstractProxyService.