### PR TITLE
Adds http.redirect service

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -127,6 +127,11 @@
                 <artifactId>gateway.service.update.check.management</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>gateway.service.http.redirect</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!-- transport dependencies -->
             <dependency>
                 <groupId>org.kaazing</groupId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -109,6 +109,10 @@
             <groupId>org.kaazing</groupId>
             <artifactId>gateway.service.update.check.management</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.service.http.redirect</artifactId>
+        </dependency>
 
         <!-- transport dependencies -->
         <dependency>

--- a/distribution/src/main/assembly/generic-bin.xml
+++ b/distribution/src/main/assembly/generic-bin.xml
@@ -73,6 +73,7 @@
         <include>org.kaazing:gateway.service.amqp</include>
         <include>org.kaazing:gateway.service.update.check</include>
         <include>org.kaazing:gateway.service.turn.rest</include>
+        <include>org.kaazing:gateway.service.http.redirect</include>
 
         <!-- auth jars  -->
         <include>org.kaazing:gateway.security</include>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <module>service/http.balancer</module>
         <module>service/http.directory</module>
         <module>service/http.proxy</module>
+        <module>service/http.redirect</module>
         <module>service/proxy</module>
         <module>service/turn.rest</module>
         <module>service/update.check</module>

--- a/server/src/main/xsd/gateway-config-201606.xsd
+++ b/server/src/main/xsd/gateway-config-201606.xsd
@@ -1191,9 +1191,6 @@
 
                     <!-- connect is not supported for redirect -->
 
-                    <element maxOccurs="unbounded" minOccurs="0"
-                             name="balance" type="anyURI"/>
-
                     <element fixed="http.redirect" maxOccurs="1" minOccurs="1"
                              name="type"
                              type="gateway:CollapsedString"/>
@@ -1214,9 +1211,6 @@
                              name="authorization-constraint"
                              type="gateway:AuthorizationConstraintType"/>
 
-                    <element maxOccurs="unbounded" minOccurs="0"
-                             name="cross-site-constraint"
-                             type="gateway:CrossSiteConstraintType"/>
                 </sequence>
             </restriction>
         </complexContent>

--- a/server/src/main/xsd/gateway-config-201606.xsd
+++ b/server/src/main/xsd/gateway-config-201606.xsd
@@ -1168,6 +1168,60 @@
         </complexContent>
     </complexType>
 
+    <complexType name="redirectServiceType">
+        <annotation>
+            <documentation>This type of service is for redirecting gateway.
+            </documentation>
+        </annotation>
+
+        <complexContent>
+            <restriction base="gateway:ServiceType">
+                <sequence>
+                    <element maxOccurs="1" minOccurs="1"
+                             name="name"
+                             type="gateway:CollapsedString"/>
+
+                    <element maxOccurs="1" minOccurs="0"
+                             name="description"
+                             type="gateway:CollapsedString"/>
+
+                    <element maxOccurs="unbounded" minOccurs="1"
+                             name="accept"
+                             type="anyURI"/>
+
+                    <!-- connect is not supported for redirect -->
+
+                    <element maxOccurs="unbounded" minOccurs="0"
+                             name="balance" type="anyURI"/>
+
+                    <element fixed="http.redirect" maxOccurs="1" minOccurs="1"
+                             name="type"
+                             type="gateway:CollapsedString"/>
+
+                    <element maxOccurs="1" minOccurs="1"
+                             name="properties"
+                             type="gateway:redirectServicePropertiesType"/>
+
+                    <element maxOccurs="1" minOccurs="0"
+                             name="accept-options"
+                             type="gateway:ServiceAcceptOptionsType"/>
+
+                    <element maxOccurs="1" minOccurs="0"
+                             name="realm-name"
+                             type="gateway:CollapsedString"/>
+
+                    <element maxOccurs="unbounded" minOccurs="0"
+                             name="authorization-constraint"
+                             type="gateway:AuthorizationConstraintType"/>
+
+                    <element maxOccurs="unbounded" minOccurs="0"
+                             name="cross-site-constraint"
+                             type="gateway:CrossSiteConstraintType"/>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+    
     <complexType name="PropertiesType">
         <sequence>
             <element maxOccurs="unbounded" minOccurs="1" name="property"
