### PR TITLE
Converting transport options that contain tls values

### DIFF
--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultOptionsContext.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultOptionsContext.java
@@ -234,8 +234,13 @@ class DefaultOptionsContext {
                     }
                 }
                 String localName = node.getLocalName();
+                // convert options like tls.ciphers converted to ssl.ciphers
                 if (localName.contains("tls")) {
                     localName = localName.replace("tls", "ssl");
+                }
+                // convert options like pipe.transport=socks+tls://foo to pipe.transport=socks+ssl://foo
+                if (localName.contains(".transport") && nodeValue.contains("tls://")) {
+                    nodeValue = nodeValue.replace("tls://", "ssl://");
                 }
                 optionsMap.put(localName, nodeValue);
             }

--- a/server/src/test/java/org/kaazing/gateway/server/context/resolve/AcceptOptionsTest.java
+++ b/server/src/test/java/org/kaazing/gateway/server/context/resolve/AcceptOptionsTest.java
@@ -78,6 +78,12 @@ public class AcceptOptionsTest {
     }
 
     @Test
+    public void testTlsCiphersOption() throws Exception {
+        expectSuccess("tls.ciphers", "  FOO,BAR ", "ssl.ciphers", new String[]{"FOO", "BAR"});
+        expectParseFailure("tls.ciphers", "FOO, BAR");
+    }
+
+    @Test
     public void testHttpKeepAliveTimeoutOption() throws Exception {
         // expect default if 0 is specified
         expectSuccess("http.keepalive.timeout", "0 minutes", "http[http/1.1].keepAliveTimeout", 30);
@@ -96,6 +102,12 @@ public class AcceptOptionsTest {
     public void testHttpTransportOption() throws Exception {
         expectSuccess("http.transport", "tcp://127.0.0.1:80", "http[http/1.1].transport", "tcp://127.0.0.1:80");
         expectSuccess("http.transport", "tcp://127.0.0.1:80", "http.transport", null);
+    }
+
+    @Test
+    public void testTlsTransportOption() throws Exception {
+        expectSuccess("tls.transport", "tcp://127.0.0.1:80", "ssl.transport", "tcp://127.0.0.1:80");
+        expectSuccess("tls.transport", "tcp://127.0.0.1:80", "tls.transport", null);
     }
 
     @Test


### PR DESCRIPTION
When option values contain tls transports, they are replaced with ssl
For example: pipe.transport=socks+tls://foo, it will be replaced by
pipe.transport=socks+ssl://foo