### PR TITLE
Validating Host header when client sends a request in absolute-form

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <hazelcast.version>1.9.4.8</hazelcast.version>
-        <k3po.version>3.0.0-alpha-55</k3po.version>
+        <k3po.version>3.0.0-alpha-56</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
         <slf4j.log4j.version>1.7.21</slf4j.log4j.version>

--- a/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceIT.java
+++ b/service/http.directory/src/test/java/org/kaazing/gateway/service/http/directory/HttpDirectoryServiceIT.java
@@ -179,11 +179,6 @@ public class HttpDirectoryServiceIT {
     }
 
     // /////////////////// HOST HEADER ///////////////////////
-    @Specification("host/host.empty.header.with.absolute.uri")
-    @Test
-    public void testEmptyHostHeaderWithAbsoluteUri() throws Exception {
-        robot.finish();
-    }
 
     @Specification("host/host.empty.header.with.relative.uri")
     @Test

--- a/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyMalformedRequestsIT.java
+++ b/service/http.proxy/src/test/java/org/kaazing/gateway/service/http/proxy/HttpProxyMalformedRequestsIT.java
@@ -81,7 +81,6 @@ public class HttpProxyMalformedRequestsIT {
         robot.finish();
     }
 
-    @Ignore("https://github.com/kaazing/tickets/issues/629")
     @Specification("http.proxy.malformed.hostname.not.match.uri")
     @Test
     public void hostnameDoesNotMatchUri() throws Exception {

--- a/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.malformed.hostname.not.match.uri.rpt
+++ b/service/http.proxy/src/test/scripts/org/kaazing/gateway/service/http/proxy/http.proxy.malformed.hostname.not.match.uri.rpt
@@ -29,25 +29,3 @@ read "HTTP/1.1 400 Bad Request" "\r\n"
 
 close
 closed
-
-#
-# server
-#
-
-accept tcp://localhost:8080
-accepted
-connected
-
-read "GET / HTTP/1.1\r\n"
-read /Via: 1.1 kaazing-.+/ "\r\n"
-read "User-Agent: Kaazing Gateway\r\n"
-read "Host: anotherhost:8080" "\r\n"
-read "Host: localhost:8080" "\r\n"
-read "Connection: close\r\n"
-read "\r\n"
-
-write "HTTP/1.1 400 Bad Request" "\r\n"
-write "\r\n"
-
-close
-closed

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/HttpRequestMessage.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/HttpRequestMessage.java
@@ -43,6 +43,8 @@ public class HttpRequestMessage extends HttpStartMessage {
 	private boolean secure;
 	private Map<String, List<String>> parameters;
 	private URI requestURI;
+	private URI absoluteRequestURI;
+
 	private HttpMethod method;
 	private ResourceAddress localAddress;
 	private Subject subject;
@@ -153,6 +155,14 @@ public class HttpRequestMessage extends HttpStartMessage {
 	public Map<String, List<String>> getParameters() {
 		Map<String, List<String>> parameters = getParameters(false);
 		return (parameters != null && !parameters.isEmpty()) ? Collections.unmodifiableMap(parameters) : EMPTY_PARAMETERS;
+	}
+
+	public void setAbsoluteRequestURI(URI absoluteRequestURI) {
+		this.absoluteRequestURI = absoluteRequestURI;
+	}
+
+	public URI getAbsoluteRequestURI() {
+		return absoluteRequestURI;
 	}
 
 	public void setRequestURI(URI requestURI) {

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpProtocolDecoderException.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/bridge/filter/HttpProtocolDecoderException.java
@@ -29,6 +29,11 @@ public class HttpProtocolDecoderException extends ProtocolDecoderException {
 	public HttpProtocolDecoderException(HttpStatus status) {
 		httpStatus = status;
 	}
+
+	public HttpProtocolDecoderException(String msg, HttpStatus status) {
+		super(msg);
+		httpStatus = status;
+	}
 	
 	public HttpStatus getHttpStatus() {
 		return httpStatus;

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/acceptor/specification/rfc7230/MessageRoutingIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/acceptor/specification/rfc7230/MessageRoutingIT.java
@@ -82,20 +82,10 @@ public class MessageRoutingIT {
     @Test
     @Specification({"inbound.must.reject.request.with.400.if.host.header.does.not.match.uri/request"})
     public void inboundMustRejectRequestWith400IfHostHeaderDoesNotMatchURI() throws Exception {
-        final CountDownLatch latch = new CountDownLatch(1);
-
-        final IoHandler acceptHandler = new IoHandlerAdapter<HttpAcceptSession>() {
-            @Override
-            protected void doSessionOpened(HttpAcceptSession session) throws Exception {
-                latch.countDown();
-                session.setStatus(HttpStatus.CLIENT_BAD_REQUEST);
-                session.close(true);
-            }
-        };
+        IoHandler acceptHandler = new IoHandlerAdapter<HttpAcceptSession>();
         acceptor.bind(HTTP_ADDRESS, acceptHandler);
 
         k3po.finish();
-        assertTrue(latch.await(4, SECONDS));
     }
 
     @Test


### PR DESCRIPTION
RFC 7230 says "A server MUST respond with a 400 (Bad Request) status code to any
HTTP/1.1 request message that lacks a Host header field and to any
request message that contains more than one Host header field or a
Host header field with an invalid field-value."

From Server's point of view, if there is Host header with invalid field-value,
Http acceptor should send 400 status code.