### PR TITLE
Reusing of downstream message event issue for udp

### DIFF
--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioChildDatagramPipelineSink.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioChildDatagramPipelineSink.java
@@ -71,48 +71,51 @@ class NioChildDatagramPipelineSink extends AbstractNioChannelSink {
                     break;
             }
         } else if (e instanceof MessageEvent) {
+            // Making sure that child channel WriteFuture is fired on child channel's worker thread
             final MessageEvent childMessageEvent = (MessageEvent) e;
             ParentMessageEvent parentMessageEvent = new ParentMessageEvent(childMessageEvent);
+            ChannelFuture parentFuture = parentMessageEvent.getFuture();
+            parentFuture.addListener(f -> {
+                childChannel.getWorker().executeInIoThread(() -> {
+                    if (f.isSuccess()) {
+                        childFuture.setSuccess();
+                    } else {
+                        childFuture.setFailure(f.getCause());
+                    }
+                });
+            });
 
             // Write to parent channel
             NioDatagramChannel parentChannel = (NioDatagramChannel) childChannel.getParent();
             boolean offered = parentChannel.writeBufferQueue.offer(parentMessageEvent);
             assert offered;
             parentChannel.worker.writeFromUserCode(parentChannel);
-
-            // No need to propagate parentMessageEvent.getFuture() to childFuture
-            // as UDP is unreliable.
-            childFuture.setSuccess();
         }
     }
 
     private static final class ParentMessageEvent implements MessageEvent {
 
+        private final MessageEvent delegate;
         private final ChannelFuture parentFuture;
-        private final Object message;
-        private final SocketAddress remoteAddress;
-        private final Channel channel;
 
         ParentMessageEvent(MessageEvent delegate) {
-            this.message = delegate.getMessage();
-            this.remoteAddress = delegate.getRemoteAddress();
-            this.channel = delegate.getChannel();
+            this.delegate = delegate;
             this.parentFuture = new DefaultChannelFutureEx();
         }
 
         @Override
         public Object getMessage() {
-            return message;
+            return delegate.getMessage();
         }
 
         @Override
         public SocketAddress getRemoteAddress() {
-            return remoteAddress;
+            return delegate.getRemoteAddress();
         }
 
         @Override
         public Channel getChannel() {
-            return channel;
+            return delegate.getChannel();
         }
 
         @Override

--- a/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioChildDatagramPipelineSink.java
+++ b/mina.netty/src/main/java/org/jboss/netty/channel/socket/nio/NioChildDatagramPipelineSink.java
@@ -88,27 +88,31 @@ class NioChildDatagramPipelineSink extends AbstractNioChannelSink {
 
     private static final class ParentMessageEvent implements MessageEvent {
 
-        private final MessageEvent delegate;
         private final ChannelFuture parentFuture;
+        private final Object message;
+        private final SocketAddress remoteAddress;
+        private final Channel channel;
 
         ParentMessageEvent(MessageEvent delegate) {
-            this.delegate = delegate;
+            this.message = delegate.getMessage();
+            this.remoteAddress = delegate.getRemoteAddress();
+            this.channel = delegate.getChannel();
             this.parentFuture = new DefaultChannelFutureEx();
         }
 
         @Override
         public Object getMessage() {
-            return delegate.getMessage();
+            return message;
         }
 
         @Override
         public SocketAddress getRemoteAddress() {
-            return delegate.getRemoteAddress();
+            return remoteAddress;
         }
 
         @Override
         public Channel getChannel() {
-            return delegate.getChannel();
+            return channel;
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <hazelcast.version>1.9.4.8</hazelcast.version>
-        <k3po.version>3.0.0-alpha-57</k3po.version>
+        <k3po.version>3.0.0-alpha-58</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
         <slf4j.log4j.version>1.7.21</slf4j.log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.testSource>1.8</maven.compiler.testSource>
         <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <hazelcast.version>1.9.4.8</hazelcast.version>
-        <k3po.version>3.0.0-alpha-56</k3po.version>
+        <k3po.version>3.0.0-alpha-57</k3po.version>
         <jdom.version>1.1</jdom.version>
         <jmock.version>2.6.0</jmock.version>
         <slf4j.log4j.version>1.7.21</slf4j.log4j.version>


### PR DESCRIPTION
If the child future is fired, the event object is reused. So caching all event info into parent message event. This may fix https://github.com/kaazing/gateway/issues/796