### PR TITLE
make injected login modules return false on success

### DIFF
--- a/security/src/main/java/org/kaazing/gateway/security/auth/BasicLoginModule.java
+++ b/security/src/main/java/org/kaazing/gateway/security/auth/BasicLoginModule.java
@@ -77,7 +77,9 @@ public class BasicLoginModule extends BaseStateDrivenLoginModule {
         if (tryFirstToken) {
             try {
                 attemptAuthenticate(true);
-                return true;
+                // return false when successful, so that this login module doesn't interfere
+                // with the overall result of the login module chain
+                return false;
             } catch (LoginException le) {
                 if (debug) {
                     LOG.debug("[BasicLoginModule] reading from shared state failed: ", le);
@@ -87,7 +89,9 @@ public class BasicLoginModule extends BaseStateDrivenLoginModule {
 
         try {
             attemptAuthenticate(false);
-            return true;
+            // return false when successful, so that this login module doesn't interfere
+            // with the overall result of the login module chain
+            return false;
         } catch (LoginException loginException) {
             cleanState();
             if (debug) {

--- a/security/src/main/java/org/kaazing/gateway/security/auth/NegotiateLoginModule.java
+++ b/security/src/main/java/org/kaazing/gateway/security/auth/NegotiateLoginModule.java
@@ -83,7 +83,9 @@ public class NegotiateLoginModule extends BaseStateDrivenLoginModule {
         if (tryFirstToken) {
             try {
                 attemptAuthenticate(true);
-                return true;
+                // return false when successful, so that this login module doesn't interfere
+                // with the overall result of the login module chain
+                return false;
             } catch (Exception le) {
                 cleanState();
                 if (debug) {
@@ -94,7 +96,9 @@ public class NegotiateLoginModule extends BaseStateDrivenLoginModule {
 
         try {
             attemptAuthenticate(false);
-            return true;
+            // return false when successful, so that this login module doesn't interfere
+            // with the overall result of the login module chain
+            return false;
         } catch (Exception loginException) {
             cleanState();
             if (debug) {

--- a/security/src/main/java/org/kaazing/gateway/security/auth/TimeoutLoginModule.java
+++ b/security/src/main/java/org/kaazing/gateway/security/auth/TimeoutLoginModule.java
@@ -113,7 +113,9 @@ public class TimeoutLoginModule extends BaseStateDrivenLoginModule {
             throw le;
         }
 
-        return performedAction;
+        // always return false, so that this login module doesn't interfere
+        // with the overall result of the login module chain
+        return false;
     }
 
     @Override
@@ -143,8 +145,5 @@ public class TimeoutLoginModule extends BaseStateDrivenLoginModule {
 
     private void cleanState() {
         this.sessionTimeout = 0L;
-        if (loginResult != null) {
-            ((DefaultLoginResult) loginResult).clearTimeouts();
-        }
     }
 }

--- a/security/src/test/java/org/kaazing/gateway/security/auth/BasicLoginModuleTest.java
+++ b/security/src/test/java/org/kaazing/gateway/security/auth/BasicLoginModuleTest.java
@@ -97,25 +97,25 @@ public class BasicLoginModuleTest {
 
         context.assertIsSatisfied();
         assertNotNull(loginContext);
-        try {
-            loginContext.login();
-            final CallbackHandler nameCallbackHandler = handler.getDispatchMap().get(NameCallback.class);
-            final CallbackHandler passwordCallbackHandler = handler.getDispatchMap().get(PasswordCallback.class);
-            assertNotNull(nameCallbackHandler);
-            assertNotNull(passwordCallbackHandler);
-            assertEquals(LoginResult.Type.CHALLENGE, loginResult.getType());
 
-            NameCallback nameCallback = new NameCallback(">|<");
-            PasswordCallback passwordCallback = new PasswordCallback(">|<", false);
+        thrown.expect(LoginException.class);
+        thrown.expectMessage("all modules ignored");
+        loginContext.login();
 
-            nameCallbackHandler.handle(new Callback[]{nameCallback});
-            passwordCallbackHandler.handle(new Callback[]{passwordCallback});
+        final CallbackHandler nameCallbackHandler = handler.getDispatchMap().get(NameCallback.class);
+        final CallbackHandler passwordCallbackHandler = handler.getDispatchMap().get(PasswordCallback.class);
+        assertNotNull(nameCallbackHandler);
+        assertNotNull(passwordCallbackHandler);
+        assertEquals(LoginResult.Type.CHALLENGE, loginResult.getType());
 
-            assertEquals("Expected 'joe' as the name", "joe", nameCallback.getName());
-            assertEquals("Expected 'welcome' as the password", "welcome", new String(passwordCallback.getPassword()));
-        } catch (LoginException e) {
-            fail("Login failed to succeed as expected: "+e.getMessage());
-        }
+        NameCallback nameCallback = new NameCallback(">|<");
+        PasswordCallback passwordCallback = new PasswordCallback(">|<", false);
+
+        nameCallbackHandler.handle(new Callback[]{nameCallback});
+        passwordCallbackHandler.handle(new Callback[]{passwordCallback});
+
+        assertEquals("Expected 'joe' as the name", "joe", nameCallback.getName());
+        assertEquals("Expected 'welcome' as the password", "welcome", new String(passwordCallback.getPassword()));
     }
 
 

--- a/security/src/test/java/org/kaazing/gateway/security/auth/FileLoginModuleTest.java
+++ b/security/src/test/java/org/kaazing/gateway/security/auth/FileLoginModuleTest.java
@@ -17,7 +17,6 @@ package org.kaazing.gateway.security.auth;
 
 import static javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.OPTIONAL;
 import static javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -25,8 +24,6 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.login.AppConfigurationEntry;
@@ -115,20 +112,6 @@ public class FileLoginModuleTest {
 
         try {
             loginContext.login();
-            final CallbackHandler nameCallbackHandler = handler.getDispatchMap().get(NameCallback.class);
-            final CallbackHandler passwordCallbackHandler = handler.getDispatchMap().get(PasswordCallback.class);
-            assertNotNull(nameCallbackHandler);
-            assertNotNull(passwordCallbackHandler);
-
-            NameCallback nameCallback = new NameCallback(">|<");
-            PasswordCallback passwordCallback = new PasswordCallback(">|<", false);
-
-            nameCallbackHandler.handle(new Callback[]{nameCallback});
-            passwordCallbackHandler.handle(new Callback[]{passwordCallback});
-
-            assertEquals("Expected 'joe' as the name", "joe", nameCallback.getName());
-            assertEquals("Expected 'welcome' as the password", "welcome", new String(passwordCallback.getPassword()));
-
         } catch (LoginException e) {
             fail("Login failed to succeed as expected: " + e.getMessage());
         }
@@ -171,20 +154,6 @@ public class FileLoginModuleTest {
 
         try {
             loginContext.login();
-            final CallbackHandler nameCallbackHandler = handler.getDispatchMap().get(NameCallback.class);
-            final CallbackHandler passwordCallbackHandler = handler.getDispatchMap().get(PasswordCallback.class);
-            assertNotNull(nameCallbackHandler);
-            assertNotNull(passwordCallbackHandler);
-
-            NameCallback nameCallback = new NameCallback(">|<");
-            PasswordCallback passwordCallback = new PasswordCallback(">|<", false);
-
-            nameCallbackHandler.handle(new Callback[]{nameCallback});
-            passwordCallbackHandler.handle(new Callback[]{passwordCallback});
-
-            assertEquals("Expected 'joe' as the name", "joe", nameCallback.getName());
-            assertEquals("Expected 'welcome' as the password", "welcome", new String(passwordCallback.getPassword()));
-
         } catch (LoginException e) {
             fail("Login failed to succeed as expected: " + e.getMessage());
         }
@@ -331,20 +300,6 @@ public class FileLoginModuleTest {
 
         try {
             loginContext.login();
-            final CallbackHandler nameCallbackHandler = handler.getDispatchMap().get(NameCallback.class);
-            final CallbackHandler passwordCallbackHandler = handler.getDispatchMap().get(PasswordCallback.class);
-            assertNotNull(nameCallbackHandler);
-            assertNotNull(passwordCallbackHandler);
-
-            NameCallback nameCallback = new NameCallback(">|<");
-            PasswordCallback passwordCallback = new PasswordCallback(">|<", false);
-
-            nameCallbackHandler.handle(new Callback[]{nameCallback});
-            passwordCallbackHandler.handle(new Callback[]{passwordCallback});
-
-            assertEquals("Expected 'joe' as the name", "joe", nameCallback.getName());
-            assertEquals("Expected 'welcome' as the password", "welcome", new String(passwordCallback.getPassword()));
-
         } catch (LoginException e) {
             fail("Login failed to succeed as expected: " + e.getMessage());
         }
@@ -387,20 +342,6 @@ public class FileLoginModuleTest {
 
         try {
             loginContext.login();
-            final CallbackHandler nameCallbackHandler = handler.getDispatchMap().get(NameCallback.class);
-            final CallbackHandler passwordCallbackHandler = handler.getDispatchMap().get(PasswordCallback.class);
-            assertNotNull(nameCallbackHandler);
-            assertNotNull(passwordCallbackHandler);
-
-            NameCallback nameCallback = new NameCallback(">|<");
-            PasswordCallback passwordCallback = new PasswordCallback(">|<", false);
-
-            nameCallbackHandler.handle(new Callback[]{nameCallback});
-            passwordCallbackHandler.handle(new Callback[]{passwordCallback});
-
-            assertEquals("Expected 'joe' as the name", "joe", nameCallback.getName());
-            assertEquals("Expected 'welcome' as the password", "welcome", new String(passwordCallback.getPassword()));
-
         } catch (LoginException e) {
             fail("Login failed to succeed as expected: " + e.getMessage());
         }

--- a/security/src/test/java/org/kaazing/gateway/security/auth/NegotiateLoginModuleWithDataCallbackRegisterTest.java
+++ b/security/src/test/java/org/kaazing/gateway/security/auth/NegotiateLoginModuleWithDataCallbackRegisterTest.java
@@ -57,6 +57,7 @@ import org.kaazing.gateway.server.spi.security.LoginResultCallback;
 import org.kaazing.netx.URLConnectionHelper;
 
 public class NegotiateLoginModuleWithDataCallbackRegisterTest {
+    private static final String ALL_MODULES_IGNORED_MESSAGE = "all modules ignored";
     private static final String REALM_NAME = "demo";
     private static final String NEGOTIATE_AUTH_SCHEME = "Negotiate";
     private static final byte[] TOKEN_DATA = "test".getBytes();
@@ -147,6 +148,8 @@ public class NegotiateLoginModuleWithDataCallbackRegisterTest {
         context.assertIsSatisfied();
         assertNotNull(loginContext);
 
+        thrown.expect(LoginException.class);
+        thrown.expectMessage(ALL_MODULES_IGNORED_MESSAGE);
         loginContext.login();
 
         final CallbackHandler negotiateDataCallbackHandler = handler.getDispatchMap().get(TestNegotiateDataCallback.class);
@@ -182,6 +185,8 @@ public class NegotiateLoginModuleWithDataCallbackRegisterTest {
         context.assertIsSatisfied();
         assertNotNull(loginContext);
 
+        thrown.expect(LoginException.class);
+        thrown.expectMessage(ALL_MODULES_IGNORED_MESSAGE);
         loginContext.login();
 
         final CallbackHandler gssCallbackHandler = handler.getDispatchMap().get(TestNegotiateDataCallback.class);

--- a/security/src/test/java/org/kaazing/gateway/security/auth/TimeoutLoginModuleTest.java
+++ b/security/src/test/java/org/kaazing/gateway/security/auth/TimeoutLoginModuleTest.java
@@ -32,7 +32,9 @@ import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.kaazing.gateway.security.TypedCallbackHandlerMap;
 import org.kaazing.gateway.security.auth.context.DefaultLoginContextFactory;
 import org.kaazing.gateway.security.auth.context.ResultAwareLoginContext;
@@ -46,8 +48,9 @@ public class TimeoutLoginModuleTest {
     Configuration configuration;
     public static final String REALM_NAME = "demo";
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-    
     @Before
     public void setUp() throws Exception {
         initMockContext();
@@ -79,14 +82,10 @@ public class TimeoutLoginModuleTest {
         LoginContext loginContext = factory.createLoginContext(makeTokenCallbackMapWithToken(s));
         context.assertIsSatisfied();
         assertNotNull(loginContext);
-        try {
-            loginContext.login();
-            fail("Expected configuration exception at initialization: no timeouts were specified.");
-        } catch (LoginException e) {
-            final String msg = "You must specify the \"session-timeout\" option";
-            System.out.println(e.getMessage());
-            assertTrue(e.getMessage().contains(msg));
-        }
+
+        thrown.expect(LoginException.class);
+        thrown.expectMessage("You must specify the \"session-timeout\" option");
+        loginContext.login();
     }
 
 
@@ -108,13 +107,10 @@ public class TimeoutLoginModuleTest {
         LoginContext loginContext = factory.createLoginContext(makeTokenCallbackMapWithToken(s));
         context.assertIsSatisfied();
         assertNotNull(loginContext);
-        try {
-            loginContext.login();
-            fail("Expected configuration exception at initialization: bad syntax for session-timeout.");
-        } catch (LoginException e) {
-            final String msg = "java.lang.NumberFormatException";
-            assertTrue(e.getMessage().contains(msg));
-        }
+
+        thrown.expect(LoginException.class);
+        thrown.expectMessage("java.lang.NumberFormatException");
+        loginContext.login();
     }
 
     @Test
@@ -136,18 +132,18 @@ public class TimeoutLoginModuleTest {
         ResultAwareLoginContext loginContext = (ResultAwareLoginContext) factory.createLoginContext(makeTokenCallbackMapWithToken(s));
         context.assertIsSatisfied();
         assertNotNull(loginContext);
-        try {
-            loginContext.login();
-            fail("Expected a forced failure to clean up state - did not occur.");
-        } catch (LoginException e) {
-            // Make sure we reset everything to 0 and make the login result a failure
-            DefaultLoginResult loginResult = loginContext.getLoginResult();
-            assertEquals(null, loginResult.getSessionTimeout());
-        }
+
+        thrown.expect(LoginException.class);
+        loginContext.login();
+
+        // Make sure we reset everything to 0 and make the login result a failure
+        DefaultLoginResult loginResult = loginContext.getLoginResult();
+        assertEquals(null, loginResult.getSessionTimeout());
+
     }
 
     @Test
-    public void testTimeoutLoginModuleLoginSuccessAndEffectWithOnlyMaximumLifetimeSpecified() throws Exception {
+    public void testTimeoutLoginModuleLoginIgnoredAndEffectWithOnlyMaximumLifetimeSpecified() throws Exception {
         AuthenticationToken s = new DefaultAuthenticationToken("joe:welcome");
         context.checking(new Expectations() {
             {
@@ -164,7 +160,11 @@ public class TimeoutLoginModuleTest {
         ResultAwareLoginContext loginContext = (ResultAwareLoginContext) factory.createLoginContext(makeTokenCallbackMapWithToken(s));
         context.assertIsSatisfied();
         assertNotNull(loginContext);
+
+        thrown.expect(LoginException.class);
+        thrown.expectMessage("all modules ignored");
         loginContext.login();
+
         DefaultLoginResult loginResult = loginContext.getLoginResult();
         assertEquals(Long.valueOf(600L), loginResult.getSessionTimeout());
     }

--- a/service/turn.rest/src/test/java/org/kaazing/gateway/service/turn/rest/TestLoginModule.java
+++ b/service/turn.rest/src/test/java/org/kaazing/gateway/service/turn/rest/TestLoginModule.java
@@ -40,13 +40,13 @@ public class TestLoginModule implements LoginModule {
 
     @Override
     public boolean login() throws LoginException {
+        String username = (String)sharedState.get("javax.security.auth.login.name");
+        userPrincipal = new RolePrincipal(username);
         return true;
     }
 
     @Override
     public boolean commit() throws LoginException {
-        String username = (String)sharedState.get("javax.security.auth.login.name");
-        userPrincipal = new RolePrincipal(username);
         subject.getPrincipals().add(userPrincipal);
         return true;
     }


### PR DESCRIPTION
- login method now returns false on success, in order to not interfere
with the outcome of the whole login process
- update timeout login module to not clean up the session timeout from
the login result because, as a consequence of the previous change, the
commit() method will call the logout0() method and not commit0(),
disabling the session timeout everytime
- updated tests