### PR TITLE
Fix for NPE generated when the scheme would be ommited in <accept>

### DIFF
--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
@@ -27,7 +27,7 @@ import org.kaazing.gateway.resource.address.URLUtils;
  *
  */
 public final class URIUtils {
-    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "^(\\[@[a-zA-Z0-9 :]*\\]|@[a-zA-Z0-9:]*):([0-9]*)$";
+    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "^(\\[@[a-zA-Z0-9 :]*\\]|@    [a-zA-Z0-9:]*):([0-9]*)$";
     public static final String NETWORK_INTERFACE_AUTHORITY = "(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1})";
     private static final String MOCK_HOST = "127.0.0.1";
 
@@ -57,6 +57,9 @@ public final class URIUtils {
     public static String getHost(String uriString) {
         try {
             URI uri = new URI(uriString);
+            if(uri.getHost()==null) {
+                throw new IllegalArgumentException("URI syntax invalid. Protocol, host and port are all required: " + uriString);
+            }
             if (uri.getAuthority().startsWith("@") && !uri.getHost().startsWith("@")) {
                 return "@" + uri.getHost();
             }
@@ -71,6 +74,7 @@ public final class URIUtils {
             }
         }
     }
+
 
     /**
      * Helper method for retrieving scheme

--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
@@ -27,7 +27,7 @@ import org.kaazing.gateway.resource.address.URLUtils;
  *
  */
 public final class URIUtils {
-    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "^(\\[@[a-zA-Z0-9 :]*\\]|@    [a-zA-Z0-9:]*):([0-9]*)$";
+    public static final String NETWORK_INTERFACE_AUTHORITY_PORT = "^(\\[@[a-zA-Z0-9 :]*\\]|@[a-zA-Z0-9:]*):([0-9]*)$";
     public static final String NETWORK_INTERFACE_AUTHORITY = "(\\[{0,1}@[a-zA-Z0-9 :]*\\]{0,1})";
     private static final String MOCK_HOST = "127.0.0.1";
 

--- a/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
+++ b/resource.address/spi/src/main/java/org/kaazing/gateway/resource/address/uri/URIUtils.java
@@ -58,7 +58,7 @@ public final class URIUtils {
         try {
             URI uri = new URI(uriString);
             if(uri.getHost()==null) {
-                throw new IllegalArgumentException("URI syntax invalid. Protocol, host and port are all required: " + uriString);
+                throw new IllegalArgumentException("Invalid URI syntax. Scheme and host must be provided (port number is optional): " + uriString);
             }
             if (uri.getAuthority().startsWith("@") && !uri.getHost().startsWith("@")) {
                 return "@" + uri.getHost();

--- a/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/uri/URIUtilsTest.java
+++ b/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/uri/URIUtilsTest.java
@@ -118,7 +118,6 @@ public class URIUtilsTest {
         URIUtils.getHost(uriString);
     }
 
-
     /**
      * Method performing asserts on 127.0.0.1
      * @param uri

--- a/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/uri/URIUtilsTest.java
+++ b/resource.address/spi/src/test/java/org/kaazing/gateway/resource/address/uri/URIUtilsTest.java
@@ -45,6 +45,34 @@ public class URIUtilsTest {
     }
 
     @Test
+    public void uriUtilsMethodsBehaviorNoProtocol127001(){
+        String uriString = "127.0.0.1:8080/";
+        thrown.expect(IllegalArgumentException.class);
+        URIUtils.getHost(uriString);
+    }
+
+    @Test
+    public void uriUtilsMethodsBehaviorNoProtocolLocalhost(){
+        String uriString = "localhost:8080/";
+        thrown.expect(IllegalArgumentException.class);
+        URIUtils.getHost(uriString);
+    }
+
+    @Test
+    public void uriUtilsMethodsBehaviorProtocolOnly(){
+        String uriString = "ws://";
+        thrown.expect(IllegalArgumentException.class);
+        URIUtils.getHost(uriString);
+    }
+
+    @Test
+    public void uriUtilsMethodsBehaviorPortOnly(){
+        String uriString = ":8000";
+        thrown.expect(IllegalArgumentException.class);
+        URIUtils.getHost(uriString);
+    }
+
+    @Test
     public void uriUtilsMethodsBehaviorTcpLoopbackBrackets() {
         String uriString = "tcp://[@" + networkInterface + "]:8080/test?param1=val#fragment";
         assertEquals("[@" + networkInterface + "]", URIUtils.getHost(uriString));
@@ -89,6 +117,7 @@ public class URIUtilsTest {
         }
         URIUtils.getHost(uriString);
     }
+
 
     /**
      * Method performing asserts on 127.0.0.1

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
@@ -111,7 +111,7 @@ import org.w3c.dom.NodeList;
 
 import com.hazelcast.core.IMap;
 
-public class GatewayContextResolver {
+public class    GatewayContextResolver {
 
 	public static final String AUTHORIZATION_MODE_CHALLENGE = "challenge";
 

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
@@ -111,7 +111,7 @@ import org.w3c.dom.NodeList;
 
 import com.hazelcast.core.IMap;
 
-public class    GatewayContextResolver {
+public class  GatewayContextResolver {
 
 	public static final String AUTHORIZATION_MODE_CHALLENGE = "challenge";
 

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/GatewayContextResolver.java
@@ -111,7 +111,7 @@ import org.w3c.dom.NodeList;
 
 import com.hazelcast.core.IMap;
 
-public class  GatewayContextResolver {
+public class GatewayContextResolver {
 
 	public static final String AUTHORIZATION_MODE_CHALLENGE = "challenge";
 


### PR DESCRIPTION
If the scheme would be omited in the gateway.config.xml this would result in a NPE message when trying to start the gateway