### PR TITLE
Make unbind execute asynchronously without using the scheduler.

### DIFF
--- a/mina.netty/src/main/java/org/kaazing/mina/core/service/AbstractIoAcceptorEx.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/core/service/AbstractIoAcceptorEx.java
@@ -65,7 +65,7 @@ public abstract class AbstractIoAcceptorEx extends AbstractIoAcceptor implements
             public void operationComplete(BindFuture future) {
                 if (future.isBound()) {
                     boolean activate = false;
-                    synchronized (bindLock) {
+                    synchronized (boundAddresses) {
                         if (boundAddresses.isEmpty()) {
                             activate = true;
                         }

--- a/transport/nio/src/main/java/org/kaazing/gateway/transport/nio/internal/AbstractNioAcceptor.java
+++ b/transport/nio/src/main/java/org/kaazing/gateway/transport/nio/internal/AbstractNioAcceptor.java
@@ -377,23 +377,19 @@ public abstract class AbstractNioAcceptor implements BridgeAcceptor {
         // a hang when there's a race with Gateway.destroy().
         if (!unbindScheduler.isShutdown()) {
             final UnbindFuture future = new DefaultUnbindFuture();
-            unbindScheduler.submit(new FutureTask<>(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        unbindInternal(address);
-                        future.setUnbound();
-                    } catch (ThreadDeath td) {
-                        throw td;
-                    } catch (Throwable t) {
-                        LOG.error("Exception during unbinding:\n"+address, t);
-                        //System.out.println("Exception during unbinding:\n"+address+"\n");
-                        //t.printStackTrace(System.out);
-                        future.setException(t);
-                        throw new RuntimeException(t);
-                    }
-                }
-            }, Boolean.TRUE));
+            try {
+                unbindInternal(address);
+                future.setUnbound();
+            } catch (ThreadDeath td) {
+                throw td;
+            } catch (Throwable t) {
+                LOG.error("Exception during unbinding:\n"+address, t);
+                //System.out.println("Exception during unbinding:\n"+address+"\n");
+                //t.printStackTrace(System.out);
+                future.setException(t);
+                throw new RuntimeException(t);
+            }
+
             return future;
         }
         else {
@@ -438,7 +434,7 @@ public abstract class AbstractNioAcceptor implements BridgeAcceptor {
                         if (removed) {
                             ResourceAddress bindAddress = nioBinding.bindAddress();
                             InetSocketAddress socketAddress = asSocketAddress(bindAddress);
-                            acceptor.unbind(socketAddress);
+                            acceptor.unbindAsync(socketAddress);
                             boundAuthorities.remove(bindAddress);
                         }
                     }


### PR DESCRIPTION
The change consists in calling unbindInternal in unbind method without submitting this call to the unbindScheduler and forcing in unbindInternal a call to unbindAsync instead of unbind.

On Windows 10 without these changes, the hang can be reproduced after about 20~30 consecutive runs of the test TcpRealmEarlyAccessFeatureIT.shouldStartWhenTcpRealmAcceptOptionSetAndFeatureEnabled in enterprise gateway.

It also fails when the scheduler is used. When removing it, the test no longer failed.

However there are tests in gateway that fail during the build of which some are sporadic but we are not sure the changes have not introduced regressions.