### PR TITLE
Simplify WsnAcceptorRule by removing the unused log4j related logic and using TransportFactory.injectResources

### DIFF
--- a/management/pom.xml
+++ b/management/pom.xml
@@ -140,14 +140,17 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock-junit4</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.kaazing</groupId>


### PR DESCRIPTION
This is a change I did in a branch way back in February and it never got merged. It's worth merging since it simplifies the code and make it clearer and less brittle. And it follows the model used in HttpAcceptorRule.