### PR TITLE
Fixed instance were SslConnector was limiting the TLS session cache o…

### DIFF
--- a/transport/ssl/src/main/java/org/kaazing/gateway/transport/ssl/SslConnector.java
+++ b/transport/ssl/src/main/java/org/kaazing/gateway/transport/ssl/SslConnector.java
@@ -124,7 +124,7 @@ public class SslConnector extends AbstractBridgeConnector<SslSession> {
             // avoid caching SSLSession in shared SSLContextFactory instance
             // Note: SSLSessionContext.setSessionCacheSize(0) means unlimited,
             // so we use 1 instead
-            sslContextFactory.setServerSessionCacheSize(1);
+            sslContextFactory.setClientSessionCacheSize(1);
         } catch (NoSuchAlgorithmException ne) {
             throw new RuntimeException(ne);
         }


### PR DESCRIPTION
…f incoming connections/accepts, as opposed to outgoing connection/connects.