### PR TITLE
Fix synchronization issues in tests.

### DIFF
--- a/management/src/test/java/org/kaazing/gateway/management/jmx/JmxManagementServiceHandlerTest.java
+++ b/management/src/test/java/org/kaazing/gateway/management/jmx/JmxManagementServiceHandlerTest.java
@@ -52,6 +52,7 @@ public class JmxManagementServiceHandlerTest {
         try {
             gateway.start(gatewayConfiguration);
         } finally {
+            Thread.sleep(500); // https://github.com/kaazing/gateway/issues/883
             gateway.stop();
         }
     }

--- a/management/src/test/java/org/kaazing/gateway/management/jmx/JmxSessionIT.java
+++ b/management/src/test/java/org/kaazing/gateway/management/jmx/JmxSessionIT.java
@@ -15,6 +15,7 @@
  */
 package org.kaazing.gateway.management.jmx;
 
+import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.kaazing.gateway.management.test.util.TlsTestUtil.getKeystoreFileLocation;
@@ -110,7 +111,6 @@ public class JmxSessionIT {
 
         // to make sure jmx is updated
         Thread.sleep(1000);
-
         MBeanServerConnection mbeanServerConn = jmxConnection.getConnection();
         ObjectName summaryBeansObjectNamePattern = new ObjectName(
                 "org.kaazing.gateway.server.management:root=gateways,subtype=services,serviceType=echo,serviceId=\""
@@ -121,8 +121,14 @@ public class JmxSessionIT {
         assertEquals(Long.valueOf(1), (Long) mbeanServerConn.getAttribute(summaryBean, "NumberOfCumulativeSessions"));
         assertEquals(Long.valueOf(0), (Long) mbeanServerConn.getAttribute(summaryBean, "NumberOfCurrentSessions"));
 
-        mbeanNames = mbeanServerConn.queryNames(
-                ObjectName.getInstance("*:serviceType=echo,name=sessions,*"), null);
-        assertEquals("The set of sessions should be empty", 0, mbeanNames.size());
+        long startTime = currentTimeMillis();
+        int sessionsCount = 1;
+        while (sessionsCount > 0 && (currentTimeMillis() - startTime) < 10000) {
+            Thread.sleep(500);
+            mbeanNames = mbeanServerConn.queryNames(
+                    ObjectName.getInstance("*:serviceType=echo,name=sessions,*"), null);
+            sessionsCount = mbeanNames.size();
+        }
+        assertEquals("The set of sessions should be empty", 0, sessionsCount);
     }
 }


### PR DESCRIPTION
Discovered that in some cases, the WSEB session created in JmxSessionPrincipalsIT.sessionAttributePrincipalsShouldListUserPrincipals is not removed from the MBeans repository after the test finishes. Even though the echo service calls `close()` on each active session, it seems the call is not synchronous and it proceeds to stop the worker threads without making sure the actual close command has been executed. This effectively makes the session still visible in the JMX repository.