### PR TITLE
Add logging filter constructor

### DIFF
--- a/transport/spi/src/main/java/org/kaazing/gateway/transport/ExceptionLoggingFilter.java
+++ b/transport/spi/src/main/java/org/kaazing/gateway/transport/ExceptionLoggingFilter.java
@@ -32,6 +32,10 @@ public class ExceptionLoggingFilter
         super(logger, "%s");
     }
 
+    public ExceptionLoggingFilter(Logger logger, IoSession session, String transportName) {
+        super(logger, session, transportName);
+    }
+
     @Override
     protected void logSessionCreated(IoSession session) {
         // Do not log

--- a/transport/spi/src/main/java/org/kaazing/gateway/transport/LoggingFilter.java
+++ b/transport/spi/src/main/java/org/kaazing/gateway/transport/LoggingFilter.java
@@ -15,6 +15,8 @@
  */
 package org.kaazing.gateway.transport;
 
+import static java.lang.Thread.currentThread;
+
 import java.io.IOException;
 
 import org.apache.mina.core.filterchain.IoFilterAdapter;
@@ -25,6 +27,7 @@ import org.apache.mina.core.session.IoSession;
 import org.apache.mina.core.write.WriteRequest;
 import org.apache.mina.filter.logging.LogLevel;
 import org.kaazing.gateway.transport.bridge.Message;
+import org.kaazing.mina.core.session.IoSessionEx;
 import org.kaazing.mina.filter.codec.ProtocolCodecFilter;
 import org.slf4j.Logger;
 
@@ -94,6 +97,10 @@ public class LoggingFilter extends IoFilterAdapter {
         this(logger, "%s");
     }
 
+    public LoggingFilter(Logger logger, IoSession session, String transportName) {
+        this(logger, getLoggingFormat(session, transportName));
+    }
+
     public LoggingFilter(Logger logger, String sessionIdFormat) {
         if (logger == null) {
             throw new NullPointerException("logger");
@@ -120,12 +127,11 @@ public class LoggingFilter extends IoFilterAdapter {
             return false;
         }
         String loggingFilterName = transportName + "#logging";
-        String format = getLoggingFormat(session, transportName);
         if (logger.isTraceEnabled()) {
-            session.getFilterChain().addLast(loggingFilterName, new ObjectLoggingFilter(logger, format));
+            session.getFilterChain().addLast(loggingFilterName, new ObjectLoggingFilter(logger, session, transportName));
             return true;
         } else {
-            session.getFilterChain().addLast(loggingFilterName, new ExceptionLoggingFilter(logger, format));
+            session.getFilterChain().addLast(loggingFilterName, new ExceptionLoggingFilter(logger, session, transportName));
             return true;
         }
     }

--- a/transport/spi/src/main/java/org/kaazing/gateway/transport/ObjectLoggingFilter.java
+++ b/transport/spi/src/main/java/org/kaazing/gateway/transport/ObjectLoggingFilter.java
@@ -15,12 +15,17 @@
  */
 package org.kaazing.gateway.transport;
 
+import org.apache.mina.core.session.IoSession;
 import org.slf4j.Logger;
 
 public class ObjectLoggingFilter extends LoggingFilter {
 
     public ObjectLoggingFilter(Logger logger, String format) {
         super(logger, format);
+    }
+
+    public ObjectLoggingFilter(Logger logger, IoSession session, String transportName) {
+        super(logger, session, transportName);
     }
 
 }


### PR DESCRIPTION
Added a new constructor to LoggerFilter and subclasses to make them easier to use in services. Services can pass in the service type as the transport name in in order to cause service level log messages to be logged, including user identity obtained from the IoSession.