### PR TITLE
ExceptionMonitor can receive a null session.

### DIFF
--- a/mina.netty/src/main/java/org/kaazing/mina/core/service/AbstractIoService.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/core/service/AbstractIoService.java
@@ -306,7 +306,11 @@ public abstract class AbstractIoService implements IoService {
                 try {
                     this.disposalFuture = disposalFuture = dispose0();
                 } catch (Exception e) {
-                    ExceptionMonitor.getInstance().exceptionCaught(e, this.disposalFuture.getSession());
+                    IoSession ioSession = null;
+                    if (this.disposalFuture != null) {
+                        ioSession = this.disposalFuture.getSession();
+                    }
+                    ExceptionMonitor.getInstance().exceptionCaught(e, ioSession);
                 } finally {
                     if (disposalFuture == null) {
                         disposed = true;

--- a/mina.netty/src/main/java/org/kaazing/mina/core/service/AbstractIoService.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/core/service/AbstractIoService.java
@@ -306,10 +306,7 @@ public abstract class AbstractIoService implements IoService {
                 try {
                     this.disposalFuture = disposalFuture = dispose0();
                 } catch (Exception e) {
-                    IoSession ioSession = null;
-                    if (this.disposalFuture != null) {
-                        ioSession = this.disposalFuture.getSession();
-                    }
+                    IoSession ioSession = this.disposalFuture != null ? this.disposalFuture.getSession() : null;
                     ExceptionMonitor.getInstance().exceptionCaught(e, ioSession);
                 } finally {
                     if (disposalFuture == null) {

--- a/mina.netty/src/main/java/org/kaazing/mina/util/DefaultExceptionMonitor.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/util/DefaultExceptionMonitor.java
@@ -34,7 +34,7 @@ public class DefaultExceptionMonitor extends ExceptionMonitor {
             .getLogger(DefaultExceptionMonitor.class);
 
     @Override
-    public void exceptionCaught(Throwable cause, IoSession s) {
+    public void exceptionCaught0(Throwable cause, IoSession s) {
         if (cause instanceof Error) {
             throw (Error) cause;
         }

--- a/mina.netty/src/main/java/org/kaazing/mina/util/ExceptionMonitor.java
+++ b/mina.netty/src/main/java/org/kaazing/mina/util/ExceptionMonitor.java
@@ -57,5 +57,13 @@ public abstract class ExceptionMonitor {
     /**
      * Invoked when there are any uncaught exceptions.
      */
-    public abstract void exceptionCaught(Throwable cause, IoSession s);
+    public void exceptionCaught(Throwable cause, IoSession s) {
+        if (s == null) {
+            org.apache.mina.util.ExceptionMonitor.getInstance().exceptionCaught(cause);
+        } else {
+            exceptionCaught0(cause, s);
+        }
+    }
+
+    public abstract void exceptionCaught0(Throwable cause, IoSession s);
 }

--- a/mina.netty/src/test/java/org/kaazing/mina/netty/ExceptionMonitorTest.java
+++ b/mina.netty/src/test/java/org/kaazing/mina/netty/ExceptionMonitorTest.java
@@ -19,21 +19,30 @@ package org.kaazing.mina.netty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.mina.core.session.DummySession;
 import org.apache.mina.core.session.IoSession;
+import org.junit.Before;
 import org.junit.Test;
 import org.kaazing.mina.util.DefaultExceptionMonitor;
 import org.kaazing.mina.util.ExceptionMonitor;
 
 
-public class ExceptionMonitorTest
-{
+public class ExceptionMonitorTest {
+
+    @Before
+    public void setUp() {
+        ExceptionMonitor.setInstance(null);
+    }
+
     @Test
-    public void getInstanceShouldReturnDefaultMonitorInitially(){
+    public void getInstanceShouldReturnDefaultMonitorInitially() {
         assertTrue(ExceptionMonitor.getInstance().getClass().isAssignableFrom(DefaultExceptionMonitor.class));
     }
 
     @Test
-    public void getInstanceShouldReturnLastSetInstance () {
+    public void getInstanceShouldReturnLastSetInstance() {
         ExceptionMonitor expectedMonitor = new ExceptionMonitor() {
             @Override
             public void exceptionCaught0(Throwable cause, IoSession s) {
@@ -41,7 +50,32 @@ public class ExceptionMonitorTest
             }
         };
         ExceptionMonitor.setInstance(expectedMonitor);
-
         assertEquals(expectedMonitor, ExceptionMonitor.getInstance());
     }
+
+    @Test
+    public void getInstanceShouldCallNettySetInstanceWithNonNullSession() {
+        AtomicInteger exceptionCaught = new AtomicInteger(0);
+        ExceptionMonitor nettyExpectedMonitor = new ExceptionMonitor() {
+            @Override
+            public void exceptionCaught0(Throwable cause, IoSession s) {
+                exceptionCaught.set(1);
+            }
+        };
+        org.apache.mina.util.ExceptionMonitor minaExpectedMonitor = new org.apache.mina.util.ExceptionMonitor() {
+            @Override
+            public void exceptionCaught(Throwable cause) {
+                exceptionCaught.set(-1);
+            }
+        };
+        ExceptionMonitor.setInstance(nettyExpectedMonitor);
+        org.apache.mina.util.ExceptionMonitor.setInstance(minaExpectedMonitor);
+        assertEquals(nettyExpectedMonitor, ExceptionMonitor.getInstance());
+        assertEquals(minaExpectedMonitor, org.apache.mina.util.ExceptionMonitor.getInstance());
+        ExceptionMonitor.getInstance().exceptionCaught(new Exception(), new DummySession());
+        assertEquals(1, exceptionCaught.get());
+        ExceptionMonitor.getInstance().exceptionCaught(new Exception(), null);
+        assertEquals(-1, exceptionCaught.get());
+    }
+
 }

--- a/mina.netty/src/test/java/org/kaazing/mina/netty/ExceptionMonitorTest.java
+++ b/mina.netty/src/test/java/org/kaazing/mina/netty/ExceptionMonitorTest.java
@@ -36,7 +36,7 @@ public class ExceptionMonitorTest
     public void getInstanceShouldReturnLastSetInstance () {
         ExceptionMonitor expectedMonitor = new ExceptionMonitor() {
             @Override
-            public void exceptionCaught(Throwable cause, IoSession s) {
+            public void exceptionCaught0(Throwable cause, IoSession s) {
                 //
             }
         };

--- a/transport/spi/src/main/java/org/kaazing/gateway/transport/TransportExceptionMonitor.java
+++ b/transport/spi/src/main/java/org/kaazing/gateway/transport/TransportExceptionMonitor.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 public class TransportExceptionMonitor extends ExceptionMonitor {
 
     @Override
-    public void exceptionCaught(Throwable cause, IoSession session) {
+    public void exceptionCaught0(Throwable cause, IoSession session) {
         if (cause instanceof Error) {
             throw (Error) cause;
         }


### PR DESCRIPTION
Fallback to org.apache.mina.util.ExceptionMonitor when session is null.