@@ -1685,6 +1739,28 @@
                     </element>
                     <element maxOccurs="unbounded" minOccurs="1" name="url"
                         type="gateway:CollapsedString">
+                        <annotation />
+                    </element>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+
+
+    <complexType name="redirectServicePropertiesType">
+        <complexContent>
+            <restriction base="gateway:ServicePropertiesType">
+                <sequence>
+                    <element maxOccurs="1" minOccurs="1"
+                             name="location" type="anyURI">
+                        <annotation/>
+                    </element>
+                    <element maxOccurs="1" minOccurs="0"
+                             name="status-code" type="nonNegativeInteger">
+                        <annotation/>
+                    </element>
+                    <element maxOccurs="unbounded" minOccurs="0"
+                             name="cache-control" type="gateway:CollapsedString">
                         <annotation />
                     </element>
                 </sequence>

--- a/service/http.redirect/pom.xml
+++ b/service/http.redirect/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.kaazing</groupId>
+        <artifactId>gateway</artifactId>
+        <version>develop-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>gateway.service.http.redirect</artifactId>
+    <name>Http Redirect Service</name>
+    <description>Service that redirects from http to https</description>
+
+    <url>https://github.com/kaazing/gateway.service.http.redirect.git</url>
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+        <url>git@github.com:kaazing/gateway.service.http.redirect.git</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.transport.http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.jmock</groupId>
+            <artifactId>jmock-legacy</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>test.util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>k3po.junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.test.ca</artifactId>
+            <version>[1.0.0.0,1.1.0.0)</version>
+            <classifier>keystore</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+                <groupId>org.kaazing</groupId>
+                <artifactId>specification.http</artifactId>
+                <version>${k3po.version}</version>
+            </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.kaazing</groupId>
+                <artifactId>k3po-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.apk</exclude>
+                        <exclude>**/*.xap</exclude>
+                        <exclude>src/test/**/*.html</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
+                <executions>
+                    <execution>
+                        <id>unpack-truststore</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>gateway.test.ca</includeArtifactIds>
+                            <outputDirectory>${basedir}/target/truststore</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectService.java
+++ b/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectService.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.service.http.redirect;
+
+import java.util.Properties;
+
+import javax.annotation.Resource;
+
+import org.apache.mina.core.session.IoSession;
+import org.kaazing.gateway.service.Service;
+import org.kaazing.gateway.service.ServiceContext;
+import org.kaazing.gateway.service.ServiceProperties;
+import org.kaazing.gateway.transport.http.HttpStatus;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gateway service of type "directory".
+ */
+public class HttpRedirectService implements Service {
+
+    private final Logger logger = LoggerFactory.getLogger("service.directory");
+
+    private HttpRedirectServiceHandler handler;
+    private ServiceContext serviceContext;
+    private Properties configuration;
+
+    @Resource(
+            name = "configuration")
+    public void setConfiguration(Properties configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void init(ServiceContext serviceContext) throws Exception {
+        EarlyAccessFeatures.HTTP_REDIRECT.assertEnabled(configuration, serviceContext.getLogger());
+
+        this.serviceContext = serviceContext;
+        handler = new HttpRedirectServiceHandler(logger);
+        ServiceProperties properties = serviceContext.getProperties();
+
+        String location = properties.get("location");
+        if (location == null || "".equals(location)) {
+            throw new IllegalArgumentException("Missing required property: location");
+        }
+
+        HttpStatus statusCode;
+        String strStatusCode = properties.get("status-code");
+        if (strStatusCode == null)
+            statusCode = HttpStatus.REDIRECT_MULTIPLE_CHOICES;
+        else
+            statusCode = HttpStatus.getHttpStatus(strStatusCode);
+
+        if (statusCode.code() > 399 || statusCode.code() < 300) {
+            throw new IllegalArgumentException(
+                    "Wrong value for status-code:" + statusCode + ". Valid values are integers between 300 and 399");
+        }
+
+        String cacheControlDirectives = properties.get("cache-control"); // this is null-able
+
+        handler.setLocation(location);
+        handler.setStatusCode(statusCode);
+        handler.setCacheControl(cacheControlDirectives);
+    }
+
+    @Override
+    public String getType() {
+        return "http.redirect";
+    }
+
+    @Override
+    public void start() throws Exception {
+        serviceContext.bind(serviceContext.getAccepts(), handler);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        quiesce();
+
+        if (serviceContext != null) {
+            for (IoSession session : serviceContext.getActiveSessions()) {
+                session.close(true);
+            }
+        }
+    }
+
+    @Override
+    public void quiesce() throws Exception {
+        if (serviceContext != null) {
+            serviceContext.unbind(serviceContext.getAccepts(), handler);
+        }
+    }
+
+    @Override
+    public void destroy() throws Exception {
+    }
+
+    public HttpRedirectServiceHandler getHandler() {
+        return handler;
+    }
+
+    public void setHandler(HttpRedirectServiceHandler handler) {
+        this.handler = handler;
+    }
+}

--- a/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceFactorySpi.java
+++ b/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceFactorySpi.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.service.http.redirect;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.kaazing.gateway.service.Service;
+import org.kaazing.gateway.service.ServiceFactorySpi;
+
+public class HttpRedirectServiceFactorySpi extends ServiceFactorySpi {
+
+    @Override
+    public Collection<String> getServiceTypes() {
+        return Collections.singletonList("http.redirect");
+    }
+
+    @Override
+    public Service newService(String serviceType) {
+        assert "http.redirect".equals(serviceType);
+        return new HttpRedirectService();
+    }
+}

--- a/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceHandler.java
+++ b/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceHandler.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.service.http.redirect;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.kaazing.gateway.transport.IoHandlerAdapter;
+import org.kaazing.gateway.transport.http.HttpAcceptSession;
+import org.kaazing.gateway.transport.http.HttpMethod;
+import org.kaazing.gateway.transport.http.HttpStatus;
+import org.slf4j.Logger;
+
+class HttpRedirectServiceHandler extends IoHandlerAdapter<HttpAcceptSession> {
+    private final Logger logger;
+    private String location;
+    private HttpStatus statusCode;
+    private String cacheControl;
+
+    private static final DateFormat RFC822_FORMAT_PATTERN =
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
+    static {
+        RFC822_FORMAT_PATTERN.setTimeZone(TimeZone.getTimeZone("GMT"));
+    }
+
+    HttpRedirectServiceHandler(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void doSessionCreated(HttpAcceptSession session) throws Exception {
+        // NOOP no license check needed
+    }
+
+    @Override
+    public void doSessionClosed(HttpAcceptSession session) throws Exception {
+        // NOOP no license check needed
+    }
+
+    @Override
+    protected void doExceptionCaught(HttpAcceptSession session, Throwable cause) throws Exception {
+        // trigger sessionClosed to update connection capabilities accordingly
+        session.close(true);
+    }
+
+    @Override
+    protected void doSessionOpened(HttpAcceptSession session) throws Exception {
+        // Get the method used for this request; if not a GET, refuse the
+        // request (KG-1233).
+        // (KG-11211) Enabling HEAD method too.
+        HttpMethod method = session.getMethod();
+        if (method != HttpMethod.GET && method != HttpMethod.HEAD) {
+            logger.warn("Wrong Http method used: " + method + ". Only GET or HEAD accepted");
+            session.close(false);
+            return;
+        }
+
+        session.setStatus(getStatusCode());
+        session.setWriteHeader("Location", getLocation());
+        if (getCacheControl() != null) {
+            session.setWriteHeader("Cache-Control", getCacheControl());
+            session.setWriteHeader("Expires", getExpiresHeader());
+        }
+        session.close(false);
+    }
+
+    private String getExpiresHeader() {
+        return RFC822_FORMAT_PATTERN.format(new Date(0));
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("HttpRedirectServiceHandler [");
+        sb.append("location='").append(location).append("'");
+        sb.append(", cache-control='").append(cacheControl).append("'");
+        sb.append(", status-code=").append(statusCode);
+        sb.append("]");
+        return sb.toString();
+    }
+
+    String getLocation() {
+        return location;
+    }
+
+    void setLocation(String location) {
+        this.location = location;
+    }
+
+    HttpStatus getStatusCode() {
+        return statusCode;
+    }
+
+    void setStatusCode(HttpStatus statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    String getCacheControl() {
+        return cacheControl;
+    }
+
+    void setCacheControl(String cacheControl) {
+        this.cacheControl = cacheControl;
+    }
+}

--- a/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceHandler.java
+++ b/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceHandler.java
@@ -43,16 +43,6 @@ class HttpRedirectServiceHandler extends IoHandlerAdapter<HttpAcceptSession> {
     }
 
     @Override
-    public void doSessionCreated(HttpAcceptSession session) throws Exception {
-        // NOOP no license check needed
-    }
-
-    @Override
-    public void doSessionClosed(HttpAcceptSession session) throws Exception {
-        // NOOP no license check needed
-    }
-
-    @Override
     protected void doExceptionCaught(HttpAcceptSession session, Throwable cause) throws Exception {
         // trigger sessionClosed to update connection capabilities accordingly
         session.close(true);
@@ -60,9 +50,6 @@ class HttpRedirectServiceHandler extends IoHandlerAdapter<HttpAcceptSession> {
 
     @Override
     protected void doSessionOpened(HttpAcceptSession session) throws Exception {
-        // Get the method used for this request; if not a GET, refuse the
-        // request (KG-1233).
-        // (KG-11211) Enabling HEAD method too.
 
         session.setStatus(getStatusCode());
         session.setWriteHeader("Location", getLocation());

--- a/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceHandler.java
+++ b/service/http.redirect/src/main/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceHandler.java
@@ -23,7 +23,6 @@ import java.util.TimeZone;
 
 import org.kaazing.gateway.transport.IoHandlerAdapter;
 import org.kaazing.gateway.transport.http.HttpAcceptSession;
-import org.kaazing.gateway.transport.http.HttpMethod;
 import org.kaazing.gateway.transport.http.HttpStatus;
 import org.slf4j.Logger;
 
@@ -64,12 +63,6 @@ class HttpRedirectServiceHandler extends IoHandlerAdapter<HttpAcceptSession> {
         // Get the method used for this request; if not a GET, refuse the
         // request (KG-1233).
         // (KG-11211) Enabling HEAD method too.
-        HttpMethod method = session.getMethod();
-        if (method != HttpMethod.GET && method != HttpMethod.HEAD) {
-            logger.warn("Wrong Http method used: " + method + ". Only GET or HEAD accepted");
-            session.close(false);
-            return;
-        }
 
         session.setStatus(getStatusCode());
         session.setWriteHeader("Location", getLocation());

--- a/service/http.redirect/src/main/resources/META-INF/services/org.kaazing.gateway.service.ServiceFactorySpi
+++ b/service/http.redirect/src/main/resources/META-INF/services/org.kaazing.gateway.service.ServiceFactorySpi
@@ -1,0 +1,1 @@
+org.kaazing.gateway.service.http.redirect.HttpRedirectServiceFactorySpi

--- a/service/http.redirect/src/test/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceIT.java
+++ b/service/http.redirect/src/test/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceIT.java
@@ -31,7 +31,7 @@ public class HttpRedirectServiceIT {
 
     private static final String REDIRECT_SERVICE_ACCEPT = "http://localhost:8000/";
 
-    private final K3poRule robot = new K3poRule().setScriptRoot("org/kaazing/specification/http/rfc7231/redirection");
+    private final K3poRule robot = new K3poRule();// .setScriptRoot("org/kaazing/specification/http/rfc7231/redirection");
 
     private final GatewayRule gateway = new GatewayRule() {
         {

--- a/service/http.redirect/src/test/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceIT.java
+++ b/service/http.redirect/src/test/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceIT.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.service.http.redirect;
+
+import static org.kaazing.gateway.util.feature.EarlyAccessFeatures.HTTP_REDIRECT;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.kaazing.gateway.server.test.GatewayRule;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+
+public class HttpRedirectServiceIT {
+
+    private static final String REDIRECT_SERVICE_ACCEPT = "http://localhost:8000/";
+
+    private final K3poRule robot = new K3poRule().setScriptRoot("org/kaazing/specification/http/rfc7231/redirection");
+
+    private final GatewayRule gateway = new GatewayRule() {
+        {
+            // @formatter:off
+            GatewayConfiguration configuration =
+                    new GatewayConfigurationBuilder()
+                .property(HTTP_REDIRECT.getPropertyName(), "true")
+                        .service()
+                            .accept(REDIRECT_SERVICE_ACCEPT)
+                            .type("http.redirect")
+                            .property("location", "https://www.google.com")
+                            .property("status-code", "301")
+                            .property("cache-control", "no-store, no-cache, must-revalidate")
+                        .done()
+                    .done();
+            // @formatter:on
+            init(configuration);
+        }
+    };
+
+    @Rule
+    public TestRule chain = createRuleChain(gateway, robot);
+
+    @Test
+    @Specification({"secure.location/request"})
+    public void shouldAcceptSecureLocation() throws Exception {
+        robot.finish();
+    }
+
+}

--- a/service/http.redirect/src/test/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceTest.java
+++ b/service/http.redirect/src/test/java/org/kaazing/gateway/service/http/redirect/HttpRedirectServiceTest.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.service.http.redirect;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestRule;
+import org.kaazing.gateway.server.context.resolve.DefaultServiceProperties;
+import org.kaazing.gateway.server.test.Gateway;
+import org.kaazing.gateway.server.test.config.GatewayConfiguration;
+import org.kaazing.gateway.server.test.config.builder.GatewayConfigurationBuilder;
+import org.kaazing.gateway.service.ServiceContext;
+import org.kaazing.gateway.service.ServiceFactory;
+import org.kaazing.gateway.transport.http.HttpStatus;
+import org.kaazing.gateway.util.feature.EarlyAccessFeatures;
+import org.kaazing.test.util.MethodExecutionTrace;
+import org.slf4j.Logger;
+
+public class HttpRedirectServiceTest {
+    @Rule
+    public TestRule testExecutionTrace = new MethodExecutionTrace();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    Mockery context = new Mockery();
+    @Test
+    public void testCreateService() throws Exception {
+        HttpRedirectService service = (HttpRedirectService) ServiceFactory.newServiceFactory().newService("http.redirect");
+        Assert.assertNotNull("Failed to create HttpRedirectService", service);
+    }
+
+    @Test
+    public void shouldFailWhenEarlyAccessNotEnabled() throws Exception {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Feature \"http.redirect\" (HTTP Redirect Service) not enabled");
+        Gateway gateway = new Gateway();
+        // @formatter:off
+        GatewayConfiguration configuration =
+                new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_REDIRECT.getPropertyName(), "false")
+                        .service()
+                            .accept("http://localhost:8080/")
+                            .name("foo")
+                            .type("http.redirect")
+                            .property("location", "https://www.google.com")
+                            .property("status-code", "301")
+                            .property("cache-control", "no-store, no-cache, must-revalidate")
+                        .done()
+                    .done();
+        // @formatter:on
+        try {
+            gateway.start(configuration);
+        } finally {
+            gateway.stop();
+        }
+    }
+
+    @Test
+    public void shouldFailWithNonRedirectStatusCode() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Wrong value for status-code:404. Valid values are integers between 300 and 399");
+        Gateway gateway = new Gateway();
+        // @formatter:off
+        GatewayConfiguration configuration =
+                new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_REDIRECT.getPropertyName(), "true")
+                        .service()
+                            .accept("http://localhost:8080")
+                            .name("foo")
+                            .type("http.redirect")
+                            .property("location", "https://www.google.com")
+                            .property("status-code", "404")
+                            .property("cache-control", "no-store, no-cache, must-revalidate")
+                        .done()
+                    .done();
+        // @formatter:on
+        try {
+            gateway.start(configuration);
+        } finally {
+            gateway.stop();
+        }
+    }
+    @Test
+    public void shouldFailWithNullLocation() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Missing required property: location");
+        Gateway gateway = new Gateway();
+        // @formatter:off
+        GatewayConfiguration configuration =
+                new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_REDIRECT.getPropertyName(), "true")
+                        .service()
+                            .accept("http://localhost:8080/")
+                            .name("foo")
+                            .type("http.redirect")
+                            .property("location", null)
+                            .property("status-code", "301")
+                            .property("cache-control", "no-store, no-cache, must-revalidate")
+                        .done()
+                    .done();
+        // @formatter:on
+        try {
+            gateway.start(configuration);
+        } finally {
+            gateway.stop();
+        }
+    }
+
+    @Test
+    public void shouldPassWithDefaultConnectPath() throws Exception {
+        Gateway gateway = new Gateway();
+        // @formatter:off
+        GatewayConfiguration configuration =
+                new GatewayConfigurationBuilder()
+                        .property(EarlyAccessFeatures.HTTP_REDIRECT.getPropertyName(), "true")
+                        .service()
+                            .accept("http://localhost:8080/")
+                            .name("foo")
+                            .type("http.redirect")
+                            .property("location", "https://www.google.com")
+                            .property("status-code", "301")
+                            .property("cache-control", "no-store, no-cache, must-revalidate")
+                        .done()
+                    .done();
+        // @formatter:on
+        try {
+            gateway.start(configuration);
+        } finally {
+            gateway.stop();
+        }
+    }
+
+    @Test
+    public void shouldUse303AsDefaultStatusCode() throws Exception {
+        HttpRedirectService service = createRedirectService();
+
+        DefaultServiceProperties sp = new DefaultServiceProperties();
+        sp.put("location", "https://www.google.com");
+        sp.put("cache-control", "no-store, no-cache, must-revalidate");
+
+        ServiceContext serviceContext = createServiceContext(sp);
+        service.init(serviceContext);
+        HttpRedirectServiceHandler h = service.getHandler();
+        assertEquals(HttpStatus.REDIRECT_MULTIPLE_CHOICES, h.getStatusCode());
+    }
+
+    @Test
+    public void testServiceHandlerToString() throws Exception {
+        HttpRedirectService service = createRedirectService();
+
+        DefaultServiceProperties sp = new DefaultServiceProperties();
+        sp.put("location", "https://www.google.com");
+        sp.put("status-code", "305");
+        sp.put("cache-control", "no-store, no-cache, must-revalidate");
+
+        ServiceContext serviceContext = createServiceContext(sp);
+        service.init(serviceContext);
+        HttpRedirectServiceHandler h = service.getHandler();
+        assertEquals(
+                "HttpRedirectServiceHandler [location='https://www.google.com', cache-control='no-store, no-cache, must-revalidate', status-code=305]",
+                h.toString());
+    }
+    private ServiceContext createServiceContext(DefaultServiceProperties sp) {
+        ServiceContext serviceContext = context.mock(ServiceContext.class);
+        Logger logger = context.mock(Logger.class);
+
+        // expectations
+        context.checking(new Expectations() {
+            {
+                oneOf(serviceContext).getLogger();
+                will(returnValue(logger));
+                oneOf(serviceContext).getProperties();
+                will(returnValue(sp));
+            }
+        });
+        return serviceContext;
+    }
+
+    private HttpRedirectService createRedirectService() {
+        Properties properties = new Properties();
+        properties.setProperty("feature.http.redirect", "True");
+        HttpRedirectService service = new HttpRedirectService();
+        service.setConfiguration(properties);
+        return service;
+    }
+
+}

--- a/service/http.redirect/src/test/scripts/org/kaazing/gateway/service/http/redirect/secure.location/request.rpt
+++ b/service/http.redirect/src/test/scripts/org/kaazing/gateway/service/http/redirect/secure.location/request.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+connect http://localhost:8000/resource
+connected
+
+write method "GET"
+write header host
+write close
+
+read status /3\d\d/ /.*/
+read header "Location" "https://www.google.com"
+read header "Cache-Control" "no-store, no-cache, must-revalidate"
+# read notify FOLLOW_REDIRECT

--- a/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeatures.java
+++ b/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeatures.java
@@ -26,5 +26,6 @@ public interface EarlyAccessFeatures {
     EarlyAccessFeature LOGIN_MODULE_EXPIRING_STATE = new EarlyAccessFeature("login.module.expiring.state", "Login Module Expiring State", false);
     EarlyAccessFeature TCP_REALM_EXTENSION = new EarlyAccessFeature("tcp.realm", "TCP Realm", false);
     EarlyAccessFeature HTTP_REALM_ACCEPT_OPTION = new EarlyAccessFeature("http.realm", "Http Realm", false);
+    EarlyAccessFeature HTTP_REDIRECT = new EarlyAccessFeature("http.redirect", "HTTP Redirect Service", false);
 
 }


### PR DESCRIPTION
This service allows HTTP redirects to HTTPS url when they access a secure service on port 80.  This is a common case for HTTP Proxy configurations which we are now supporting.