### PR TITLE
 Applied keepAliveTimeout to all layers properly.  No need for HTTPPersistanceFilter for HTTPXE when HTTP is directly over HTTP on the upper HTTP

### DIFF
--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultAcceptOptionsContext.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultAcceptOptionsContext.java
@@ -164,7 +164,12 @@ public class DefaultAcceptOptionsContext extends DefaultOptionsContext implement
         result.put("ws[ws/draft-7x].ws[ws/draft-7x].maxMessageSize", wsMaxMessageSize);
 
         int httpKeepaliveTimeout = getHttpKeepaliveTimeout(httpKeepaliveTimeoutStr);
+
         result.put("http[http/1.1].keepAliveTimeout", httpKeepaliveTimeout);
+        result.put("http[x-kaazing-handshake].keepAliveTimeout", httpKeepaliveTimeout);
+        result.put("http[httpxe/1.1].keepAliveTimeout", httpKeepaliveTimeout);
+        result.put("http[httpxe/1.1].http[http/1.1].keepAliveTimeout", httpKeepaliveTimeout);
+
         if (wsInactivityTimeoutStr != null &&
             MILLISECONDS.convert(httpKeepaliveTimeout, SECONDS) < wsInactivityTimeout) {
             LOGGER.warn("http.keepalive.timeout={} should be greater-than-or-equal-to ws.inactivity.timeout={} in accept-options",

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
@@ -34,6 +34,7 @@ import static org.kaazing.gateway.transport.http.HttpAcceptFilter.ELEVATE_EMULAT
 import static org.kaazing.gateway.transport.http.HttpAcceptFilter.HOST_HEADER;
 import static org.kaazing.gateway.transport.http.HttpAcceptFilter.HTTP_SERIALIZE_REQUEST_FILTER;
 import static org.kaazing.gateway.transport.http.HttpAcceptFilter.MERGE_REQUEST;
+import static org.kaazing.gateway.transport.http.HttpAcceptFilter.PERSISTENCE;
 import static org.kaazing.gateway.transport.http.HttpAcceptFilter.PROTOCOL_HTTP;
 import static org.kaazing.gateway.transport.http.HttpAcceptFilter.PROTOCOL_HTTPXE;
 import static org.kaazing.gateway.transport.http.HttpStatus.CLIENT_NOT_FOUND;
@@ -168,7 +169,8 @@ public class HttpAcceptor extends AbstractBridgeAcceptor<DefaultHttpSession, Htt
                                                                          PROTOCOL_HTTP,
                                                                          HOST_HEADER,
                                                                          ELEVATE_EMULATED_REQUEST,
-                                                                         CONDITIONAL_WRAPPED_RESPONSE)));
+                                                                         CONDITIONAL_WRAPPED_RESPONSE,
+                                                                         PERSISTENCE)));
 
         acceptFiltersByProtocol.put("x-kaazing-handshake", complementOf(of(CONTENT_LENGTH_ADJUSTMENT,
                                                                            PROTOCOL_HTTPXE,

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptor.java
@@ -169,8 +169,7 @@ public class HttpAcceptor extends AbstractBridgeAcceptor<DefaultHttpSession, Htt
                                                                          PROTOCOL_HTTP,
                                                                          HOST_HEADER,
                                                                          ELEVATE_EMULATED_REQUEST,
-                                                                         CONDITIONAL_WRAPPED_RESPONSE,
-                                                                         PERSISTENCE)));
+                                                                         CONDITIONAL_WRAPPED_RESPONSE)));
 
         acceptFiltersByProtocol.put("x-kaazing-handshake", complementOf(of(CONTENT_LENGTH_ADJUSTMENT,
                                                                            PROTOCOL_HTTPXE,


### PR DESCRIPTION
…sistanceFilter for HTTPXE when HTTP is directly over HTTP on the upper HTTP